### PR TITLE
Improve CMake scripts & add CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,77 @@
+name: CI
+
+on: [push, pull_request]
+
+jobs:
+  main:
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+        - os-image: ubuntu-latest
+          crypto-provider: OpenSSL
+        
+        - os-image: ubuntu-latest
+          crypto-provider: MbedTLS
+          mbedtls-version: v2.28.0
+        
+        - os-image: ubuntu-latest
+          crypto-provider: MbedTLS
+          mbedtls-version: v3.1.0
+          allow-failure: true
+
+        - os-image: ubuntu-latest
+          crypto-provider: Test
+
+    runs-on: ${{ matrix.config.os-image }}
+
+    continue-on-error: ${{ matrix.config.allow-failure || false }}
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Fetch mbedTLS
+      if: matrix.config.crypto-provider == 'MbedTLS'
+      uses: actions/checkout@v3
+      with:
+        repository: ARMmbed/mbedtls
+        ref: ${{ matrix.config.mbedtls-version }}
+        path: mbedtls
+
+    - name: Install mbedTLS
+      if: matrix.config.crypto-provider == 'MbedTLS'
+      run: |
+        cd mbedtls
+        make -j $(nproc)
+        sudo make install
+
+    - name: Fetch QCBOR
+      uses: actions/checkout@v3
+      with:
+        repository: laurencelundblade/QCBOR
+        path: QCBOR
+
+    - name: Install QCBOR
+      run: |
+        cd QCBOR
+        make -j$(nproc)
+        sudo make install
+
+    - name: Build t_cose
+      run: |
+        set -ex
+        mkdir build
+        cd build
+        cmake -DCRYPTO_PROVIDER=${{ matrix.config.crypto-provider }} ..
+        make -j $(nproc)
+
+    - name: Run OpenSSL example
+      if: matrix.config.crypto-provider == 'OpenSSL'
+      run: build/t_cose_basic_example_ossl
+
+    - name: Run MbedTLS example
+      if: matrix.config.crypto-provider == 'MbedTLS'
+      run: build/t_cose_basic_example_psa
+
+    - name: Run tests
+      run: build/t_cose_test

--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,6 @@ dkms.conf
 # Compiled binaries
 t_cose_test
 t_cose_basic_example_ossl
+
+# CMake build folder
+build/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,34 +1,135 @@
-cmake_minimum_required(VERSION 3.10.2)
+cmake_minimum_required(VERSION 3.12)
 project(t_cose
-	DESCRIPTION "t_cose"
-	LANGUAGES C
-	VERSION 1.0.1)
+    DESCRIPTION "t_cose"
+    LANGUAGES C
+    VERSION 1.0.1)
 
-set(CMAKE_C_FLAGS "-pedantic -Wall -O3 -ffunction-sections")
+# Constants
+set(CRYPTO_PROVIDERS "OpenSSL" "MbedTLS" "Test")
 
-include_directories(inc)
-include_directories(src)
+# Project options
+set(CRYPTO_PROVIDER "OpenSSL" CACHE STRING "The crypto provider to use: ${CRYPTO_PROVIDERS}")
+set(BUILD_TESTS ON CACHE BOOL "Build tests")
+set(BUILD_EXAMPLES ON CACHE BOOL "Build examples")
 
-include_directories(${thirdparty_inc})
-list(APPEND libs ${thirdparty_lib})
-add_definitions(${thirdparty_def})
+if (NOT CRYPTO_PROVIDER IN_LIST CRYPTO_PROVIDERS)
+    message(FATAL_ERROR "CRYPTO_PROVIDER must be one of ${CRYPTO_PROVIDERS}")
+endif()
 
-if(MBEDTLS)
+# Built-in CMake options
+set(BUILD_SHARED_LIBS OFF CACHE BOOL "Create shared instead of static libraries")
 
-	set(T_COSE_SOURCE crypto_adapters/t_cose_psa_crypto.c src/t_cose_sign1_sign.c src/t_cose_parameters.c src/t_cose_sign1_verify.c src/t_cose_util.c)
+# Used in find_package() calls as preferred search paths
+set(QCBOR_ROOT "" CACHE PATH "Installation prefix of QCBOR")
+set(MbedTLS_ROOT "" CACHE PATH "Installation prefix of MbedTLS")
+set(OpenSSL_ROOT "" CACHE PATH "Installation prefix of OpenSSL")
 
-	add_definitions(-DT_COSE_USE_PSA_CRYPTO=1)
+if (NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
+    message(STATUS "No build type selected, defaulting to Release")
+    set(CMAKE_BUILD_TYPE "Release" CACHE STRING "Build type" FORCE)
+endif()
 
-	add_library(t_cose ${T_COSE_SOURCE})
+list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
+
+if(CRYPTO_PROVIDER STREQUAL "MbedTLS")
+
+    find_package(MbedTLS REQUIRED)
+    set(CRYPTO_LIBRARY MbedTLS::MbedCrypto)
+    set(CRYPTO_COMPILE_DEFS -DT_COSE_USE_PSA_CRYPTO=1)
+    set(CRYPTO_ADAPTER_SRC crypto_adapters/t_cose_psa_crypto.c)
+
+elseif(CRYPTO_PROVIDER STREQUAL "OpenSSL")
+
+    find_package(OpenSSL REQUIRED)
+    set(CRYPTO_LIBRARY OpenSSL::Crypto)
+    set(CRYPTO_COMPILE_DEFS -DT_COSE_USE_OPENSSL_CRYPTO=1)
+    set(CRYPTO_ADAPTER_SRC crypto_adapters/t_cose_openssl_crypto.c)
+
+elseif(CRYPTO_PROVIDER STREQUAL "Test")
+
+    add_library(b_con_hash crypto_adapters/b_con_hash/sha256.c)
+    target_include_directories(b_con_hash PUBLIC crypto_adapters/b_con_hash)
+
+    set(CRYPTO_LIBRARY b_con_hash)
+    set(CRYPTO_COMPILE_DEFS -DT_COSE_USE_B_CON_SHA256 -DT_COSE_ENABLE_HASH_FAIL_TEST)
+    set(CRYPTO_ADAPTER_SRC crypto_adapters/t_cose_test_crypto.c)
 
 else()
+    message(FATAL_ERROR "Bug!")
+endif()
 
-	add_definitions(-DT_COSE_USE_OPENSSL_CRYPTO=1)
+# Global compile options applying to all targets
+add_compile_options(-pedantic -Wall)
 
-	set(T_COSE_SOURCE crypto_adapters/t_cose_openssl_crypto.c src/t_cose_sign1_sign.c src/t_cose_parameters.c src/t_cose_sign1_verify.c src/t_cose_util.c)
+set(T_COSE_SRC_COMMON
+    src/t_cose_sign1_sign.c
+    src/t_cose_parameters.c
+    src/t_cose_sign1_verify.c
+    src/t_cose_util.c
+)
 
-	add_library(t_cose ${T_COSE_SOURCE})
+find_package(QCBOR REQUIRED)
+
+add_library(t_cose ${T_COSE_SRC_COMMON} ${CRYPTO_ADAPTER_SRC})
+target_compile_options(t_cose PRIVATE -ffunction-sections)
+target_compile_definitions(t_cose PRIVATE ${CRYPTO_COMPILE_DEFS})
+target_include_directories(t_cose PUBLIC inc PRIVATE src)
+target_link_libraries(t_cose PUBLIC QCBOR::QCBOR PRIVATE ${CRYPTO_LIBRARY})
+
+include(GNUInstallDirs)
+
+install(TARGETS t_cose
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+)
+install(DIRECTORY inc/ DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+
+if (BUILD_EXAMPLES)
+
+    if (CRYPTO_PROVIDER STREQUAL "MbedTLS")
+        add_executable(t_cose_basic_example_psa examples/t_cose_basic_example_psa.c)
+        target_link_libraries(t_cose_basic_example_psa PRIVATE t_cose ${CRYPTO_LIBRARY})
+    elseif (CRYPTO_PROVIDER STREQUAL "OpenSSL")
+        add_executable(t_cose_basic_example_ossl examples/t_cose_basic_example_ossl.c)
+        target_link_libraries(t_cose_basic_example_ossl PRIVATE t_cose ${CRYPTO_LIBRARY})
+    endif()
 
 endif()
 
+if (BUILD_TESTS)
 
+    enable_testing()
+
+    set(TEST_SRC_COMMON
+        main.c
+        test/run_tests.c
+        test/t_cose_make_test_messages.c
+        test/t_cose_test.c
+    )
+
+    if (NOT CRYPTO_PROVIDER STREQUAL "Test")
+        list(APPEND TEST_SRC_COMMON test/t_cose_sign_verify_test.c)
+    endif()
+
+    if (CRYPTO_PROVIDER STREQUAL "MbedTLS")
+        set(TEST_SRC_EXTRA test/t_cose_make_psa_test_key.c)
+        set(TEST_EXTRA_DEFS)
+    elseif(CRYPTO_PROVIDER STREQUAL "OpenSSL")
+        set(TEST_SRC_EXTRA test/t_cose_make_openssl_test_key.c)
+        set(TEST_EXTRA_DEFS)
+    elseif(CRYPTO_PROVIDER STREQUAL "Test")
+        set(TEST_SRC_EXTRA)
+        set(TEST_EXTRA_DEFS -DT_COSE_ENABLE_HASH_FAIL_TEST -DT_COSE_DISABLE_SIGN_VERIFY_TESTS)
+    else()
+        message(FATAL_ERROR "Bug!")
+    endif()
+
+    add_executable(t_cose_test ${TEST_SRC_COMMON} ${TEST_SRC_EXTRA})
+    target_include_directories(t_cose_test PRIVATE src test)
+    target_link_libraries(t_cose_test PRIVATE t_cose ${CRYPTO_LIBRARY})
+    # Crypto defs are needed because the tests include headers from src/
+    target_compile_definitions(t_cose_test PRIVATE ${CRYPTO_COMPILE_DEFS} ${TEST_EXTRA_DEFS})
+    
+    add_test(NAME t_cose_test COMMAND t_cose_test)
+
+endif()

--- a/cmake/FindMbedTLS.cmake
+++ b/cmake/FindMbedTLS.cmake
@@ -1,0 +1,108 @@
+#[=======================================================================[.rst:
+FindMbedTLS
+-------
+
+Finds the mbedTLS library.
+
+Imported Targets
+^^^^^^^^^^^^^^^^
+
+This module provides the following imported targets, if found:
+
+``MbedTLS::MbedTLS``
+  The mbedTLS library
+
+``MbedTLS::MbedCrypto``
+  The mbedTLS crypto library
+
+``MbedTLS::MbedX509``
+  The mbedTLS X509 library
+
+Result Variables
+^^^^^^^^^^^^^^^^
+
+This will define the following variables:
+
+``MbedTLS_FOUND``
+  True if the system has the MbedTLS library.
+``MbedTLS_INCLUDE_DIRS``
+  Include directories needed to use MbedTLS.
+``MbedTLS_LIBRARIES``
+  Libraries needed to link to MbedTLS.
+
+Cache Variables
+^^^^^^^^^^^^^^^
+
+The following cache variables may also be set:
+
+``MbedTLS_INCLUDE_DIR``
+  The directory containing ``mbedtls/``.
+``MbedTLS_LIBRARY``
+  The path to the mbedtls library.
+``MbedTLS_CRYPTO_LIBRARY``
+  The path to the mbedcrypto library.
+``MbedTLS_X509_LIBRARY``
+  The path to the mbedx509 library.
+
+#]=======================================================================]
+
+find_path(MbedTLS_INCLUDE_DIR
+  NAMES mbedtls/version.h
+)
+find_library(MbedTLS_LIBRARY
+  NAMES mbedtls
+)
+find_library(MbedTLS_CRYPTO_LIBRARY
+  NAMES mbedcrypto
+)
+find_library(MbedTLS_X509_LIBRARY
+  NAMES mbedx509
+)
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(MbedTLS
+  FOUND_VAR MbedTLS_FOUND
+  REQUIRED_VARS
+    MbedTLS_LIBRARY
+    MbedTLS_CRYPTO_LIBRARY
+    MbedTLS_X509_LIBRARY
+    MbedTLS_INCLUDE_DIR
+)
+
+if(MbedTLS_FOUND)
+  set(MbedTLS_LIBRARIES "${MbedTLS_LIBRARY}" "${MbedTLS_X509_LIBRARY}" "${MbedTLS_CRYPTO_LIBRARY}")
+  set(MbedTLS_INCLUDE_DIRS "${MbedTLS_INCLUDE_DIR}")
+endif()
+
+if(MbedTLS_FOUND AND NOT TARGET MbedTLS::MbedCrypto)
+  add_library(MbedTLS::MbedCrypto UNKNOWN IMPORTED)
+  set_target_properties(MbedTLS::MbedCrypto PROPERTIES
+    IMPORTED_LOCATION "${MbedTLS_CRYPTO_LIBRARY}"
+    INTERFACE_INCLUDE_DIRECTORIES "${MbedTLS_INCLUDE_DIR}"
+  )
+endif()
+
+if(MbedTLS_FOUND AND NOT TARGET MbedTLS::MbedX509)
+  add_library(MbedTLS::MbedX509 UNKNOWN IMPORTED)
+  set_target_properties(MbedTLS::MbedX509 PROPERTIES
+    IMPORTED_LOCATION "${MbedTLS_X509_LIBRARY}"
+    INTERFACE_INCLUDE_DIRECTORIES "${MbedTLS_INCLUDE_DIR}"
+  )
+  target_link_libraries(MbedTLS::MbedX509 INTERFACE MbedTLS::MbedCrypto)
+endif()
+
+if(MbedTLS_FOUND AND NOT TARGET MbedTLS::MbedTLS)
+  add_library(MbedTLS::MbedTLS UNKNOWN IMPORTED)
+  set_target_properties(MbedTLS::MbedTLS PROPERTIES
+    IMPORTED_LOCATION "${MbedTLS_LIBRARY}"
+    INTERFACE_INCLUDE_DIRECTORIES "${MbedTLS_INCLUDE_DIR}"
+  )
+  target_link_libraries(MbedTLS::MbedX509 INTERFACE MbedTLS::MbedCrypto MbedTLS::MbedX509)
+endif()
+
+mark_as_advanced(
+  MbedTLS_INCLUDE_DIR
+  MbedTLS_LIBRARY
+  MbedTLS_CRYPTO_LIBRARY
+  MbedTLS_X509_LIBRARY
+)

--- a/cmake/FindQCBOR.cmake
+++ b/cmake/FindQCBOR.cmake
@@ -1,0 +1,81 @@
+#[=======================================================================[.rst:
+FindQCBOR
+-------
+
+Finds the QCBOR library.
+
+Imported Targets
+^^^^^^^^^^^^^^^^
+
+This module provides the following imported targets, if found:
+
+``QCBOR::QCBOR``
+  The QCBOR library
+
+Result Variables
+^^^^^^^^^^^^^^^^
+
+This will define the following variables:
+
+``QCBOR_FOUND``
+  True if the system has the QCBOR library.
+``QCBOR_INCLUDE_DIRS``
+  Include directories needed to use QCBOR.
+``QCBOR_LIBRARIES``
+  Libraries needed to link to QCBOR.
+
+Cache Variables
+^^^^^^^^^^^^^^^
+
+The following cache variables may also be set:
+
+``QCBOR_INCLUDE_DIR``
+  The directory containing ``t_cose/``.
+``QCBOR_LIBRARY``
+  The path to the QCBOR library.
+
+#]=======================================================================]
+
+include(CheckLibraryExists)
+
+find_path(QCBOR_INCLUDE_DIR
+  NAMES qcbor/qcbor.h
+)
+find_library(QCBOR_LIBRARY
+  NAMES qcbor
+)
+
+CHECK_LIBRARY_EXISTS(m sin "" HAVE_LIB_M)
+set(EXTRA_LIBS)
+if(HAVE_LIB_M)
+  set(EXTRA_LIBS m)
+endif()
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(QCBOR
+  FOUND_VAR QCBOR_FOUND
+  REQUIRED_VARS
+    QCBOR_LIBRARY
+    QCBOR_INCLUDE_DIR
+)
+
+if(QCBOR_FOUND)
+  set(QCBOR_LIBRARIES "${QCBOR_LIBRARY} ${EXTRA_LIBS}")
+  set(QCBOR_INCLUDE_DIRS "${QCBOR_INCLUDE_DIR}")
+endif()
+
+if(QCBOR_FOUND AND NOT TARGET QCBOR::QCBOR)
+  add_library(QCBOR::QCBOR UNKNOWN IMPORTED)
+  set_target_properties(QCBOR::QCBOR PROPERTIES
+    IMPORTED_LOCATION "${QCBOR_LIBRARY}"
+    INTERFACE_INCLUDE_DIRECTORIES "${QCBOR_INCLUDE_DIR}"
+  )
+  if (EXTRA_LIBS)
+    target_link_libraries(QCBOR::QCBOR INTERFACE ${EXTRA_LIBS})
+  endif()
+endif()
+
+mark_as_advanced(
+  QCBOR_INCLUDE_DIR
+  QCBOR_LIBRARY
+)


### PR DESCRIPTION
This PR brings the CMake scripts on par with the Makefiles and adds CI through GitHub Actions, for now Ubuntu only. Over time, the CI matrix can be extended to more variants along dimensions like operating system, compiler, dependency versions etc.

Note the CMake Find* modules were written according to https://cmake.org/cmake/help/latest/manual/cmake-developer.7.html#a-sample-find-module.

Also addresses https://github.com/laurencelundblade/t_cose/issues/37. Finding packages now relies on CMake's search logic, which can be influenced through command-line options.