### PR TITLE
CI: Test against OpenSSL 3.0 and Clang

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,43 +7,70 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        c-compiler: [gcc, clang]
+
         config:
+        # OpenSSL 1.1.1 (Ubuntu 20.04)
         - os-image: ubuntu-latest
+          container: ubuntu:20.04
+          crypto-provider: OpenSSL
+
+        # OpenSSL 3.0 (Ubuntu 22.04)
+        - os-image: ubuntu-latest
+          container: ubuntu:22.04
           crypto-provider: OpenSSL
         
         - os-image: ubuntu-latest
+          container: ubuntu:20.04
           crypto-provider: MbedTLS
-          mbedtls-version: v2.28.0
+          crypto-provider-version: '2.28.0'
         
         - os-image: ubuntu-latest
+          container: ubuntu:20.04
           crypto-provider: MbedTLS
-          mbedtls-version: v3.1.0
+          crypto-provider-version: '3.1.0'
           allow-failure: true
 
         - os-image: ubuntu-latest
+          container: ubuntu:20.04
           crypto-provider: Test
 
+    name: ${{ matrix.config.crypto-provider }} ${{ matrix.config.crypto-provider-version }} • ${{ matrix.c-compiler }} • ${{ matrix.config.container }}
+
     runs-on: ${{ matrix.config.os-image }}
+    container: ${{ matrix.config.container }}
 
     continue-on-error: ${{ matrix.config.allow-failure || false }}
 
     steps:
     - uses: actions/checkout@v3
 
-    - name: Fetch mbedTLS
+    - name: Install build tools
+      run: |
+        set -ex
+        export DEBIAN_FRONTEND=noninteractive
+        apt-get update
+        apt-get install -y build-essential cmake python3 ${{ matrix.c-compiler }}
+        echo "CC=${{ matrix.c-compiler }}" >> $GITHUB_ENV
+    
+    - name: Install OpenSSL
+      if: matrix.config.crypto-provider == 'OpenSSL'
+      run: apt-get install -y libssl-dev
+
+    - name: Fetch MbedTLS
       if: matrix.config.crypto-provider == 'MbedTLS'
       uses: actions/checkout@v3
       with:
         repository: ARMmbed/mbedtls
-        ref: ${{ matrix.config.mbedtls-version }}
+        ref: v${{ matrix.config.crypto-provider-version }}
         path: mbedtls
 
-    - name: Install mbedTLS
+    - name: Install MbedTLS
       if: matrix.config.crypto-provider == 'MbedTLS'
       run: |
         cd mbedtls
         make -j $(nproc)
-        sudo make install
+        make install
 
     - name: Fetch QCBOR
       uses: actions/checkout@v3
@@ -55,7 +82,7 @@ jobs:
       run: |
         cd QCBOR
         make -j$(nproc)
-        sudo make install
+        make install
 
     - name: Build t_cose
       run: |


### PR DESCRIPTION
Part of #53. This also adds CI jobs for OpenSSL 3 and Clang.

I switched to containers which I needed for Ubuntu 22.04 as that's the first version with OpenSSL 3 (GitHub Actions doesn't provide 22.04 host images yet) and it also makes CI more reproducable locally.