### PR TITLE
Fixes #25: Makefile 'install' targets depend on 'all' target.

### DIFF
--- a/Makefile.ossl
+++ b/Makefile.ossl
@@ -1,7 +1,7 @@
 # Makefile -- UNIX-style make for t_cose using OpenSSL crypto
 #
 # Copyright (c) 2019-2020, Laurence Lundblade. All rights reserved.
-# Copyright (c) 2020, Michael Eckel.
+# Copyright (c) 2020, Michael Eckel, Fraunhofer SIT.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 #
@@ -67,7 +67,7 @@ CFLAGS=$(ALL_INC) $(C_OPTS) $(TEST_CONFIG_OPTS) $(CRYPTO_CONFIG_OPTS)
 
 SRC_OBJ=src/t_cose_sign1_verify.o src/t_cose_sign1_sign.o src/t_cose_util.o src/t_cose_parameters.o
 
-.PHONY: all install uninstall clean
+.PHONY: all install install_headers install_so uninstall clean
 
 all: libt_cose.a t_cose_test t_cose_basic_example_ossl
 
@@ -93,17 +93,19 @@ ifeq ($(PREFIX),)
     PREFIX := /usr/local
 endif
 
-install: all
+install: libt_cose.a install_headers
 	install -d $(DESTDIR)$(PREFIX)/lib/
 	install -m 644 libt_cose.a $(DESTDIR)$(PREFIX)/lib/
 	install -d $(DESTDIR)$(PREFIX)/include/t_cose
+
+install_headers: $(PUBLIC_INTERFACE)
 	install -m 644 inc/t_cose/t_cose_common.h $(DESTDIR)$(PREFIX)/include/t_cose
 	install -m 644 inc/t_cose/q_useful_buf.h $(DESTDIR)$(PREFIX)/include/t_cose
 	install -m 644 inc/t_cose/t_cose_sign1_sign.h $(DESTDIR)$(PREFIX)/include/t_cose
 	install -m 644 inc/t_cose/t_cose_sign1_verify.h $(DESTDIR)$(PREFIX)/include/t_cose
 
 # The shared library is not installed by default because of platform variability.
-install_so: all
+install_so: libt_cose.so install_headers
 	install -m 755 libt_cose.so $(DESTDIR)$(PREFIX)/lib/libt_cose.so.1.0.0
 	ln -sf libt_cose.so.1 $(DESTDIR)$(PREFIX)/lib/libt_cose.so
 	ln -sf libt_cose.so.1.0.0 $(DESTDIR)$(PREFIX)/lib/libt_cose.so.1

--- a/Makefile.ossl
+++ b/Makefile.ossl
@@ -96,9 +96,9 @@ endif
 install: libt_cose.a install_headers
 	install -d $(DESTDIR)$(PREFIX)/lib/
 	install -m 644 libt_cose.a $(DESTDIR)$(PREFIX)/lib/
-	install -d $(DESTDIR)$(PREFIX)/include/t_cose
 
 install_headers: $(PUBLIC_INTERFACE)
+	install -d $(DESTDIR)$(PREFIX)/include/t_cose
 	install -m 644 inc/t_cose/t_cose_common.h $(DESTDIR)$(PREFIX)/include/t_cose
 	install -m 644 inc/t_cose/q_useful_buf.h $(DESTDIR)$(PREFIX)/include/t_cose
 	install -m 644 inc/t_cose/t_cose_sign1_sign.h $(DESTDIR)$(PREFIX)/include/t_cose

--- a/Makefile.psa
+++ b/Makefile.psa
@@ -98,9 +98,9 @@ endif
 install: libt_cose.a install_headers
 	install -d $(DESTDIR)$(PREFIX)/lib/
 	install -m 644 libt_cose.a $(DESTDIR)$(PREFIX)/lib/
-	install -d $(DESTDIR)$(PREFIX)/include/t_cose
 
 install_headers: $(PUBLIC_INTERFACE)
+	install -d $(DESTDIR)$(PREFIX)/include/t_cose
 	install -m 644 inc/t_cose/t_cose_common.h $(DESTDIR)$(PREFIX)/include/t_cose
 	install -m 644 inc/t_cose/q_useful_buf.h $(DESTDIR)$(PREFIX)/include/t_cose
 	install -m 644 inc/t_cose/t_cose_sign1_sign.h $(DESTDIR)$(PREFIX)/include/t_cose

--- a/Makefile.psa
+++ b/Makefile.psa
@@ -2,7 +2,7 @@
 # MBed Crypto uses the PSA Crypto interface
 #
 # Copyright (c) 2019-2020, Laurence Lundblade. All rights reserved.
-# Copyright (c) 2020, Michael Eckel.
+# Copyright (c) 2020, Michael Eckel, Fraunhofer SIT.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 #
@@ -69,7 +69,7 @@ CFLAGS=$(ALL_INC) $(C_OPTS) $(TEST_CONFIG_OPTS) $(CRYPTO_CONFIG_OPTS)
 
 SRC_OBJ=src/t_cose_sign1_verify.o src/t_cose_sign1_sign.o src/t_cose_util.o src/t_cose_parameters.o
 
-.PHONY: all install uninstall clean
+.PHONY: all install install_headers install_so uninstall clean
 
 all: libt_cose.a t_cose_test t_cose_basic_example_psa
 
@@ -95,17 +95,19 @@ ifeq ($(PREFIX),)
     PREFIX := /usr/local
 endif
 
-install: all
+install: libt_cose.a install_headers
 	install -d $(DESTDIR)$(PREFIX)/lib/
 	install -m 644 libt_cose.a $(DESTDIR)$(PREFIX)/lib/
 	install -d $(DESTDIR)$(PREFIX)/include/t_cose
+
+install_headers: $(PUBLIC_INTERFACE)
 	install -m 644 inc/t_cose/t_cose_common.h $(DESTDIR)$(PREFIX)/include/t_cose
 	install -m 644 inc/t_cose/q_useful_buf.h $(DESTDIR)$(PREFIX)/include/t_cose
 	install -m 644 inc/t_cose/t_cose_sign1_sign.h $(DESTDIR)$(PREFIX)/include/t_cose
 	install -m 644 inc/t_cose/t_cose_sign1_verify.h $(DESTDIR)$(PREFIX)/include/t_cose
 
 # The shared library is not installed by default because of platform variability.
-install_so: all
+install_so: libt_cose.so install_headers
 	install -m 755 libt_cose.so $(DESTDIR)$(PREFIX)/lib/libt_cose.so.1.0.0
 	ln -sf libt_cose.so.1 $(DESTDIR)$(PREFIX)/lib/libt_cose.so
 	ln -sf libt_cose.so.1.0.0 $(DESTDIR)$(PREFIX)/lib/libt_cose.so.1

--- a/Makefile.test
+++ b/Makefile.test
@@ -1,7 +1,7 @@
 # Makefile -- UNIX-style make for no-crypto test config for t_cose
 #
 # Copyright (c) 2019, Laurence Lundblade. All rights reserved.
-# Copyright (c) 2020, Michael Eckel.
+# Copyright (c) 2020, Michael Eckel, Fraunhofer SIT.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 #


### PR DESCRIPTION
Made the following modifications to `Makefile.psa` and `Makefile.ossl`:

* Added new target 'install_headers' for installing headers as it is required
  by both install targets 'install' and 'install_so'.
* Removed dependency to 'all' target for both install targets, and
  replaced it with the new 'install_headers' target and the library
  (*.a/*.so), accordingly.

Further, updated copyright note in Makefiles.

Signed-off-by: Michael Eckel <michael.eckel@sit.fraunhofer.de>