### PR TITLE
Fix bug in decode_critical_parameter()

### DIFF
--- a/src/t_cose_parameters.c
+++ b/src/t_cose_parameters.c
@@ -2,6 +2,7 @@
  * t_cose_parameters.c
  *
  * Copyright 2019-2020, Laurence Lundblade
+ * Copyright (c) 2021, Arm Limited. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *
@@ -155,7 +156,7 @@ decode_critical_parameter(QCBORDecodeContext       *decode_context,
 
     while(1) {
         cbor_result = QCBORDecode_GetNext(decode_context, &item);
-        if(cbor_result != QCBOR_ERR_NO_MORE_ITEMS) {
+        if(cbor_result == QCBOR_ERR_NO_MORE_ITEMS) {
             /* successful exit from loop */
             break;
         }

--- a/test/t_cose_test.c
+++ b/test/t_cose_test.c
@@ -2,6 +2,7 @@
  *  t_cose_test.c
  *
  * Copyright 2019-2021, Laurence Lundblade
+ * Copyright (c) 2021, Arm Limited. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *
@@ -938,7 +939,7 @@ int_fast32_t crit_parameters_test()
 
     for(test = crit_tests_table; test->test_option; test++) {
         if(run_test_sign_and_verify(test->test_option) != test->result) {
-            return (int_fast32_t)(test - crit_tests_table);
+            return (int_fast32_t)(test - crit_tests_table + 1);
         }
     }
 


### PR DESCRIPTION
This fixes a bug in `decode_critical_parameter()` and also a bug in the test code which made the former undetected. 

`decode_critical_parameter()` iterates on the critical parameters in a CBOR array, but after checking the `QCBORDecode_GetNext()` return value, always exits the while loop without adding any elements to the list.

This error would have been caught by the test case `crit_parameters_test()`, but this one also had a bug. If `run_test_sign_and_verify()` returned with an unexpected value for the first item in the `crit_tests_table`, `crit_parameters_test()` returned `0`. This was interpreted as *test pass* by the caller.