### PR TITLE
Fix some compilers warnings

### DIFF
--- a/Makefile.test
+++ b/Makefile.test
@@ -1,6 +1,6 @@
 # Makefile -- UNIX-style make for no-crypto test config for t_cose
 #
-# Copyright (c) 2019, Laurence Lundblade. All rights reserved.
+# Copyright (c) 2019-2022, Laurence Lundblade. All rights reserved.
 # Copyright (c) 2020, Michael Eckel, Fraunhofer SIT.
 #
 # SPDX-License-Identifier: BSD-3-Clause
@@ -16,10 +16,10 @@
 
 # ---- QCBOR location ----
 # Adjust this to the location of QCBOR in your build environment
-QCBOR_INC= -I ../../QCBOR/master/inc
-QCBOR_LIB=../../QCBOR/master/libqcbor.a
-#QCBOR_INC= -I/usr/include -I/usr/local/include
-#QCBOR_LIB= -l qcbor
+#QCBOR_INC= -I ../../QCBOR/master/inc
+#QCBOR_LIB=../../QCBOR/master/libqcbor.a
+QCBOR_INC= -I/usr/include -I/usr/local/include
+QCBOR_LIB= -l qcbor
 
 
 # ---- crypto configuration -----

--- a/crypto_adapters/t_cose_openssl_crypto.c
+++ b/crypto_adapters/t_cose_openssl_crypto.c
@@ -1,7 +1,7 @@
 /*
  *  t_cose_openssl_crypto.c
  *
- * Copyright 2019, Laurence Lundblade
+ * Copyright 2019-2022, Laurence Lundblade
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *
@@ -149,7 +149,7 @@ convert_ecdsa_signature_to_ossl(unsigned               key_len,
         goto Done;
     }
 
-    ossl_signature_s_bn = BN_bin2bn(((uint8_t *)signature.ptr)+key_len,
+    ossl_signature_s_bn = BN_bin2bn(((const uint8_t *)signature.ptr)+key_len,
                                     (int)key_len,
                                     NULL);
     if(ossl_signature_s_bn == NULL) {

--- a/inc/t_cose/t_cose_common.h
+++ b/inc/t_cose/t_cose_common.h
@@ -1,7 +1,7 @@
 /*
  * t_cose_common.h
  *
- * Copyright 2019-2020, Laurence Lundblade
+ * Copyright 2019-2022, Laurence Lundblade
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *
@@ -134,9 +134,28 @@ struct t_cose_key {
     } k;
 };
 
+
 /** An empty or \c NULL \c t_cose_key */
+/*
+ * This has to be definied differently in C than C++ because there is
+ * no common construct for a literal structure.
+ *
+ * In C compound literals are used.
+ *
+ * In C++ list initalization is used. This only works
+ * in C++11 and later.
+ *
+ * Note that some popular C++ compilers can handle compound
+ * literals with on-by-default extensions, however
+ * this code aims for full correctness with strict
+ * compilers so they are not used.
+ */
+#ifdef __cplusplus
+#define T_COSE_NULL_KEY {T_COSE_CRYPTO_LIB_UNIDENTIFIED, {0}}
+#else
 #define T_COSE_NULL_KEY \
     ((struct t_cose_key){T_COSE_CRYPTO_LIB_UNIDENTIFIED, {0}})
+#endif
 
 
 /* Private value. Intentionally not documented for Doxygen.  This is

--- a/test/t_cose_test.c
+++ b/test/t_cose_test.c
@@ -1,7 +1,7 @@
 /*
  *  t_cose_test.c
  *
- * Copyright 2019-2021, Laurence Lundblade
+ * Copyright 2019-2022, Laurence Lundblade
  * Copyright (c) 2021, Arm Limited. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
@@ -269,7 +269,8 @@ int_fast32_t short_circuit_verify_fail_test()
         return 6000;
     }
     /* Change "payload" to "hayload" */
-    ((char *)signed_cose.ptr)[payload_offset] = 'h';
+    struct q_useful_buf temp_unconst = q_useful_buf_unconst(signed_cose);
+    ((char *)temp_unconst.ptr)[payload_offset] = 'h';
     /* --- Tamper with payload Done --- */
 
 
@@ -582,8 +583,8 @@ int_fast32_t short_circuit_decode_only_test()
         return 2000 + (int32_t)result;
     }
 
-    /* Finally close of the CBOR formatting and get the pointer and length
-     * of the resulting COSE_Sign1
+    /* Finally close of the CBOR formatting and get the pointer and
+     * length of the resulting COSE_Sign1
      */
     cbor_error = QCBOREncode_Finish(&cbor_encode, &signed_cose);
     if(cbor_error) {
@@ -591,17 +592,20 @@ int_fast32_t short_circuit_decode_only_test()
     }
     /* --- Done making COSE Sign1 object  --- */
 
-    /* -- Tweak signature bytes -- */
-    /* The signature is the last thing so reach back that many bytes and tweak
-       so if signature verification were attempted, it would fail */
+    /* --- Tweak signature bytes --- */
+    /* The signature is the last thing so reach back that many bytes
+     * and tweak so if signature verification were attempted, it would
+     * fail (but this is a decode-only test so it won't fail).
+     */
     const size_t last_byte_offset = signed_cose.len - T_COSE_EC_P256_SIG_SIZE;
-    ((uint8_t *)signed_cose.ptr)[last_byte_offset]++;
+    struct q_useful_buf temp_unconst = q_useful_buf_unconst(signed_cose);
+    ((uint8_t *)temp_unconst.ptr)[last_byte_offset]++;
 
 
     /* --- Start verifying the COSE Sign1 object  --- */
     t_cose_sign1_verify_init(&verify_ctx, T_COSE_OPT_DECODE_ONLY);
 
-    /* No key necessary with short circuit */
+    /* Decode-only mode so no key and no signature check. */
 
     /* Run the signature verification */
     result = t_cose_sign1_verify(&verify_ctx,

--- a/test/t_cose_test.h
+++ b/test/t_cose_test.h
@@ -1,7 +1,7 @@
 /*
  *  t_cose_test.h
  *
- * Copyright 2019-2020, Laurence Lundblade
+ * Copyright 2019-2022, Laurence Lundblade
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *
@@ -77,7 +77,7 @@ int_fast32_t short_circuit_make_cwt_test(void);
 
 /*
  * Test the decode only mode, the mode where the
- * headers are returned, but the signature is no
+ * headers are returned, but the signature is not
  * verified.
  */
 int_fast32_t short_circuit_decode_only_test(void);


### PR DESCRIPTION
This is related to improved warnings checking in a new version of tdv that does the full thorough compilation with full warnings checking and against c++.