### PR TITLE
update: support PSA Crypto API 1.0 beta 3

### DIFF
--- a/Makefile.psa
+++ b/Makefile.psa
@@ -1,5 +1,5 @@
-# Makefile -- UNIX-style make for t_cose using crypto with MBed Crypto
-# MBed Crypto uses the PSA Crypto interface
+# Makefile -- UNIX-style make for t_cose using crypto with Mbed Crypto
+# Mbed Crypto uses the PSA Crypto interface
 #
 # Copyright (c) 2019-2021, Laurence Lundblade. All rights reserved.
 # Copyright (c) 2020, Michael Eckel, Fraunhofer SIT.
@@ -10,7 +10,7 @@
 #
 
 # ---- comment ----
-# This is for PSA Crypto / MBed Crypto. See longer explanation in README.md
+# This is for PSA Crypto / Mbed Crypto. See longer explanation in README.md
 # Adjust CRYPTO_INC and CRYPTO_LIB for the
 # location of the openssl libraries on your build machine.
 
@@ -33,13 +33,13 @@ QCBOR_LIB=-lqcbor
 
 # ---- crypto configuration -----
 
-# These two are for direct reference to MBed Crypto that is not installed
+# These two are for direct reference to Mbed Crypto that is not installed
 # in /usr/local/ /usr/local or some system location. The path names
-# may need to be adjusted for your location of MBed Crypto
-#CRYPTO_INC=-I ../../mbed-crypto/include/
-#CRYPTO_LIB=../../mbed-crypto/library/libmbedcrypto.a
+# may need to be adjusted for your location of Mbed Crypto
+#CRYPTO_INC=-I ../../mbedtls/include/
+#CRYPTO_LIB=../../mbedtls/library/libmbedcrypto.a
 
-# These two are for reference to MBed Crypto that has been installed in
+# These two are for reference to Mbed Crypto that has been installed in
 # /usr/local/ or in some system location.
 CRYPTO_LIB=-l mbedcrypto
 CRYPTO_INC=-I /usr/local/include

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ useful for embedded implementations that have to run in small fixed memory.
 
 As of December 2019, the code is in reasonable working order and the public interface is 
 fairly stable. There is a crypto adaptaion layer for [OpenSSL](https://www.openssl.org) 
-and for [Arm MBed Crypto](https://github.com/ARMmbed/mbed-crypto).
+and for [Arm Mbed Crypto](https://github.com/ARMmbed/mbedtls).
 
 This version requires a QCBOR library that supports Spiffy Decode. 
 
@@ -108,7 +108,7 @@ by virtue of the Makefile not linking to it.
 #### PSA Crypto -- Makefile.psa
 
 This build configuration works for Arm PSA Crypto compatible libraries
-like the MBed Crypto Library. 
+like the Mbed Crypto Library. 
 
 This integration supports SHA-256, SHA-384 and SHA-512 with ECDSA to support
 the COSE algorithms ES256, ES384 and ES512. It is a full implementation but
@@ -138,16 +138,16 @@ using earlier APIs so this variation must be handled by the crypto
 adpatation layer here. There are no official mechanisms, like a 
 #define to help handle variations in these older versions.
 
-The MBed Crypto Library is an implementation of the PSA Crypto API and
+The Mbed Crypto Library is an implementation of the PSA Crypto API and
 is versions separately. Presumably there are or will be implementations of
-the PSA Crypto API that are not the MBed Crypto Library.
+the PSA Crypto API that are not the Mbed Crypto Library.
 
 t_cose has been made to work against the released 1.1.0 version of
-MBed released in June 2019 and the 2.0.0 version released in September
+Mbed released in June 2019 and the 2.0.0 version released in September
 2019. Also, it works against the 1.1 version that is in TF-M which has
 different internals than the 1.1.0 version on the public GitHub. 
 
-The PSA Crypto API in MBed 1.1.0 is different from that in MBed 2.0.0.
+The PSA Crypto API in Mbed 1.1.0 is different from that in Mbed 2.0.0.
 t_cose has one configuration that covers both which hinges off a 
 #define that happens to occur in 1.1.0 and not in 2.0.0. It can auto-detect
 which is which so you shouldn't have to worry about it. To override
@@ -155,7 +155,7 @@ the auto-detect `#define T_COSE_USE_PSA_CRYPTO_FROM_MBED_CRYPTO11`
 or `#define T_COSE_USE_PSA_CRYPTO_FROM_MBED_CRYPTO20`.
 
 Presumably, this will soon become less messy with the release of 
-PSA Crypto 1.0. Presumably the older implementations like MBed
+PSA Crypto 1.0. Presumably the older implementations like Mbed
 Crypto 1.1 will stop being used. Also, PSA Crypto 1.0 has 
 official #defines to manage API versions.
 

--- a/crypto_adapters/t_cose_psa_crypto.c
+++ b/crypto_adapters/t_cose_psa_crypto.c
@@ -99,7 +99,7 @@ static enum t_cose_err_t psa_status_to_t_cose_error_signing(psa_status_t err)
            err == PSA_ERROR_INVALID_SIGNATURE   ? T_COSE_ERR_SIG_VERIFY :
            err == PSA_ERROR_NOT_SUPPORTED       ? T_COSE_ERR_UNSUPPORTED_SIGNING_ALG:
            err == PSA_ERROR_INSUFFICIENT_MEMORY ? T_COSE_ERR_INSUFFICIENT_MEMORY :
-           err == PSA_ERROR_TAMPERING_DETECTED  ? T_COSE_ERR_TAMPERING_DETECTED :
+           err == PSA_ERROR_CORRUPTION_DETECTED  ? T_COSE_ERR_TAMPERING_DETECTED :
                                                   T_COSE_ERR_SIG_FAIL;
 }
 
@@ -133,7 +133,7 @@ t_cose_crypto_pub_key_verify(int32_t               cose_algorithm_id,
      * signing_key passed in, not the cose_algorithm_id This check
      * looks for ECDSA signing as indicated by COSE and rejects what
      * is not. (Perhaps this check can be removed to save object code
-     * if it is the case that psa_asymmetric_verify() does the right
+     * if it is the case that psa_verify_hash() does the right
      * checks).
      */
     if(!PSA_ALG_IS_ECDSA(psa_alg_id)) {
@@ -145,14 +145,14 @@ t_cose_crypto_pub_key_verify(int32_t               cose_algorithm_id,
 
 
     /* The official PSA Crypto API expected to be formally set in 2020
-     * uses psa_verify_hash() instead of psa_asymmetric_verify().
+     * uses psa_verify_hash() instead of psa_verify_hash().
      * This older API is used because Mbed Crypto 2.0 provides
      * backwards compatibility to this with crypto_compat.h and there
      * is no forward compatibility in the other direction. If Mbed
      * Crypto ceases providing backwards compatibility then this code
      * has to be changed to use psa_verify_hash().
      */
-    psa_result = psa_asymmetric_verify(verification_key_psa,
+    psa_result = psa_verify_hash(verification_key_psa,
                                        psa_alg_id,
                                        hash_to_verify.ptr,
                                        hash_to_verify.len,
@@ -191,7 +191,7 @@ t_cose_crypto_pub_key_sign(int32_t                cose_algorithm_id,
      * signing_key passed in, not the cose_algorithm_id This check
      * looks for ECDSA signing as indicated by COSE and rejects what
      * is not. (Perhaps this check can be removed to save object code
-     * if it is the case that psa_asymmetric_verify() does the right
+     * if it is the case that psa_verify_hash() does the right
      * checks).
      */
     if(!PSA_ALG_IS_ECDSA(psa_alg_id)) {
@@ -205,14 +205,14 @@ t_cose_crypto_pub_key_sign(int32_t                cose_algorithm_id,
      * length and won't write off the end of it.
      */
     /* The official PSA Crypto API expected to be formally set in 2020
-     * uses psa_sign_hash() instead of psa_asymmetric_sign().  This
+     * uses psa_sign_hash() instead of psa_sign_hash().  This
      * older API is used because Mbed Crypto 2.0 provides backwards
      * compatibility to this crypto_compat.h and there is no forward
      * compatibility in the other direction. If Mbed Crypto ceases
      * providing backwards compatibility then this code has to be
      * changed to use psa_sign_hash().
      */
-    psa_result = psa_asymmetric_sign(signing_key_psa,
+    psa_result = psa_sign_hash(signing_key_psa,
                                      psa_alg_id,
                                      hash_to_sign.ptr,
                                      hash_to_sign.len,

--- a/examples/t_cose_basic_example_psa.c
+++ b/examples/t_cose_basic_example_psa.c
@@ -112,21 +112,21 @@ enum t_cose_err_t make_psa_ecdsa_key_pair(int32_t            cose_algorithm_id,
     case T_COSE_ALGORITHM_ES256:
         private_key     = private_key_256;
         private_key_len = sizeof(private_key_256);
-        key_type        = PSA_KEY_TYPE_ECC_KEY_PAIR(PSA_ECC_CURVE_SECP256R1);
+        key_type        = PSA_KEY_TYPE_ECC_KEY_PAIR(PSA_ECC_FAMILY_SECP_R1);
         key_alg         = PSA_ALG_ECDSA(PSA_ALG_SHA_256);
         break;
 
     case T_COSE_ALGORITHM_ES384:
         private_key     = private_key_384;
         private_key_len = sizeof(private_key_384);
-        key_type        = PSA_KEY_TYPE_ECC_KEY_PAIR(PSA_ECC_CURVE_SECP384R1);
+        key_type        = PSA_KEY_TYPE_ECC_KEY_PAIR(PSA_ECC_FAMILY_SECP_R1);
         key_alg         = PSA_ALG_ECDSA(PSA_ALG_SHA_384);
         break;
 
     case T_COSE_ALGORITHM_ES512:
         private_key     = private_key_521;
         private_key_len = sizeof(private_key_521);
-        key_type        = PSA_KEY_TYPE_ECC_KEY_PAIR(PSA_ECC_CURVE_SECP521R1);
+        key_type        = PSA_KEY_TYPE_ECC_KEY_PAIR(PSA_ECC_FAMILY_SECP_R1);
         key_alg         = PSA_ALG_ECDSA(PSA_ALG_SHA_512);
         break;
 

--- a/inc/t_cose/t_cose_common.h
+++ b/inc/t_cose/t_cose_common.h
@@ -234,7 +234,7 @@ enum t_cose_err_t {
     /** General unspecific failure. */
     T_COSE_ERR_FAIL = 17,
 
-    /** Equivalent to \c PSA_ERROR_TAMPERING_DETECTED. */
+    /** Equivalent to \c PSA_ERROR_CORRUPTION_DETECTED. */
     T_COSE_ERR_TAMPERING_DETECTED = 18,
 
     /** The key identified by a \ref t_cose_key or a key ID was not

--- a/src/t_cose_crypto.h
+++ b/src/t_cose_crypto.h
@@ -193,7 +193,7 @@ t_cose_crypto_sig_size(int32_t            cose_algorithm_id,
  * \retval T_COSE_ERR_FAIL
  *         General unspecific failure.
  * \retval T_COSE_ERR_TAMPERING_DETECTED
- *         Equivalent to \c PSA_ERROR_TAMPERING_DETECTED.
+ *         Equivalent to \c PSA_ERROR_CORRUPTION_DETECTED.
  *
  * This is called to do public key signing. The implementation will
  * vary from one platform / OS to another but should conform to the
@@ -267,7 +267,7 @@ t_cose_crypto_pub_key_sign(int32_t                cose_algorithm_id,
  * \retval T_COSE_ERR_FAIL
  *         General unspecific failure.
  * \retval T_COSE_ERR_TAMPERING_DETECTED
- *         Equivalent to \c PSA_ERROR_TAMPERING_DETECTED.
+ *         Equivalent to \c PSA_ERROR_CORRUPTION_DETECTED.
  */
 enum t_cose_err_t
 t_cose_crypto_pub_key_verify(int32_t               cose_algorithm_id,

--- a/test/t_cose_make_psa_test_key.c
+++ b/test/t_cose_make_psa_test_key.c
@@ -86,21 +86,21 @@ enum t_cose_err_t make_ecdsa_key_pair(int32_t            cose_algorithm_id,
     case COSE_ALGORITHM_ES256:
         private_key     = private_key_256;
         private_key_len = sizeof(private_key_256);
-        key_type        = PSA_KEY_TYPE_ECC_KEY_PAIR(PSA_ECC_CURVE_SECP256R1);
+        key_type        = PSA_KEY_TYPE_ECC_KEY_PAIR(PSA_ECC_FAMILY_SECP_R1);
         key_alg         = PSA_ALG_ECDSA(PSA_ALG_SHA_256);
         break;
 
     case COSE_ALGORITHM_ES384:
         private_key     = private_key_384;
         private_key_len = sizeof(private_key_384);
-        key_type        = PSA_KEY_TYPE_ECC_KEY_PAIR(PSA_ECC_CURVE_SECP384R1);
+        key_type        = PSA_KEY_TYPE_ECC_KEY_PAIR(PSA_ECC_FAMILY_SECP_R1);
         key_alg         = PSA_ALG_ECDSA(PSA_ALG_SHA_384);
         break;
 
     case COSE_ALGORITHM_ES512:
         private_key     = private_key_521;
         private_key_len = sizeof(private_key_521);
-        key_type        = PSA_KEY_TYPE_ECC_KEY_PAIR(PSA_ECC_CURVE_SECP521R1);
+        key_type        = PSA_KEY_TYPE_ECC_KEY_PAIR(PSA_ECC_FAMILY_SECP_R1);
         key_alg         = PSA_ALG_ECDSA(PSA_ALG_SHA_512);
         break;
 


### PR DESCRIPTION
This PR make t_cose support latest Mbed Crypto.

Old [Mbed Crypto](https://github.com/ARMmbed/mbed-crypto) has moved and merged into [Mbed TLS](https://github.com/ARMmbed/mbedtls), and now its APIs are changed.
The changes can be seen [here](https://armmbed.github.io/mbed-crypto/html/appendix/history.html).