### PR TITLE
Switch to OpenSSL EVP API

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,50 @@ As of March 2022, the code is in  working order and the public interface has bee
 stable for over a year. There is a crypto adaptaion layer for [OpenSSL](https://www.openssl.org) 
 and for [Arm Mbed TLS](https://github.com/ARMmbed/mbedtls).
 
+### MbedTLS
+
+The crypto adapter for Mbed TLS is small and simple. The adapter
+allocates no memory and as far as I know Mbed TLS internally also
+allocates no memory. It is a good choice for embedded use.
+
+It makes use of the 1.0 version of the PSA cryptographic API.  No
+deprecated or to-be-deprecated functions are called (an older t_cose
+used some deprecated APIs).
+
+It is regularly tested against the latest version 2 and version 3 of
+Mbed TLS, an implementation of the PSA crypto API.
+
+Confidence in the adaptor code is high and reasonably well tested
+because it is simple.
+
+### OpenSSL
+
+The crypto adaptor for OpenSSL is about twice the size of that for
+Mbed TLS because the API doesn't line up well with the needs for COSE
+(OpenSSL is ASN.1/DER oriented). Memory allocation is performed inside
+OpenSSL and in the crypto adaptaion layer. This makes the OpenSSL
+crypto library less suitable for embedded use.
+
+No deprecated or to-be-deprecated APIs are used. 
+
+There are several different sets of APIs in OpenSSL that can be used
+to implement ECDSA and hashing. The ones choosen are the most official
+and well-supported, however others might suit particular uses cases
+better.  An older t_cose used some to-be-deprecated APIs and is a more
+efficient than this one.  It is unfortunate that these APIs
+(ECDSA_do_sign and ECDSA_do_verify) are slated for deprecation and
+there is no supported alternative to those that work with DER-encoded
+signatures.
+
+t_cose is regularly tested against OpenSSL 1.1.1 and 3.0.
+
+There are no known problems with the code and test coverages for the
+adaptor is reasonably good with the exception of the fan out of all
+the possible memory allocation failures. (Ideally there would be a
+test case for the failure of every single memory allocation, but this
+is difficult to implement. The code should handle them all correctly.
+
+
 
 ## Building and Dependencies
 

--- a/crypto_adapters/t_cose_openssl_crypto.c
+++ b/crypto_adapters/t_cose_openssl_crypto.c
@@ -13,11 +13,9 @@
 
 #include "t_cose_crypto.h" /* The interface this code implements */
 
-#include <openssl/ecdsa.h> // TODO: get rid of this
-
+#include <openssl/ecdsa.h>
 #include <openssl/evp.h>
 #include <openssl/err.h>
-
 #include <openssl/sha.h>
 
 
@@ -45,7 +43,6 @@
  */
 
 
-
 /**
  * \brief Convert OpenSSL ECDSA_SIG to serialized on-the-wire format
  *
@@ -65,32 +62,34 @@
  * internals are NULL.
  */
 static inline struct q_useful_buf_c
-convert_ecdsa_signature_from_ossl(unsigned               key_len,
-                                  struct q_useful_buf_c  ossl_signature,
-                                  struct q_useful_buf    signature_buffer)
+signature_der_to_cose(unsigned               key_len,
+                      struct q_useful_buf_c  der_signature,
+                      struct q_useful_buf    signature_buffer)
 {
     size_t                r_len;
     size_t                s_len;
-    const BIGNUM         *ossl_signature_r_bn;
-    const BIGNUM         *ossl_signature_s_bn;
-    struct q_useful_buf_c signature;
+    const BIGNUM         *r_bn;
+    const BIGNUM         *s_bn;
+    struct q_useful_buf_c cose_signature;
     void                 *r_start_ptr;
     void                 *s_start_ptr;
     const unsigned char  *temp_der_sig_pointer;
+    ECDSA_SIG            *es;
 
-    temp_der_sig_pointer = ossl_signature.ptr;
-    ECDSA_SIG *es = d2i_ECDSA_SIG(NULL,
-                                  &temp_der_sig_pointer,
-                                  (long)ossl_signature.len);
-    // TODO: Check for NULL
+    temp_der_sig_pointer = der_signature.ptr;
+    es = d2i_ECDSA_SIG(NULL, &temp_der_sig_pointer, (long)der_signature.len);
+    if(es == NULL) {
+        cose_signature = NULL_Q_USEFUL_BUF_C;
+        goto Done;
+    }
 
     /* Zero the buffer so that bytes r and s are padded with zeros */
     q_useful_buf_set(signature_buffer, 0);
 
     /* Get the signature r and s as BIGNUMs */
-    ossl_signature_r_bn = NULL;
-    ossl_signature_s_bn = NULL;
-    ECDSA_SIG_get0(es, &ossl_signature_r_bn, &ossl_signature_s_bn);
+    r_bn = NULL;
+    s_bn = NULL;
+    ECDSA_SIG_get0(es, &r_bn, &s_bn);
     /* ECDSA_SIG_get0 returns void */
 
 
@@ -101,27 +100,27 @@ convert_ecdsa_signature_from_ossl(unsigned               key_len,
     /* Cast is safe because BN_num_bytes() is documented to not return
      * negative numbers.
      */
-    r_len = (size_t)BN_num_bytes(ossl_signature_r_bn);
-    s_len = (size_t)BN_num_bytes(ossl_signature_s_bn);
+    r_len = (size_t)BN_num_bytes(r_bn);
+    s_len = (size_t)BN_num_bytes(s_bn);
     if(r_len + s_len > signature_buffer.len) {
-        signature = NULL_Q_USEFUL_BUF_C;
+        cose_signature = NULL_Q_USEFUL_BUF_C;
         goto Done2;
     }
 
     /* Copy r and s of signature to output buffer and set length */
     r_start_ptr = (uint8_t *)(signature_buffer.ptr) + key_len - r_len;
-    BN_bn2bin(ossl_signature_r_bn, r_start_ptr);
+    BN_bn2bin(r_bn, r_start_ptr);
 
     s_start_ptr = (uint8_t *)signature_buffer.ptr + 2 * key_len - s_len;
-    BN_bn2bin(ossl_signature_s_bn, s_start_ptr);
+    BN_bn2bin(s_bn, s_start_ptr);
 
-    signature = (UsefulBufC){signature_buffer.ptr, 2 * key_len};
+    cose_signature = (UsefulBufC){signature_buffer.ptr, 2 * key_len};
 
 Done2:
     ECDSA_SIG_free(es);
 
 Done:
-    return signature;
+    return cose_signature;
 }
 
 
@@ -140,9 +139,9 @@ Done:
  * concatenated.
  */
 static enum t_cose_err_t
-convert_ecdsa_signature_to_ossl(unsigned               key_len,
-                                struct q_useful_buf_c  signature,
-                                ECDSA_SIG            **ossl_sig_to_verify)
+signature_cose_to_der(unsigned               key_len,
+                      struct q_useful_buf_c  signature,
+                      ECDSA_SIG            **ossl_sig_to_verify)
 {
     enum t_cose_err_t return_value;
     BIGNUM           *ossl_signature_r_bn = NULL;
@@ -200,8 +199,6 @@ Done:
 }
 
 
-
-
 /**
  * \brief Common checks and conversions for signing and verification key.
  *
@@ -215,18 +212,15 @@ Done:
  * it and figures out the number of bytes in the key rounded up. This
  * is also the size of r and s in the signature.
  */
-// TODO: convert this to EVP
 static enum t_cose_err_t
-ecdsa_key_checks(struct t_cose_key  t_cose_key,
-                 EC_KEY           **return_ossl_ec_key,
-                 unsigned          *return_key_size_in_bytes)
+key_convert_and_size(struct t_cose_key  t_cose_key,
+                     EVP_PKEY         **return_ossl_ec_key,
+                     unsigned          *return_key_size_in_bytes)
 {
     enum t_cose_err_t  return_value;
-    const EC_GROUP    *key_group;
     int                key_len_bits; /* type unsigned is conscious choice */
     unsigned           key_len_bytes; /* type unsigned is conscious choice */
-    int                ossl_result; /* type int is conscious choice */
-    EC_KEY            *ossl_ec_key;
+    EVP_PKEY          *ossl_ec_key;
 
     /* Check the signing key and get it out of the union */
     if(t_cose_key.crypto_lib != T_COSE_CRYPTO_LIB_OPENSSL) {
@@ -237,41 +231,19 @@ ecdsa_key_checks(struct t_cose_key  t_cose_key,
         return_value = T_COSE_ERR_EMPTY_KEY;
         goto Done;
     }
-    ossl_ec_key = (EC_KEY *)t_cose_key.k.key_ptr;
+    ossl_ec_key = (EVP_PKEY *)t_cose_key.k.key_ptr;
 
-    /* Check the key to be sure it is OK */
-    ossl_result = EC_KEY_check_key(ossl_ec_key);
-    if(ossl_result == 0) {
-        return_value = T_COSE_ERR_SIG_FAIL;
-        goto Done;
-    }
+    key_len_bits = EVP_PKEY_bits(ossl_ec_key);
 
-    /* Get the key size, which depends on the group */
-    key_group = EC_KEY_get0_group(ossl_ec_key);
-    if(key_group == NULL) {
-        return_value = T_COSE_ERR_WRONG_TYPE_OF_KEY;
-        goto Done;
-    }
-    key_len_bits = EC_GROUP_get_degree(key_group);
-    if(key_len_bits <= 0) {
-        /* This is not expected to ever happen */
-        return_value = T_COSE_ERR_SIG_FAIL;
-        goto Done;
-    }
-
-    /* Convert group size in bits to key size in bytes per RFC 8152
-     * section 8.1. This is also the size of r and s in the
-     * signature. This is by rounding up to the number of bytes to
-     * hold the give number of bits. Cast is safe because of
-     * check above.
-     */
+    /* Calculation of size per RFC 8152 section 8.1 -- round up to
+     * number of bytes. */
     key_len_bytes = (unsigned)key_len_bits / 8;
     if(key_len_bits % 8) {
         key_len_bytes++;
     }
 
     *return_key_size_in_bytes = key_len_bytes;
-    *return_ossl_ec_key       = ossl_ec_key;
+    *return_ossl_ec_key = ossl_ec_key;
 
     return_value = T_COSE_SUCCESS;
 
@@ -280,32 +252,27 @@ Done:
 }
 
 
-
 /*
- * See documentation in t_cose_crypto.h
+ * Public Interface. See documentation in t_cose_crypto.h
  */
 enum t_cose_err_t t_cose_crypto_sig_size(int32_t           cose_algorithm_id,
                                          struct t_cose_key signing_key,
                                          size_t           *sig_size)
 {
     enum t_cose_err_t return_value;
-    size_t            key_len_bits;
-    size_t            key_len_bytes;
+    unsigned          key_len_bytes;
+    EVP_PKEY         *signing_key_evp; /* Unused */
 
     if(!t_cose_algorithm_is_ecdsa(cose_algorithm_id)) {
         return_value = T_COSE_ERR_UNSUPPORTED_SIGNING_ALG;
         goto Done;
     }
 
-    // TODO: say why cast is safe
-    key_len_bits = (size_t)EVP_PKEY_bits(signing_key.k.key_ptr);
-
-    /* Calculation of size per RFC 8152 section 8.1 -- round up to
-     * number of bytes. */
-    key_len_bytes = key_len_bits / 8;
-    if(key_len_bits % 8) {
-        key_len_bytes++;
+    return_value = key_convert_and_size(signing_key, &signing_key_evp, &key_len_bytes);
+    if(return_value != T_COSE_SUCCESS) {
+        goto Done;
     }
+
     /* Double because signature is made of up r and s values */
     *sig_size = key_len_bytes * 2;
 
@@ -324,16 +291,16 @@ t_cose_crypto_pub_key_sign(int32_t                cose_algorithm_id,
                            struct t_cose_key      signing_key,
                            struct q_useful_buf_c  hash_to_sign,
                            struct q_useful_buf    signature_buffer,
-                           struct q_useful_buf_c *serialized_signature)
+                           struct q_useful_buf_c *signature)
 {
 #define DER_SIG_ENCODE_OVER_HEAD 20
-    enum t_cose_err_t  return_value;
-    EVP_MD_CTX        *sign_context;
-    EVP_PKEY          *private_key;
-    int                ossl_result;
-    size_t             temp_der_signature_length;
-    uint8_t            temp_der_signature[T_COSE_MAX_SIG_SIZE + DER_SIG_ENCODE_OVER_HEAD];
-    struct q_useful_buf_c temp_der_signature_ub;
+
+    enum t_cose_err_t      return_value;
+    EVP_MD_CTX            *sign_context;
+    EVP_PKEY              *signing_key_evp;
+    int                    ossl_result;
+    unsigned               key_size_bytes;
+    MakeUsefulBufOnStack(  der_format_signature, T_COSE_MAX_SIG_SIZE + DER_SIG_ENCODE_OVER_HEAD);
 
     /* This implementation supports ECDSA and only ECDSA. The
      * interface allows it to support other, but none are implemented.
@@ -351,15 +318,13 @@ t_cose_crypto_pub_key_sign(int32_t                cose_algorithm_id,
         goto Done2;
     }
 
-    /*
-     * Make a message signature context to hold temporary state
-     * during signature creation
-     */
-    sign_context = EVP_MD_CTX_new();
-    if(sign_context == NULL) {
-        return_value = 99; // TODO: correct error
-        goto Done;
+    /* Pull the pointer of the OpenSSL-format key out of the
+     * t_cose key structure. */
+    return_value = key_convert_and_size(signing_key, &signing_key_evp, &key_size_bytes);
+    if(return_value != T_COSE_SUCCESS) {
+        goto Done2;
     }
+
 
     /*
      * Initialize the sign context to use the fetched
@@ -388,33 +353,32 @@ t_cose_crypto_pub_key_sign(int32_t                cose_algorithm_id,
      needed in the signature. RSA signature schemes like PSS need
      this. ECDSA doesn't so they are both NULL.
      */
-
-    private_key = (EVP_PKEY *)signing_key.k.key_ptr;
-
+    sign_context = EVP_MD_CTX_new();
+    if(sign_context == NULL) {
+        return_value = T_COSE_ERR_INSUFFICIENT_MEMORY;
+        goto Done;
+    }
     ossl_result = EVP_DigestSignInit(sign_context,
                                      NULL, /* pctx */
                                      NULL, /* type */
                                      NULL, /* Engine */
-                                     private_key /* The private key */);
-
+                                     signing_key_evp /* The private key */);
     if(!ossl_result) {
         return_value = T_COSE_ERR_SIG_FAIL;
         goto Done;
     }
 
 
-    temp_der_signature_length = sizeof(temp_der_signature);
+    /* Actually do the signature.
 
-    /*
      EVP_DigestSign(
         EVP_MD_CTX *ctx,
         unsigned char *sigret, size_t *siglen,
         const unsigned char *tbs, size_t tbslen);
      */
     ossl_result = EVP_DigestSign(sign_context,
-                                 temp_der_signature, &temp_der_signature_length,
+                                 der_format_signature.ptr, &der_format_signature.len,
                                  hash_to_sign.ptr, hash_to_sign.len);
-
     if(ossl_result != 1) {
         return_value = 99;
         goto Done;
@@ -425,19 +389,11 @@ t_cose_crypto_pub_key_sign(int32_t                cose_algorithm_id,
      * a q_useful_buf. Presumably everything inside ossl_signature is
      * correct since it is not NULL.
      */
-    temp_der_signature_ub.ptr = temp_der_signature;
-    temp_der_signature_ub.len = temp_der_signature_length;
-
-    size_t sig_size;
-
-    return_value = t_cose_crypto_sig_size(cose_algorithm_id, signing_key, &sig_size);
-
-    *serialized_signature =
-        convert_ecdsa_signature_from_ossl((unsigned int)sig_size/2,
-                                          temp_der_signature_ub,
+    *signature = signature_der_to_cose((unsigned)key_size_bytes,
+                                          // TODO: q_usebuf version of this
+                                          UsefulBuf_Const(der_format_signature),
                                           signature_buffer);
-
-    if(q_useful_buf_c_is_null(*serialized_signature)) {
+    if(q_useful_buf_c_is_null(*signature)) {
         return_value = T_COSE_ERR_SIG_FAIL;
         goto Done;
     }
@@ -472,7 +428,9 @@ t_cose_crypto_pub_key_verify(int32_t                cose_algorithm_id,
     ECDSA_SIG        *ossl_sig_to_verify;
     EVP_MD_CTX        *verify_context = NULL;
     EVP_PKEY          *public_key;
+    unsigned           key_size;
 
+    // TODO: lots of fixes to this code
     /* This implementation doesn't use any key store with the ability
      * to look up a key based on kid. */
     (void)kid;
@@ -484,16 +442,16 @@ t_cose_crypto_pub_key_verify(int32_t                cose_algorithm_id,
         goto Done;
     }
 
-
-    size_t sig_size;
-
-    return_value = t_cose_crypto_sig_size(cose_algorithm_id, verification_key, &sig_size);
+    return_value = key_convert_and_size(verification_key, &public_key, &key_size);
+    if(return_value != T_COSE_SUCCESS) {
+        goto Done;
+    }
 
     /* Convert the serialized signature off the wire into the openssl
      * object / structure
      */
     return_value =
-       convert_ecdsa_signature_to_ossl((unsigned)sig_size/2,
+       signature_cose_to_der(key_size,
                                        serialized_sig_to_verify,
                                        &ossl_sig_to_verify);
     if(return_value) {
@@ -557,73 +515,68 @@ Done:
 /*
  * See documentation in t_cose_crypto.h
  */
-enum t_cose_err_t t_cose_crypto_hash_start(struct t_cose_crypto_hash *hash_ctx,
-                                           int32_t cose_hash_alg_id)
+enum t_cose_err_t
+t_cose_crypto_hash_start(struct t_cose_crypto_hash *hash_ctx,
+                         int32_t cose_hash_alg_id)
 {
-    int ossl_result;
+    int           ossl_result;
+    int           nid;
+    const EVP_MD *message_digest;
 
     switch(cose_hash_alg_id) {
 
     case COSE_ALGORITHM_SHA_256:
-        ossl_result = SHA256_Init(&hash_ctx->ctx.sha_256);
+        nid = NID_sha256;
         break;
 
 #ifndef T_COSE_DISABLE_ES384
     case COSE_ALGORITHM_SHA_384:
-        ossl_result = SHA384_Init(&hash_ctx->ctx.sha_512);
+        nid = NID_sha384;
         break;
 #endif
 
 #ifndef T_COSE_DISABLE_ES512
     case COSE_ALGORITHM_SHA_512:
-        ossl_result = SHA512_Init(&hash_ctx->ctx.sha_512);
+        nid = NID_sha512;
         break;
 #endif
 
     default:
         return T_COSE_ERR_UNSUPPORTED_HASH;
-
     }
+
+    message_digest = EVP_get_digestbynid(NID_sha256);
+    if(message_digest == NULL){
+        return T_COSE_ERR_UNSUPPORTED_HASH;
+    }
+
+    hash_ctx->evp_ctx = EVP_MD_CTX_new();
+
+    ossl_result = EVP_DigestInit_ex(hash_ctx->evp_ctx, message_digest, NULL);
+    if(ossl_result == 0) {
+        EVP_MD_CTX_free(hash_ctx->evp_ctx);
+        return T_COSE_ERR_HASH_GENERAL_FAIL;
+    }
+
     hash_ctx->cose_hash_alg_id = cose_hash_alg_id;
     hash_ctx->update_error = 1; /* 1 is success in OpenSSL */
 
-    /* OpenSSL returns 1 for success, not 0 */
-    return ossl_result ? T_COSE_SUCCESS : T_COSE_ERR_HASH_GENERAL_FAIL;
+    return T_COSE_SUCCESS;
 }
 
 
 /*
  * See documentation in t_cose_crypto.h
  */
-void t_cose_crypto_hash_update(struct t_cose_crypto_hash *hash_ctx,
-                               struct q_useful_buf_c data_to_hash)
+void
+t_cose_crypto_hash_update(struct t_cose_crypto_hash *hash_ctx,
+                          struct q_useful_buf_c data_to_hash)
 {
     if(hash_ctx->update_error) { /* 1 is no error, 0 means error for OpenSSL */
         if(data_to_hash.ptr) {
-            switch(hash_ctx->cose_hash_alg_id) {
-
-            case COSE_ALGORITHM_SHA_256:
-                hash_ctx->update_error = SHA256_Update(&hash_ctx->ctx.sha_256,
-                                                       data_to_hash.ptr,
-                                                       data_to_hash.len);
-                break;
-
-#ifndef T_COSE_DISABLE_ES384
-            case COSE_ALGORITHM_SHA_384:
-                hash_ctx->update_error = SHA384_Update(&hash_ctx->ctx.sha_512,
-                                                       data_to_hash.ptr,
-                                                       data_to_hash.len);
-                break;
-#endif
-
-#ifndef T_COSE_DISABLE_ES512
-            case COSE_ALGORITHM_SHA_512:
-                hash_ctx->update_error = SHA512_Update(&hash_ctx->ctx.sha_512,
-                                                       data_to_hash.ptr,
-                                                       data_to_hash.len);
-                break;
-#endif
-            }
+            hash_ctx->update_error = EVP_DigestUpdate(hash_ctx->evp_ctx,
+                                                      data_to_hash.ptr,
+                                                      data_to_hash.len);
         }
     }
 }
@@ -634,43 +587,24 @@ void t_cose_crypto_hash_update(struct t_cose_crypto_hash *hash_ctx,
  */
 enum t_cose_err_t
 t_cose_crypto_hash_finish(struct t_cose_crypto_hash *hash_ctx,
-                          struct q_useful_buf buffer_to_hold_result,
-                          struct q_useful_buf_c *hash_result)
+                          struct q_useful_buf        buffer_to_hold_result,
+                          struct q_useful_buf_c     *hash_result)
 {
-    size_t hash_result_len = 0;
-
-    int ossl_result = 0; /* Assume failure; 0 == failure for OpenSSL */
+    int          ossl_result;
+    unsigned int hash_result_len;
 
     if(!hash_ctx->update_error) {
         return T_COSE_ERR_HASH_GENERAL_FAIL;
     }
 
-    switch(hash_ctx->cose_hash_alg_id) {
-
-    case COSE_ALGORITHM_SHA_256:
-        ossl_result = SHA256_Final(buffer_to_hold_result.ptr,
-                                   &hash_ctx->ctx.sha_256);
-        hash_result_len = T_COSE_CRYPTO_SHA256_SIZE;
-        break;
-
-#ifndef T_COSE_DISABLE_ES384
-    case COSE_ALGORITHM_SHA_384:
-        ossl_result = SHA384_Final(buffer_to_hold_result.ptr,
-                                   &hash_ctx->ctx.sha_512);
-        hash_result_len = T_COSE_CRYPTO_SHA384_SIZE;
-        break;
-#endif
-
-#ifndef T_COSE_DISABLE_ES512
-    case COSE_ALGORITHM_SHA_512:
-        ossl_result = SHA512_Final(buffer_to_hold_result.ptr,
-                                   &hash_ctx->ctx.sha_512);
-        hash_result_len = T_COSE_CRYPTO_SHA512_SIZE;
-        break;
-#endif
-    }
+    hash_result_len = (unsigned int)buffer_to_hold_result.len;
+    ossl_result = EVP_DigestFinal_ex(hash_ctx->evp_ctx,
+                                     buffer_to_hold_result.ptr,
+                                     &hash_result_len);
 
     *hash_result = (UsefulBufC){buffer_to_hold_result.ptr, hash_result_len};
+
+    EVP_MD_CTX_free(hash_ctx->evp_ctx);
 
     /* OpenSSL returns 1 for success, not 0 */
     return ossl_result ? T_COSE_SUCCESS : T_COSE_ERR_HASH_GENERAL_FAIL;

--- a/examples/t_cose_basic_example_ossl.c
+++ b/examples/t_cose_basic_example_ossl.c
@@ -33,6 +33,7 @@
 #include "openssl/ecdsa.h"
 #include "openssl/obj_mac.h" /* for NID for EC curve */
 #include "openssl/err.h"
+#include "openssl/evp.h"
 
 
 /*
@@ -98,110 +99,56 @@
 enum t_cose_err_t make_ossl_ecdsa_key_pair(int32_t            cose_algorithm_id,
                                            struct t_cose_key *key_pair)
 {
-    EC_GROUP          *ossl_ec_group = NULL;
     enum t_cose_err_t  return_value;
-    BIGNUM            *ossl_private_key_bn = NULL;
-    EC_KEY            *ossl_ec_key = NULL;
     int                ossl_result;
-    EC_POINT          *ossl_pub_key_point = NULL;
-    int                nid;
-    const char        *public_key;
-    const char        *private_key;
+    int                ossl_nid;
+    EVP_PKEY          *pkey = NULL;
+    EVP_PKEY_CTX      *ctx;
 
     switch (cose_algorithm_id) {
     case T_COSE_ALGORITHM_ES256:
-        nid         = NID_X9_62_prime256v1;
-        public_key  = PUBLIC_KEY_prime256v1;
-        private_key =  PRIVATE_KEY_prime256v1 ;
+        ossl_nid  = NID_X9_62_prime256v1;
         break;
 
     case T_COSE_ALGORITHM_ES384:
-        nid         = NID_secp384r1;
-        public_key  = PUBLIC_KEY_secp384r1;
-        private_key = PRIVATE_KEY_secp384r1;
+        ossl_nid = NID_secp384r1;
         break;
 
     case T_COSE_ALGORITHM_ES512:
-        nid         = NID_secp521r1;
-        public_key  = PUBLIC_KEY_secp521r1;
-        private_key = PRIVATE_KEY_secp521r1;
+        ossl_nid = NID_secp521r1;
         break;
 
     default:
-       return T_COSE_ERR_UNSUPPORTED_SIGNING_ALG;
+        return T_COSE_ERR_UNSUPPORTED_SIGNING_ALG;
     }
 
-    /* Make a group for the particular EC algorithm */
-    ossl_ec_group = EC_GROUP_new_by_curve_name(nid);
-    if(ossl_ec_group == NULL) {
+    ctx = EVP_PKEY_CTX_new_id(EVP_PKEY_EC, NULL);
+    if(ctx == NULL) {
         return_value = T_COSE_ERR_INSUFFICIENT_MEMORY;
         goto Done;
     }
 
-    /* Make an empty EC key object */
-    ossl_ec_key = EC_KEY_new();
-    if(ossl_ec_key == NULL) {
-        return_value = T_COSE_ERR_INSUFFICIENT_MEMORY;
+    if (EVP_PKEY_keygen_init(ctx) <= 0) {
+        return_value = T_COSE_ERR_FAIL;
         goto Done;
     }
 
-    /* Associate group with key object */
-    ossl_result = EC_KEY_set_group(ossl_ec_key, ossl_ec_group);
-    if (!ossl_result) {
-        return_value = T_COSE_ERR_SIG_FAIL;
+    ossl_result = EVP_PKEY_CTX_set_ec_paramgen_curve_nid(ctx, ossl_nid);
+    if(ossl_result != 1) {
+        return_value = T_COSE_ERR_FAIL;
         goto Done;
     }
 
-    /* Make an instance of a big number to store the private key */
-    ossl_private_key_bn = BN_new();
-    if(ossl_private_key_bn == NULL) {
-        return_value = T_COSE_ERR_INSUFFICIENT_MEMORY;
-        goto Done;
-    }
-    BN_zero(ossl_private_key_bn);
+    pkey = EVP_PKEY_new();
 
-    /* Stuff the specific private key into the big num */
-    ossl_result = BN_hex2bn(&ossl_private_key_bn, private_key);
-    if(ossl_private_key_bn == 0) {
-        return_value = T_COSE_ERR_SIG_FAIL;
+    ossl_result = EVP_PKEY_keygen(ctx, &pkey);
+
+    if(ossl_result != 1) {
+        return_value = T_COSE_ERR_FAIL;
         goto Done;
     }
 
-    /* Now associate the big num with the key object so we finally
-     * have a key set up and ready for signing */
-    ossl_result = EC_KEY_set_private_key(ossl_ec_key, ossl_private_key_bn);
-    if (!ossl_result) {
-        return_value = T_COSE_ERR_SIG_FAIL;
-        goto Done;
-    }
-
-
-    /* Make an empty EC point into which the public key gets loaded */
-    ossl_pub_key_point = EC_POINT_new(ossl_ec_group);
-    if(ossl_pub_key_point == NULL) {
-        return_value = T_COSE_ERR_INSUFFICIENT_MEMORY;
-        goto Done;
-    }
-
-    /* Turn the serialized public key into an EC point */
-    ossl_pub_key_point = EC_POINT_hex2point(ossl_ec_group,
-                                            public_key,
-                                            ossl_pub_key_point,
-                                            NULL);
-    if(ossl_pub_key_point == NULL) {
-        return_value = T_COSE_ERR_SIG_FAIL;
-        goto Done;
-    }
-
-    /* Associate the EC point with key object */
-    /* The key object has both the public and private keys in it */
-    ossl_result = EC_KEY_set_public_key(ossl_ec_key, ossl_pub_key_point);
-    if(ossl_result == 0) {
-        return_value = T_COSE_ERR_SIG_FAIL;
-        goto Done;
-    }
-
-    key_pair->k.key_ptr  = ossl_ec_key;
+    key_pair->k.key_ptr  = pkey;
     key_pair->crypto_lib = T_COSE_CRYPTO_LIB_OPENSSL;
     return_value         = T_COSE_SUCCESS;
 
@@ -217,7 +164,7 @@ Done:
  */
 void free_ossl_ecdsa_key_pair(struct t_cose_key key_pair)
 {
-    EC_KEY_free(key_pair.k.key_ptr);
+    EVP_PKEY_free(key_pair.k.key_ptr);
 }
 
 

--- a/examples/t_cose_basic_example_ossl.c
+++ b/examples/t_cose_basic_example_ossl.c
@@ -31,60 +31,9 @@
 #include <stdio.h>
 
 #include "openssl/ecdsa.h"
-#include "openssl/obj_mac.h" /* for NID for EC curve */
 #include "openssl/err.h"
 #include "openssl/evp.h"
 
-
-/*
- * Some hard coded keys for the test cases here.
- */
-#define PUBLIC_KEY_prime256v1 \
-"0437ab65955fae0466673c3a2934a3" \
-"4f2f0ec2b3eec224198557998fc04b" \
-"f4b2b495d9798f2539c90d7d102b3b" \
-"bbda7fcbdb0e9b58d4e1ad2e61508d" \
-"a75f84a67b"
-
-#define PRIVATE_KEY_prime256v1 \
-"f1b7142343402f3b5de7315ea894f9" \
-"da5cf503ff7938a37ca14eb0328698" \
-"8450"
-
-
-#define PUBLIC_KEY_secp384r1 \
-"04bdd9c3f818c9cef3e11e2d40e775" \
-"beb37bc376698d71967f93337a4e03" \
-"2dffb11b505067dddb4214b56d9bce" \
-"c59177eccd8ab05f50975933b9a738" \
-"d90c0b07eb9519567ef9075807cf77" \
-"139fc1fe85608851361136806123ed" \
-"c735ce5a03e8e4"
-
-#define PRIVATE_KEY_secp384r1 \
-"03df14f4b8a43fd8ab75a6046bd2b5" \
-"eaa6fd10b2b203fd8a78d7916de20a" \
-"a241eb37ec3d4c693d23ba2b4f6e5b" \
-"66f57f"
-
-
-#define PUBLIC_KEY_secp521r1 \
-"0400e4d253175a14311fc2dd487687" \
-"70cb49b07bd15d327beb98aa33e60c" \
-"d0181b17fb8f1cbf07dbc8652ff5b7" \
-"b4452c082e0686c0fab8089071cbc5" \
-"37101d344b94c201e6424f3a18da4f" \
-"20ecabfbc84b8467c217cd67055fa5" \
-"dec7fb1ae87082302c1813caa4b7b1" \
-"cf28d94677e486fb4b317097e9307a" \
-"bdb9d50187779a3d1e682c123c"
-
-#define PRIVATE_KEY_secp521r1 \
-"0045d2d1439435fab333b1c6c8b534" \
-"f0969396ad64d5f535d65f68f2a160" \
-"6590bb15fd5322fc97a416c395745e" \
-"72c7c85198c0921ab3b8e92dd901b5" \
-"a42159adac6d"
 
 
 /**
@@ -226,9 +175,9 @@ int32_t one_step_sign_example()
     /* ------   Construct the payload    ------
      *
      * The payload is constructed into its own continguous buffer.
-     * In this case the payload is CBOR formatm so it uses QCBOR to
-     * encode it, but CBOR is not
-     * required by COSE so it could be anything at all.
+     * In this case the payload is CBOR format so it uses QCBOR to
+     * encode it, but CBOR is not required for COSE payloads so it could
+     * be anything at all.
      *
      * The payload constructed here is a map of some label-value
      * pairs similar to a CWT or EAT, but using string labels

--- a/inc/t_cose/q_useful_buf.h
+++ b/inc/t_cose/q_useful_buf.h
@@ -66,6 +66,11 @@ static inline int q_useful_buf_c_is_null_or_empty(struct q_useful_buf_c in)
     return UsefulBuf_IsNULLOrEmptyC(in);
 }
 
+static inline struct q_useful_buf_c q_usefulbuf_const(struct q_useful_buf ub)
+{
+    return UsefulBuf_Const(ub);
+}
+
 
 static inline struct q_useful_buf q_useful_buf_unconst(struct q_useful_buf_c in)
 {

--- a/inc/t_cose/t_cose_common.h
+++ b/inc/t_cose/t_cose_common.h
@@ -18,6 +18,8 @@
 extern "C" {
 #endif
 
+
+
 /**
  * \file t_cose_common.h
  *
@@ -118,7 +120,7 @@ enum t_cose_crypto_lib_t {
  * fill in this data structure.
  *
  * For example, in the OpenSSL integration, \ref key_ptr should point
- * to an OpenSSL \c EC_KEY type.
+ * to an OpenSSL \c EVP_KEY type.
  */
 struct t_cose_key {
     /** Identifies the crypto library this key was created for.  The

--- a/src/t_cose_crypto.h
+++ b/src/t_cose_crypto.h
@@ -284,6 +284,7 @@ t_cose_crypto_pub_key_verify(int32_t               cose_algorithm_id,
 
 #elif T_COSE_USE_OPENSSL_CRYPTO
 #include "openssl/sha.h"
+#include "openssl/evp.h"
 
 #elif T_COSE_USE_B_CON_SHA256
 /* This is code for use with Brad Conte's crypto.  See
@@ -340,6 +341,7 @@ struct t_cose_crypto_hash {
         psa_status_t         status;
 
     #elif T_COSE_USE_OPENSSL_CRYPTO
+        EVP_MD_CTX  *evp_ctx;
         /* --- The context for PSA Crypto (MBed Crypto) --- */
 
         /* What is needed for a full proper integration of OpenSSL's hashes */

--- a/src/t_cose_crypto.h
+++ b/src/t_cose_crypto.h
@@ -283,7 +283,6 @@ t_cose_crypto_pub_key_verify(int32_t               cose_algorithm_id,
 #include "psa/crypto.h"
 
 #elif T_COSE_USE_OPENSSL_CRYPTO
-#include "openssl/sha.h"
 #include "openssl/evp.h"
 
 #elif T_COSE_USE_B_CON_SHA256
@@ -341,21 +340,10 @@ struct t_cose_crypto_hash {
         psa_status_t         status;
 
     #elif T_COSE_USE_OPENSSL_CRYPTO
+        /* --- The context for OpenSSL crypto --- */
         EVP_MD_CTX  *evp_ctx;
-        /* --- The context for PSA Crypto (MBed Crypto) --- */
-
-        /* What is needed for a full proper integration of OpenSSL's hashes */
-        union {
-            SHA256_CTX sha_256;
-        #if !defined T_COSE_DISABLE_ES512 || !defined T_COSE_DISABLE_ES384
-            /* SHA 384 uses the sha_512 context
-             * This uses about 100 bytes above SHA-256  */
-            SHA512_CTX sha_512;
-        #endif
-        } ctx;
-
-        int     update_error; /* Used to track error return by SHAXXX_Update() */
-        int32_t cose_hash_alg_id; /* COSE integer ID for the hash alg */
+        int          update_error; /* Used to track error return by SHAXXX_Update() */
+        int32_t      cose_hash_alg_id; /* COSE integer ID for the hash alg */
 
    #elif T_COSE_USE_B_CON_SHA256
         /* --- Specific context for Brad Conte's sha256.c --- */
@@ -395,7 +383,7 @@ struct t_cose_crypto_hash {
 
 
 /**
- * The maximum needed to hold a hash. It is smaller and less stack is used
+ * The maximum needed to hold a hash. It is smaller and less stack is needed
  * if the larger hashes are disabled.
  */
 #ifndef T_COSE_DISABLE_ES512
@@ -520,7 +508,8 @@ t_cose_crypto_hash_finish(struct t_cose_crypto_hash *hash_ctx,
  * (As other types of signing algorithms are added, RSA for example,
  * a similar function can be added for them.)
  */
-static bool t_cose_algorithm_is_ecdsa(int32_t cose_algorithm_id);
+static bool
+t_cose_algorithm_is_ecdsa(int32_t cose_algorithm_id);
 
 
 
@@ -557,7 +546,8 @@ t_cose_check_list(int32_t cose_algorithm_id, const int32_t *list)
     return false;
 }
 
-static inline bool t_cose_algorithm_is_ecdsa(int32_t cose_algorithm_id)
+static inline bool
+t_cose_algorithm_is_ecdsa(int32_t cose_algorithm_id)
 {
     /* The simple list of COSE alg IDs that use ECDSA */
     static const int32_t ecdsa_list[] = {

--- a/src/t_cose_crypto.h
+++ b/src/t_cose_crypto.h
@@ -1,7 +1,7 @@
 /*
  * t_cose_crypto.h
  *
- * Copyright 2019, Laurence Lundblade
+ * Copyright 2019-2022, Laurence Lundblade
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *
@@ -234,7 +234,7 @@ t_cose_crypto_pub_key_sign(int32_t                cose_algorithm_id,
  * \param[in] verification_key  The verification key to use.
  * \param[in] kid               The COSE kid (key ID) or \c NULL_Q_USEFUL_BUF_C.
  * \param[in] hash_to_verify    The data or hash that is to be verified.
- * \param[in] signature         The signature.
+ * \param[in] signature         The COSE-format signature.
  *
  * This verifies that the \c signature passed in was over the \c
  * hash_to_verify passed in.

--- a/test/t_cose_make_openssl_test_key.c
+++ b/test/t_cose_make_openssl_test_key.c
@@ -1,7 +1,7 @@
 /*
  *  t_cose_make_openssl_test_key.c
  *
- * Copyright 2019-2020, Laurence Lundblade
+ * Copyright 2019-2022, Laurence Lundblade
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *
@@ -11,7 +11,6 @@
 #include "t_cose_make_test_pub_key.h" /* The interface implemented here */
 
 #include "openssl/ecdsa.h"
-#include "openssl/obj_mac.h" /* for NID for EC curve */
 #include "openssl/err.h"
 #include "openssl/evp.h"
 
@@ -25,7 +24,7 @@
  * by calling free_ecdsa_key_pair(). This heap use is a part of
  * OpenSSL and not t_cose which does not use the heap
  */
-enum t_cose_err_t make_ecdsa_key_pair(int32_t           cose_algorithm_id,
+enum t_cose_err_t make_ecdsa_key_pair(int32_t            cose_algorithm_id,
                                       struct t_cose_key *key_pair)
 {
     enum t_cose_err_t  return_value;

--- a/test/t_cose_sign_verify_test.h
+++ b/test/t_cose_sign_verify_test.h
@@ -22,7 +22,7 @@
 
 
 /**
- * \brief Self test using openssl crypto.
+ * \brief Self test using integrated  crypto.
  *
  * \return non-zero on failure.
  */

--- a/test/t_cose_test.h
+++ b/test/t_cose_test.h
@@ -129,7 +129,7 @@ int_fast32_t sign1_structure_decode_test(void);
  * by default because it needs a hacked version of a hash algorithm.
  * It is very hard to get hash algorithms to fail, so this hacked
  * version is necessary. This test will not run correctly with
- * OpenSSL or PSA hashes because they aren't (and shouldn't be) hacked.
+ * OpenSSL or Mbed TLS hashes because they aren't (and shouldn't be) hacked.
  * It works only with the b_con hash bundled and not intended for
  * commercial use (though it is a perfectly fine implementation).
  */


### PR DESCRIPTION
This uses the OpenSSL APIs that are not going to be deprecated for ECDSA signatures and works on 1.1.1 and 3.0.