### PR TITLE
Add restartable api

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,33 +14,46 @@ jobs:
         - os-image: ubuntu-latest
           container: ubuntu:20.04
           crypto-provider: OpenSSL
+          restartable: non-restartable
 
         # OpenSSL 3.0 (Ubuntu 22.04)
         - os-image: ubuntu-latest
           container: ubuntu:22.04
           crypto-provider: OpenSSL
+          restartable: non-restartable
         
         - os-image: ubuntu-latest
           container: ubuntu:20.04
           crypto-provider: MbedTLS_PSA
           crypto-provider-version: '2.28.0'
+          restartable: non-restartable
         
         - os-image: ubuntu-latest
           container: ubuntu:20.04
           crypto-provider: MbedTLS_PSA
           crypto-provider-version: '3.1.0'
+          restartable: non-restartable
 
         # The Mbedtls adapter only supports Mbed TLS version 3.1.0
         - os-image: ubuntu-latest
           container: ubuntu:20.04
           crypto-provider: MbedTLS_Mbedtls
           crypto-provider-version: '3.1.0'
+          restartable: restartable
+
+        # The Mbedtls adapter only supports Mbed TLS version 3.1.0
+        - os-image: ubuntu-latest
+          container: ubuntu:20.04
+          crypto-provider: MbedTLS_Mbedtls
+          crypto-provider-version: '3.1.0'
+          restartable: non-restartable
 
         - os-image: ubuntu-latest
           container: ubuntu:20.04
           crypto-provider: Test
+          restartable: non-restartable
 
-    name: ${{ matrix.config.crypto-provider }} ${{ matrix.config.crypto-provider-version }} • ${{ matrix.c-compiler }} • ${{ matrix.config.container }}
+    name: ${{ matrix.config.crypto-provider }} ${{ matrix.config.crypto-provider-version }} • ${{ matrix.c-compiler }} • ${{ matrix.config.container }} • ${{ matrix.config.restartable }}
 
     runs-on: ${{ matrix.config.os-image }}
     container: ${{ matrix.config.container }}
@@ -67,6 +80,12 @@ jobs:
         repository: ARMmbed/mbedtls
         ref: v${{ matrix.config.crypto-provider-version }}
         path: mbedtls
+
+    - name: Enable ECP restartable in mbedTLS
+      if: startsWith( matrix.config.crypto-provider, 'MbedTLS_' ) && matrix.config.restartable == 'restartable'
+      run: |
+        cd mbedtls
+        sed -i 's%//#define MBEDTLS_ECP_RESTARTABLE%#define MBEDTLS_ECP_RESTARTABLE%' include/mbedtls/mbedtls_config.h
 
     - name: Install MbedTLS
       if: startsWith( matrix.config.crypto-provider, 'MbedTLS_' )

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,12 +22,18 @@ jobs:
         
         - os-image: ubuntu-latest
           container: ubuntu:20.04
-          crypto-provider: MbedTLS
+          crypto-provider: MbedTLS_PSA
           crypto-provider-version: '2.28.0'
         
         - os-image: ubuntu-latest
           container: ubuntu:20.04
-          crypto-provider: MbedTLS
+          crypto-provider: MbedTLS_PSA
+          crypto-provider-version: '3.1.0'
+
+        # The Mbedtls adapter only supports Mbed TLS version 3.1.0
+        - os-image: ubuntu-latest
+          container: ubuntu:20.04
+          crypto-provider: MbedTLS_Mbedtls
           crypto-provider-version: '3.1.0'
 
         - os-image: ubuntu-latest
@@ -55,7 +61,7 @@ jobs:
       run: apt-get install -y libssl-dev
 
     - name: Fetch MbedTLS
-      if: matrix.config.crypto-provider == 'MbedTLS'
+      if: startsWith( matrix.config.crypto-provider, 'MbedTLS_' )
       uses: actions/checkout@v3
       with:
         repository: ARMmbed/mbedtls
@@ -63,7 +69,7 @@ jobs:
         path: mbedtls
 
     - name: Install MbedTLS
-      if: matrix.config.crypto-provider == 'MbedTLS'
+      if: startsWith( matrix.config.crypto-provider, 'MbedTLS_' )
       run: |
         cd mbedtls
         make -j $(nproc)
@@ -93,9 +99,13 @@ jobs:
       if: matrix.config.crypto-provider == 'OpenSSL'
       run: build/t_cose_basic_example_ossl
 
-    - name: Run MbedTLS example
-      if: matrix.config.crypto-provider == 'MbedTLS'
+    - name: Run MbedTLS PSA example
+      if: matrix.config.crypto-provider == 'MbedTLS_PSA'
       run: build/t_cose_basic_example_psa
+
+    - name: Run MbedTLS Mbedtls example
+      if: matrix.config.crypto-provider == 'MbedTLS_Mbedtls'
+      run: build/t_cose_basic_example_mbedtls
 
     - name: Run tests
       run: build/t_cose_test

--- a/.gitignore
+++ b/.gitignore
@@ -55,6 +55,7 @@ dkms.conf
 t_cose_test
 t_cose_basic_example_ossl
 t_cose_basic_example_psa
+t_cose_basic_example_mbedtls
 
 # CMake build folder
 build/

--- a/.gitignore
+++ b/.gitignore
@@ -54,6 +54,7 @@ dkms.conf
 # Compiled binaries
 t_cose_test
 t_cose_basic_example_ossl
+t_cose_basic_example_psa
 
 # CMake build folder
 build/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -89,9 +89,13 @@ if (BUILD_EXAMPLES)
     if (CRYPTO_PROVIDER STREQUAL "MbedTLS")
         add_executable(t_cose_basic_example_psa examples/t_cose_basic_example_psa.c)
         target_link_libraries(t_cose_basic_example_psa PRIVATE t_cose ${CRYPTO_LIBRARY})
+        # Crypto defs are needed because the tests include headers from src/
+        target_compile_definitions(t_cose_basic_example_psa PRIVATE ${CRYPTO_COMPILE_DEFS})
     elseif (CRYPTO_PROVIDER STREQUAL "OpenSSL")
         add_executable(t_cose_basic_example_ossl examples/t_cose_basic_example_ossl.c)
         target_link_libraries(t_cose_basic_example_ossl PRIVATE t_cose ${CRYPTO_LIBRARY})
+        # Crypto defs are needed because the tests include headers from src/
+        target_compile_definitions(t_cose_basic_example_ossl PRIVATE ${CRYPTO_COMPILE_DEFS})
     endif()
 
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ project(t_cose
     VERSION 1.0.1)
 
 # Constants
-set(CRYPTO_PROVIDERS "OpenSSL" "MbedTLS" "Test")
+set(CRYPTO_PROVIDERS "OpenSSL" "MbedTLS_PSA" "MbedTLS_Mbedtls" "Test")
 
 # Project options
 set(CRYPTO_PROVIDER "OpenSSL" CACHE STRING "The crypto provider to use: ${CRYPTO_PROVIDERS}")
@@ -31,12 +31,19 @@ endif()
 
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 
-if(CRYPTO_PROVIDER STREQUAL "MbedTLS")
+if(CRYPTO_PROVIDER STREQUAL "MbedTLS_PSA")
 
     find_package(MbedTLS REQUIRED)
     set(CRYPTO_LIBRARY MbedTLS::MbedCrypto)
     set(CRYPTO_COMPILE_DEFS -DT_COSE_USE_PSA_CRYPTO=1)
     set(CRYPTO_ADAPTER_SRC crypto_adapters/t_cose_psa_crypto.c)
+
+elseif(CRYPTO_PROVIDER STREQUAL "MbedTLS_Mbedtls")
+
+    find_package(MbedTLS REQUIRED)
+    set(CRYPTO_LIBRARY MbedTLS::MbedCrypto)
+    set(CRYPTO_COMPILE_DEFS  -DT_COSE_USE_MBEDTLS_CRYPTO=1)
+    set(CRYPTO_ADAPTER_SRC crypto_adapters/t_cose_mbedtls_crypto.c)
 
 elseif(CRYPTO_PROVIDER STREQUAL "OpenSSL")
 
@@ -86,11 +93,16 @@ install(DIRECTORY inc/ DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 
 if (BUILD_EXAMPLES)
 
-    if (CRYPTO_PROVIDER STREQUAL "MbedTLS")
+    if (CRYPTO_PROVIDER STREQUAL "MbedTLS_PSA")
         add_executable(t_cose_basic_example_psa examples/t_cose_basic_example_psa.c)
         target_link_libraries(t_cose_basic_example_psa PRIVATE t_cose ${CRYPTO_LIBRARY})
         # Crypto defs are needed because the tests include headers from src/
         target_compile_definitions(t_cose_basic_example_psa PRIVATE ${CRYPTO_COMPILE_DEFS})
+    elseif (CRYPTO_PROVIDER STREQUAL "MbedTLS_Mbedtls")
+        add_executable(t_cose_basic_example_mbedtls examples/t_cose_basic_example_mbedtls.c)
+        target_link_libraries(t_cose_basic_example_mbedtls PRIVATE t_cose ${CRYPTO_LIBRARY})
+        # Crypto defs are needed because the tests include headers from src/
+        target_compile_definitions(t_cose_basic_example_mbedtls PRIVATE ${CRYPTO_COMPILE_DEFS})
     elseif (CRYPTO_PROVIDER STREQUAL "OpenSSL")
         add_executable(t_cose_basic_example_ossl examples/t_cose_basic_example_ossl.c)
         target_link_libraries(t_cose_basic_example_ossl PRIVATE t_cose ${CRYPTO_LIBRARY})
@@ -115,8 +127,11 @@ if (BUILD_TESTS)
         list(APPEND TEST_SRC_COMMON test/t_cose_sign_verify_test.c)
     endif()
 
-    if (CRYPTO_PROVIDER STREQUAL "MbedTLS")
+    if (CRYPTO_PROVIDER STREQUAL "MbedTLS_PSA")
         set(TEST_SRC_EXTRA test/t_cose_make_psa_test_key.c)
+        set(TEST_EXTRA_DEFS)
+    elseif (CRYPTO_PROVIDER STREQUAL "MbedTLS_Mbedtls")
+        set(TEST_SRC_EXTRA test/t_cose_make_mbedtls_test_key.c)
         set(TEST_EXTRA_DEFS)
     elseif(CRYPTO_PROVIDER STREQUAL "OpenSSL")
         set(TEST_SRC_EXTRA test/t_cose_make_openssl_test_key.c)

--- a/Makefile.mbedtls
+++ b/Makefile.mbedtls
@@ -1,0 +1,144 @@
+# Makefile -- UNIX-style make for t_cose using crypto with Mbed TLS
+# Mbed TLS uses the Mbed TLS crypto interface (and not PSA Crypto)
+#
+# Copyright (c) 2019-2021, Laurence Lundblade. All rights reserved.
+# Copyright (c) 2020, Michael Eckel, Fraunhofer SIT.
+# Copyright (c) 2022, Arm Limited. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+# See BSD-3-Clause license in README.md
+#
+
+# ---- comment ----
+# This is for Mbed TLS. See longer explanation in README.md
+# Adjust CRYPTO_INC and CRYPTO_LIB for the
+# location of the Mbed TLS libraries on your build machine.
+
+
+# ---- QCBOR location ----
+
+# This is for direct reference to QCBOR that is not installed in
+# /usr/local or some system location. The path may need to be
+# adjusted for your location of QCBOR.
+#QCBOR_DIR=../../QCBOR/master
+#QCBOR_INC=-I $(QCBOR_DIR)/inc
+#QCBOR_LIB=$(QCBOR_DIR)/libqcbor.a
+
+# This is for reference to QCBOR that has been installed in
+# /usr/local/ or in some system location. This will typically
+# use dynamic linking if there is a libqcbor.so
+QCBOR_INC=-I /usr/local/include
+QCBOR_LIB=-lqcbor
+
+
+# ---- crypto configuration -----
+
+# These two are for direct reference to Mbed TLS that is not installed
+# in /usr/local/ /usr/local or some system location. The path names
+# may need to be adjusted for your location of MBed TLS
+#CRYPTO_INC=-I ../../mbedtls/include/
+#CRYPTO_LIB=../../mbedtls/library/libmbedcrypto.a
+
+# These two are for reference to Mbed TLS that has been installed in
+# /usr/local/ or in some system location.
+CRYPTO_LIB=-l mbedcrypto
+CRYPTO_INC=-I /usr/local/include
+
+CRYPTO_CONFIG_OPTS=-DT_COSE_USE_MBEDTLS_CRYPTO
+CRYPTO_OBJ=crypto_adapters/t_cose_mbedtls_crypto.o
+CRYPTO_TEST_OBJ=test/t_cose_make_mbedtls_test_key.o
+
+
+# ---- compiler configuration -----
+# Optimize for size
+C_OPTS=-Os -fPIC
+
+
+# ---- T_COSE Config and test options ----
+TEST_CONFIG_OPTS=
+TEST_OBJ=test/t_cose_test.o test/run_tests.o test/t_cose_sign_verify_test.o test/t_cose_make_test_messages.o $(CRYPTO_TEST_OBJ)
+
+
+# ---- the main body that is invariant ----
+INC=-I inc -I test -I src
+ALL_INC=$(INC) $(CRYPTO_INC) $(QCBOR_INC)
+CFLAGS=$(CMD_LINE) $(ALL_INC) $(C_OPTS) $(TEST_CONFIG_OPTS) $(CRYPTO_CONFIG_OPTS)
+
+SRC_OBJ=src/t_cose_sign1_verify.o src/t_cose_sign1_sign.o src/t_cose_util.o src/t_cose_parameters.o
+
+.PHONY: all install install_headers install_so uninstall clean
+
+all: libt_cose.a t_cose_test t_cose_basic_example_mbedtls
+
+libt_cose.a: $(SRC_OBJ) $(CRYPTO_OBJ)
+	ar -r $@ $^
+
+# The shared library is not made by default because of platform
+# variability For example MacOS and Linux behave differently and some
+# IoT OS's don't support them at all.
+libt_cose.so: $(SRC_OBJ) $(CRYPTO_OBJ)
+	cc -shared $^ -o $@ $(CRYPTO_LIB) $(QCBOR_LIB)
+
+t_cose_test: main.o $(TEST_OBJ) libt_cose.a
+	cc -o $@ $^ $(QCBOR_LIB) $(CRYPTO_LIB)
+
+
+t_cose_basic_example_mbedtls: examples/t_cose_basic_example_mbedtls.o libt_cose.a
+	cc -o $@ $^ $(QCBOR_LIB) $(CRYPTO_LIB)
+
+
+# ---- Installation ----
+ifeq ($(PREFIX),)
+    PREFIX := /usr/local
+endif
+
+install: libt_cose.a install_headers
+	install -d $(DESTDIR)$(PREFIX)/lib/
+	install -m 644 libt_cose.a $(DESTDIR)$(PREFIX)/lib/
+
+install_headers: $(PUBLIC_INTERFACE)
+	install -d $(DESTDIR)$(PREFIX)/include/t_cose
+	install -m 644 inc/t_cose/t_cose_common.h $(DESTDIR)$(PREFIX)/include/t_cose
+	install -m 644 inc/t_cose/q_useful_buf.h $(DESTDIR)$(PREFIX)/include/t_cose
+	install -m 644 inc/t_cose/t_cose_sign1_sign.h $(DESTDIR)$(PREFIX)/include/t_cose
+	install -m 644 inc/t_cose/t_cose_sign1_verify.h $(DESTDIR)$(PREFIX)/include/t_cose
+
+# The shared library is not installed by default because of platform variability.
+install_so: libt_cose.so install_headers
+	install -m 755 libt_cose.so $(DESTDIR)$(PREFIX)/lib/libt_cose.so.1.0.0
+	ln -sf libt_cose.so.1 $(DESTDIR)$(PREFIX)/lib/libt_cose.so
+	ln -sf libt_cose.so.1.0.0 $(DESTDIR)$(PREFIX)/lib/libt_cose.so.1
+
+uninstall: libt_cose.a $(PUBLIC_INTERFACE)
+	$(RM) -d $(DESTDIR)$(PREFIX)/include/t_cose/*
+	$(RM) -d $(DESTDIR)$(PREFIX)/include/t_cose/
+	$(RM) $(addprefix $(DESTDIR)$(PREFIX)/lib/, \
+		libt_cose.a libt_cose.so libt_cose.so.1 libt_cose.so.1.0.0)
+
+clean:
+	rm -f $(SRC_OBJ) $(TEST_OBJ) $(CRYPTO_OBJ) t_cose_basic_example_mbedtls t_cose_test libt_cose.a libt_cose.so examples/*.o main.o
+
+
+# ---- public headers -----
+PUBLIC_INTERFACE=inc/t_cose/t_cose_common.h inc/t_cose/t_cose_sign1_sign.h inc/t_cose/t_cose_sign1_verify.h
+
+# ---- source dependecies -----
+src/t_cose_util.o: src/t_cose_util.h src/t_cose_standard_constants.h inc/t_cose/t_cose_common.h src/t_cose_crypto.h
+src/t_cose_sign1_verify.o: inc/t_cose/t_cose_sign1_verify.h src/t_cose_crypto.h src/t_cose_util.h src/t_cose_parameters.h inc/t_cose/t_cose_common.h src/t_cose_standard_constants.h
+src/t_cose_parameters.o: src/t_cose_parameters.h src/t_cose_standard_constants.h inc/t_cose/t_cose_sign1_verify.h inc/t_cose/t_cose_common.h
+src/t_cose_sign1_sign.o: inc/t_cose/t_cose_sign1_sign.h src/t_cose_standard_constants.h src/t_cose_crypto.h src/t_cose_util.h inc/t_cose/t_cose_common.h
+
+
+# ---- test dependencies -----
+test/t_cose_test.o: test/t_cose_test.h test/t_cose_make_test_messages.h src/t_cose_crypto.h $(PUBLIC_INTERFACE)
+test/t_cose_sign_verify_test.o: test/t_cose_sign_verify_test.h test/t_cose_make_test_messages.h src/t_cose_crypto.h test/t_cose_make_test_pub_key.h $(PUBLIC_INTERFACE)
+test/t_cose_make_test_messages.o: test/t_cose_make_test_messages.h inc/t_cose/t_cose_sign1_sign.h inc/t_cose/t_cose_common.h src/t_cose_standard_constants.h src/t_cose_crypto.h src/t_cose_util.h
+test/run_test.o: test/run_test.h test/t_cose_test.h test/t_cose_hash_fail_test.h
+test/t_cose_make_mbedtls_test_key.o: test/t_cose_make_test_pub_key.h src/t_cose_standard_constants.h inc/t_cose/t_cose_common.h
+
+# ---- crypto dependencies ----
+crypto_adapters/t_cose_mbedtls_crypto.o: src/t_cose_crypto.h inc/t_cose/t_cose_common.h src/t_cose_standard_constants.h inc/t_cose/q_useful_buf.h
+
+# ---- example dependencies ----
+examples/t_cose_basic_example_mbedtls.o: $(PUBLIC_INTERFACE)

--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ compiler options need to be set for it to run correctly.
 **Crypto Library Integration Layer** – Works with different cryptographic
 libraries via a simple integration layer. The integration layer is kept small and simple, 
 just enough for the use cases, so that integration is simpler. Integration layers for 
-the OpenSSL and ARM Mbed TLS (PSA Cryptography API) cryptographic libraries 
-are included.
+the OpenSSL and ARM Mbed TLS (PSA Cryptography API and Mbed TLS Cryptography API)
+cryptographic libraries are included.
 
 **Secure coding style** – Uses a construct called UsefulBuf / q_useful_buf as a
 discipline for safe coding and handling of binary data.
@@ -168,6 +168,39 @@ Mbed TLS, an implementation of the PSA crypto API.
 Confidence in the adaptor code is high and reasonably well tested
 because it is simple.
 
+
+### Mbed TLS -- Makefile.mbedtls
+
+This build configuration works for the Mbed TLS Library.
+
+This integration supports SHA-256, SHA-384 and SHA-512 with ECDSA to support
+the COSE algorithms ES256, ES384 and ES512. It is a full implementation but
+needs on-target testing.
+
+To use this, edit the makefile for the location of CBOR and your
+Mbed TLS cryptographic library and do:
+
+    make -f Makefile.mbedtls
+
+The specific things that Makefile.mbedtls does is:
+    * Links the crypto_adapters/t_cose_mbedtls_crypto.o into libt_cose.a
+    * Links test/test/t_cose_make_mbedtls_test_key.o into the test binary
+    * `#define T_COSE_USE_MBEDTLS_CRYPTO`
+
+Note that the internally supplied b_con_hash is not used in this case
+by virtue of the Makefile not linking to it.
+
+Following are some notes on things discovered doing this integration.
+
+The Mbed TLS API is implemented by [Mbed TLS](https://github.com/ARMmbed/mbedtls).
+
+The project [Mbed Crypto](https://github.com/ARMmbed/mbed-crypto) used to have
+similar interface compared to Mbed TLS, but it is not the case anymore, as Mbed
+Crypto is not updating anymore, and the interface of Mbed TLS has evolved. As a
+result t_cose cannot be used with Mbed Crypto.
+
+This implementation supports the Mbed TLS library, and is tested with the version
+v3.1.0.
 
 ### General Crypto Library Strategy
 

--- a/README.md
+++ b/README.md
@@ -202,6 +202,24 @@ result t_cose cannot be used with Mbed Crypto.
 This implementation supports the Mbed TLS library, and is tested with the version
 v3.1.0.
 
+This implementation supports the restartable signing API behaviour. The
+existence of the restartable API in Mbed TLS is controlled by the define
+`MBEDTLS_ECP_RESTARTABLE`. t_cose uses the same define to decide whether it can
+call the restartable sign API in the crypto library. If
+`MBEDTLS_ECP_RESTARTABLE` is not defined for t_cose then the restartable APIs
+return `T_COSE_ERR_SIGN_RESTART_NOT_SUPPORTED`.
+
+Note that it is the responsibility of the caller of the t_cose library to set
+the maximum number of operations that can be executed by the Mbed TLS library in
+a single iteration. This can be done with the following call:
+
+```
+#ifdef MBEDTLS_ECP_RESTARTABLE
+        /* Set the number of max operations per iteration */
+        mbedtls_ecp_set_max_ops(682); /* include/mbedtls/ecp.h:446 */
+#endif
+```
+
 ### General Crypto Library Strategy
 
 The functions that t_cose needs from the crypto library are all

--- a/crypto_adapters/t_cose_mbedtls_crypto.c
+++ b/crypto_adapters/t_cose_mbedtls_crypto.c
@@ -1,0 +1,477 @@
+/*
+ * t_cose_mbedtls_crypto.c
+ *
+ * Copyright 2019, Laurence Lundblade
+ * Copyright (c) 2022, Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * See BSD-3-Clause license in README.md
+ */
+
+/**
+ * \file t_cose_mbedtls_crypto.c
+ *
+ * \brief Crypto Adaptation for t_cose to use Mbed TLS's ECDSA and hashes.
+ *
+ * This connects up the abstract interface in t_cose_crypto.h to the
+ * implementations of ECDSA signing and hashing in Mbed TLS library.
+ *
+ * This adapter layer doesn't bloat the implementation as everything
+ * here had to be done anyway -- the mapping of algorithm IDs, the
+ * data format rearranging, the error code translation.
+ *
+ * This code should just work out of the box if compiled and linked
+ * against Mbed TLS. No preprocessor #defines are needed.
+ *
+ * You can disable SHA-384 and SHA-512 to save code and space by
+ * defining T_COSE_DISABLE_ES384 or T_COSE_DISABLE_ES512. This saving
+ * is most in stack space in the main t_cose implementation. (It seems
+ * likely that changes to Mbed TLS itself would be needed to remove the
+ * SHA-384 and SHA-512 implementations to save that code. Lack of
+ * reference and dead stripping the executable won't do it).
+ */
+
+#include "t_cose_crypto.h"  /* The interface this implements */
+
+#include "mbedtls/md.h"
+#include "mbedtls/sha512.h"
+#include "mbedtls/sha256.h"
+#include "mbedtls/asn1.h"
+#include "mbedtls/ecdsa.h"
+#include <mbedtls/entropy.h>
+#include <mbedtls/hmac_drbg.h>
+
+
+/* Avoid compiler warning due to unused argument */
+#define ARG_UNUSED(arg) (void)(arg)
+
+
+/**
+ * \brief Returns whether the COSE signing algorithm ID is an ECDSA algorithm.
+ *
+ * If the algorithm is not ECDSA, the out parameters are not set.
+ *
+ * \param[in]  cose_algorithm_id  The COSE algorithm ID.
+ * \param[out] md_alg             The hash algorithm ID for this signing alg.
+ *
+ * \return 1 if the algorithm is ECDSA, 0 otherwise.
+ */
+static int is_ecdsa_algorithm(int32_t cose_algorithm_id, int *md_alg)
+{
+    switch (cose_algorithm_id) {
+    case COSE_ALGORITHM_ES256:
+        *md_alg = MBEDTLS_MD_SHA256;
+        return 1;
+    case COSE_ALGORITHM_ES384:
+        *md_alg = MBEDTLS_MD_SHA384;
+        return 1;
+    case COSE_ALGORITHM_ES512:
+        *md_alg = MBEDTLS_MD_SHA512;
+        return 1;
+    default:
+        return 0;
+    }
+}
+
+
+static enum t_cose_err_t mbedtls_err_to_t_cose_error_signing(int err)
+{
+    return
+      err == 0                                ? T_COSE_SUCCESS :
+      err == MBEDTLS_ERR_ECP_BAD_INPUT_DATA   ? T_COSE_ERR_INVALID_ARGUMENT :
+      err == MBEDTLS_ERR_ECP_BUFFER_TOO_SMALL ? T_COSE_ERR_SIG_BUFFER_SIZE :
+      err == MBEDTLS_ERR_ECP_VERIFY_FAILED    ? T_COSE_ERR_SIG_VERIFY :
+      err == MBEDTLS_ERR_ECP_ALLOC_FAILED     ? T_COSE_ERR_INSUFFICIENT_MEMORY :
+      err == MBEDTLS_ERR_MPI_BAD_INPUT_DATA   ? T_COSE_ERR_INVALID_ARGUMENT :
+      err == MBEDTLS_ERR_MPI_ALLOC_FAILED     ? T_COSE_ERR_INSUFFICIENT_MEMORY :
+      err == MBEDTLS_ERR_ASN1_ALLOC_FAILED    ? T_COSE_ERR_INSUFFICIENT_MEMORY :
+                                                T_COSE_ERR_SIG_FAIL;
+}
+
+
+/*
+ * See documentation in t_cose_crypto.h
+ */
+enum t_cose_err_t
+t_cose_crypto_verify(int32_t               cose_algorithm_id,
+                     struct t_cose_key     verification_key,
+                     struct q_useful_buf_c kid,
+                     struct q_useful_buf_c hash_to_verify,
+                     struct q_useful_buf_c signature)
+{
+    int md_alg;
+    int ret;
+    enum t_cose_err_t return_value = T_COSE_ERR_SIG_VERIFY;
+    mbedtls_ecp_keypair *ecp_keypair =
+        (mbedtls_ecp_keypair *)verification_key.k.key_ptr;
+    mbedtls_mpi r, s;
+    size_t curve_bytes = (ecp_keypair->MBEDTLS_PRIVATE(grp).pbits + 7) / 8;
+
+    /* This implementation does no look up keys by kid in the key
+     * store
+     */
+    ARG_UNUSED(kid);
+
+    /* This implementation supports ECDSA and only ECDSA. The
+     * interface allows it to support other, but none are implemented.
+     * This implementation works for different keys lengths and
+     * curves. That is the curve and key length as associated with the
+     * signing_key passed in, not the cose_algorithm_id. This check
+     * looks for ECDSA signing as indicated by COSE and rejects what
+     * is not.
+     */
+    if (!is_ecdsa_algorithm(cose_algorithm_id, &md_alg)) {
+        return_value = T_COSE_ERR_UNSUPPORTED_SIGNING_ALG;
+        goto Done;
+    }
+
+    mbedtls_mpi_init(&r);
+    mbedtls_mpi_init(&s);
+
+    if (signature.len != 2 * curve_bytes) {
+        return_value = T_COSE_ERR_INVALID_ARGUMENT;
+        goto cleanup;
+    }
+
+    ret = mbedtls_mpi_read_binary(&r,
+                                  signature.ptr,
+                                  curve_bytes);
+    if (ret) {
+        return_value = mbedtls_err_to_t_cose_error_signing(ret);
+        goto cleanup;
+    }
+    ret = mbedtls_mpi_read_binary(&s,
+                                 (unsigned char *)(signature.ptr) + curve_bytes,
+                                 curve_bytes);
+    if (ret) {
+        return_value = mbedtls_err_to_t_cose_error_signing(ret);
+        goto cleanup;
+    }
+
+    /* Check whether the public part is loaded. If not, load it. */
+    if (mbedtls_ecp_is_zero(&ecp_keypair->MBEDTLS_PRIVATE(Q))) {
+        return_value = T_COSE_ERR_WRONG_TYPE_OF_KEY;
+        goto cleanup;
+    }
+
+    ret = mbedtls_ecdsa_verify(&ecp_keypair->MBEDTLS_PRIVATE(grp),
+                               hash_to_verify.ptr,
+                               hash_to_verify.len,
+                               &ecp_keypair->MBEDTLS_PRIVATE(Q), &r, &s);
+    if (ret) {
+        return_value = mbedtls_err_to_t_cose_error_signing(ret);
+        goto cleanup;
+    }
+
+    return_value = T_COSE_SUCCESS;
+
+cleanup:
+    mbedtls_mpi_free(&r);
+    mbedtls_mpi_free(&s);
+
+Done:
+    return return_value;
+}
+
+
+/*
+ * See documentation in t_cose_crypto.h
+ */
+enum t_cose_err_t
+t_cose_crypto_sign(int32_t                           cose_algorithm_id,
+                   struct t_cose_key                 signing_key,
+                   struct q_useful_buf_c             hash_to_sign,
+                   struct q_useful_buf               signature_buffer,
+                   struct q_useful_buf_c            *signature,
+                   struct t_cose_crypto_backend_ctx *crypto_ctx)
+{
+    enum t_cose_err_t return_value = T_COSE_ERR_FAIL;
+
+    mbedtls_ecp_keypair *ecp_keypair =
+        (mbedtls_ecp_keypair *)signing_key.k.key_ptr;
+    mbedtls_ecdsa_context ecdsa_context;
+    Q_USEFUL_BUF_MAKE_STACK_UB(asn1_signature, MBEDTLS_ECDSA_MAX_LEN);
+    size_t required_sign_buf_size;
+    int md_alg;
+    unsigned char *p = asn1_signature.ptr;
+    unsigned char *end;
+    int ret;
+    size_t len;
+    const mbedtls_md_info_t *md_info;
+    mbedtls_entropy_context entropy_ctx;
+    mbedtls_hmac_drbg_context drbg_ctx;
+
+    mbedtls_mpi r, s;
+
+    size_t curve_bytes = (ecp_keypair->MBEDTLS_PRIVATE(grp).pbits + 7) / 8;
+
+    /* This implementation supports ECDSA and only ECDSA. The
+     * interface allows it to support other, but none are implemented.
+     * This implementation works for different keys lengths and
+     * curves. That is the curve and key length as associated with the
+     * signing_key passed in, not the cose_algorithm_id. This check
+     * looks for ECDSA signing as indicated by COSE and rejects what
+     * is not.
+     */
+    if (!is_ecdsa_algorithm(cose_algorithm_id, &md_alg)) {
+        return_value = T_COSE_ERR_UNSUPPORTED_SIGNING_ALG;
+        goto Done;
+    }
+
+    if (t_cose_crypto_sig_size(cose_algorithm_id,
+                                signing_key,
+                                &required_sign_buf_size)) {
+        return_value = T_COSE_ERR_UNSUPPORTED_SIGNING_ALG;
+        goto Done;
+    }
+
+    if (signature_buffer.len < required_sign_buf_size) {
+        return_value = T_COSE_ERR_SIG_BUFFER_SIZE;
+        goto Done;
+    }
+
+    /* Initialize a local PRNG context */
+    mbedtls_entropy_init(&entropy_ctx);
+    md_info = mbedtls_md_info_from_type(MBEDTLS_MD_SHA256);
+    mbedtls_hmac_drbg_init(&drbg_ctx);
+    ret = mbedtls_hmac_drbg_seed(&drbg_ctx,
+                                md_info,
+                                mbedtls_entropy_func,
+                                &entropy_ctx,
+                                NULL, 0);
+    if (ret != 0) {
+        return_value = mbedtls_err_to_t_cose_error_signing(ret);
+        goto Done;
+    }
+
+    /* Do the signing */
+    mbedtls_ecdsa_init(&ecdsa_context);
+    ret = mbedtls_ecdsa_from_keypair(&ecdsa_context, ecp_keypair);
+    if (ret != 0) {
+        return_value = mbedtls_err_to_t_cose_error_signing(ret);
+        goto Done;
+    }
+
+    ret = mbedtls_ecdsa_write_signature(&ecdsa_context,
+        md_alg,
+        hash_to_sign.ptr,
+        hash_to_sign.len,
+        asn1_signature.ptr,
+        asn1_signature.len,
+        &asn1_signature.len,
+        mbedtls_hmac_drbg_random,
+        &drbg_ctx);
+
+    if (ret != 0) {
+        return_value = mbedtls_err_to_t_cose_error_signing(ret);
+        goto Done;
+    }
+
+    /* Extract r and s from ASN1 format */
+    end = p + asn1_signature.len;
+    ret = mbedtls_asn1_get_tag(&p, end, &len,
+                    MBEDTLS_ASN1_CONSTRUCTED | MBEDTLS_ASN1_SEQUENCE);
+    if (ret != 0) {
+        return_value = T_COSE_ERR_UNSUPPORTED_SIGNING_ALG;
+        goto Done;
+    }
+
+    if (p + len != end) {
+        return_value = T_COSE_ERR_UNSUPPORTED_SIGNING_ALG;
+        goto Done;
+    }
+
+    mbedtls_mpi_init(&r);
+    mbedtls_mpi_init(&s);
+    if ((ret = mbedtls_asn1_get_mpi(&p, end, &r)) != 0 ||
+        (ret = mbedtls_asn1_get_mpi(&p, end, &s)) != 0) {
+        return_value = T_COSE_ERR_UNSUPPORTED_SIGNING_ALG;
+        mbedtls_mpi_free(&r);
+        mbedtls_mpi_free(&s);
+        goto Done;
+    }
+
+    mbedtls_mpi_write_binary(&r, signature_buffer.ptr, curve_bytes);
+    mbedtls_mpi_write_binary(&s, (unsigned char *)signature_buffer.ptr +
+                                 curve_bytes, curve_bytes);
+
+    mbedtls_mpi_free(&r);
+    mbedtls_mpi_free(&s);
+
+    (void)mbedtls_ecdsa_free(&ecdsa_context);
+
+    return_value = T_COSE_SUCCESS;
+
+Done:
+    mbedtls_hmac_drbg_free(&drbg_ctx);
+
+    signature->ptr = signature_buffer.ptr;
+    signature->len = curve_bytes * 2;
+
+    return return_value;
+}
+
+
+
+/*
+ * See documentation in t_cose_crypto.h
+ */
+enum t_cose_err_t t_cose_crypto_sig_size(int32_t           cose_algorithm_id,
+                                         struct t_cose_key signing_key,
+                                         size_t           *sig_size)
+{
+    if (!t_cose_algorithm_is_ecdsa(cose_algorithm_id)) {
+        return T_COSE_ERR_UNSUPPORTED_SIGNING_ALG;
+    }
+
+    mbedtls_ecp_keypair *ecp_keypair = signing_key.k.key_ptr;
+    size_t curve_bytes = (ecp_keypair->MBEDTLS_PRIVATE(grp).pbits + 7) / 8;
+    *sig_size = curve_bytes * 2;
+    return T_COSE_SUCCESS;
+}
+
+
+/**
+ * \brief Map a Mbed TLS error into a t_cose error for hashes.
+ *
+ * \param[in] error   The Mbed TLS error.
+ *
+ * \return The \ref t_cose_err_t.
+ */
+static enum t_cose_err_t
+mbedtls_status_to_t_cose_error_hash(int error)
+{
+    /* Intentionally limited to just this minimum set of errors to
+     * save object code as hashes don't really fail much
+     */
+    return error == 0                                 ? T_COSE_SUCCESS :
+           error == MBEDTLS_ERR_SHA256_BAD_INPUT_DATA ? T_COSE_ERR_INVALID_ARGUMENT :
+                    /* MbedTLS doesn't have an error code for the following
+                     * cases, so we use the t_cose error codes instead. As the
+                     * MbedTLS error codes are negative, there shouldn't be a
+                     * match.
+                     */
+           error == T_COSE_ERR_UNSUPPORTED_HASH       ? T_COSE_ERR_UNSUPPORTED_HASH :
+           error == T_COSE_ERR_INVALID_ARGUMENT       ? T_COSE_ERR_INVALID_ARGUMENT :
+                                                        T_COSE_ERR_HASH_GENERAL_FAIL;
+}
+
+
+/*
+ * See documentation in t_cose_crypto.h
+ */
+enum t_cose_err_t t_cose_crypto_hash_start(struct t_cose_crypto_hash *hash_ctx,
+                                           int32_t cose_hash_alg_id)
+{
+    int is384 = 0;
+
+    /* Map the algorithm ID */
+    switch (cose_hash_alg_id) {
+    case COSE_ALGORITHM_SHA_256:
+        mbedtls_sha256_init(&(hash_ctx->sha256_ctx));
+        hash_ctx->status = mbedtls_sha256_starts(
+            &(hash_ctx->sha256_ctx), 0);
+        break;
+    case COSE_ALGORITHM_SHA_384:
+        is384 = 1;
+        /* Fallthrough! */
+    case COSE_ALGORITHM_SHA_512:
+        mbedtls_sha512_init(&(hash_ctx->sha512_ctx));
+        hash_ctx->status = mbedtls_sha512_starts(
+            &(hash_ctx->sha512_ctx), is384);
+        break;
+    default:
+        hash_ctx->status = T_COSE_ERR_UNSUPPORTED_HASH;
+        goto Done;
+    }
+
+    hash_ctx->cose_hash_alg_id = cose_hash_alg_id;
+
+Done:
+    /* Map errors and return */
+    return mbedtls_status_to_t_cose_error_hash(hash_ctx->status);
+}
+
+
+/*
+ * See documentation in t_cose_crypto.h
+ */
+void t_cose_crypto_hash_update(struct t_cose_crypto_hash *hash_ctx,
+                               struct q_useful_buf_c      data_to_hash)
+{
+    if (hash_ctx->status) {
+        /* In error state. Nothing to do. */
+        return;
+    }
+
+    if (data_to_hash.ptr == NULL) {
+        /* This allows for NULL buffers to be passed in all the way at
+         * the top of signer or message creator when all that is
+         * happening is the size of the result is being computed.
+         */
+        return;
+    }
+
+    /* Actually hash the data */
+    if (hash_ctx->cose_hash_alg_id == COSE_ALGORITHM_SHA_256) {
+        hash_ctx->status = mbedtls_sha256_update(&(hash_ctx->sha256_ctx),
+            data_to_hash.ptr, data_to_hash.len);
+    } else {
+        hash_ctx->status = mbedtls_sha512_update(&(hash_ctx->sha512_ctx),
+            data_to_hash.ptr, data_to_hash.len);
+    }
+}
+
+
+/*
+ * See documentation in t_cose_crypto.h
+ */
+enum t_cose_err_t
+t_cose_crypto_hash_finish(struct t_cose_crypto_hash *hash_ctx,
+                          struct q_useful_buf        buffer_to_hold_result,
+                          struct q_useful_buf_c     *hash_result)
+{
+    if (hash_ctx->status) {
+        /* Error state. Nothing to do */
+        goto Done;
+    }
+
+    /* Actually finish up the hash */
+    if (hash_ctx->cose_hash_alg_id == COSE_ALGORITHM_SHA_256) {
+        if (buffer_to_hold_result.len < T_COSE_CRYPTO_SHA256_SIZE) {
+            hash_ctx->status = T_COSE_ERR_INVALID_ARGUMENT;
+            goto Done;
+        }
+        hash_result->len = T_COSE_CRYPTO_SHA256_SIZE;
+        hash_ctx->status = mbedtls_sha256_finish(&(hash_ctx->sha256_ctx),
+            buffer_to_hold_result.ptr);
+    } else {
+        if (hash_ctx->cose_hash_alg_id == COSE_ALGORITHM_SHA_384) {
+            if (buffer_to_hold_result.len < T_COSE_CRYPTO_SHA384_SIZE) {
+                hash_ctx->status = T_COSE_ERR_INVALID_ARGUMENT;
+                goto Done;
+            }
+            hash_result->len = T_COSE_CRYPTO_SHA384_SIZE;
+        } else {
+            if (buffer_to_hold_result.len < T_COSE_CRYPTO_SHA512_SIZE) {
+                hash_ctx->status = T_COSE_ERR_INVALID_ARGUMENT;
+                goto Done;
+            }
+            hash_result->len = T_COSE_CRYPTO_SHA512_SIZE;
+        }
+        hash_ctx->status = mbedtls_sha512_finish(&(hash_ctx->sha512_ctx),
+            buffer_to_hold_result.ptr);
+    }
+
+    hash_result->ptr = buffer_to_hold_result.ptr;
+
+Done:
+    if (hash_ctx->cose_hash_alg_id == COSE_ALGORITHM_SHA_256) {
+        mbedtls_sha256_free(&(hash_ctx->sha256_ctx));
+    } else {
+        mbedtls_sha512_free(&(hash_ctx->sha512_ctx));
+    }
+
+    return mbedtls_status_to_t_cose_error_hash(hash_ctx->status);
+}

--- a/crypto_adapters/t_cose_mbedtls_crypto.c
+++ b/crypto_adapters/t_cose_mbedtls_crypto.c
@@ -184,7 +184,8 @@ t_cose_crypto_sign(int32_t                           cose_algorithm_id,
                    struct q_useful_buf_c             hash_to_sign,
                    struct q_useful_buf               signature_buffer,
                    struct q_useful_buf_c            *signature,
-                   struct t_cose_crypto_backend_ctx *crypto_ctx)
+                   struct t_cose_crypto_backend_ctx *crypto_ctx,
+                   bool                             *started)
 {
     enum t_cose_err_t return_value = T_COSE_ERR_FAIL;
 
@@ -203,6 +204,10 @@ t_cose_crypto_sign(int32_t                           cose_algorithm_id,
     mbedtls_hmac_drbg_context drbg_ctx;
 
     mbedtls_mpi r, s;
+
+    if (started) {
+        return T_COSE_ERR_SIGN_RESTART_NOT_SUPPORTED;
+    }
 
     size_t curve_bytes = (ecp_keypair->MBEDTLS_PRIVATE(grp).pbits + 7) / 8;
 

--- a/crypto_adapters/t_cose_openssl_crypto.c
+++ b/crypto_adapters/t_cose_openssl_crypto.c
@@ -2,6 +2,7 @@
  *  t_cose_openssl_crypto.c
  *
  * Copyright 2019-2022, Laurence Lundblade
+ * Copyright (c) 2022, Arm Limited. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *
@@ -346,11 +347,12 @@ Done:
  * See documentation in t_cose_crypto.h
  */
 enum t_cose_err_t
-t_cose_crypto_sign(const int32_t                cose_algorithm_id,
-                   const struct t_cose_key      signing_key,
-                   const struct q_useful_buf_c  hash_to_sign,
-                   const struct q_useful_buf    signature_buffer,
-                   struct q_useful_buf_c       *signature)
+t_cose_crypto_sign(const int32_t                     cose_algorithm_id,
+                   const struct t_cose_key           signing_key,
+                   const struct q_useful_buf_c       hash_to_sign,
+                   const struct q_useful_buf         signature_buffer,
+                   struct q_useful_buf_c            *signature,
+                   struct t_cose_crypto_backend_ctx *crypto_ctx)
 {
     /* This is the overhead for the DER encoding of an EC signature as
      * described by ECDSA-Sig-Value in RFC 3279.  It is at max 3 * (1
@@ -366,6 +368,7 @@ t_cose_crypto_sign(const int32_t                cose_algorithm_id,
     int                    ossl_result;
     unsigned               key_size_bytes;
     MakeUsefulBufOnStack(  der_format_signature, T_COSE_MAX_SIG_SIZE + DER_SIG_ENCODE_OVER_HEAD);
+    (void)crypto_ctx;
 
     /* This implementation supports only ECDSA so far. The
      * interface allows it to support other, but none are implemented.

--- a/crypto_adapters/t_cose_openssl_crypto.c
+++ b/crypto_adapters/t_cose_openssl_crypto.c
@@ -352,7 +352,8 @@ t_cose_crypto_sign(const int32_t                     cose_algorithm_id,
                    const struct q_useful_buf_c       hash_to_sign,
                    const struct q_useful_buf         signature_buffer,
                    struct q_useful_buf_c            *signature,
-                   struct t_cose_crypto_backend_ctx *crypto_ctx)
+                   struct t_cose_crypto_backend_ctx *crypto_ctx,
+                   bool                             *started)
 {
     /* This is the overhead for the DER encoding of an EC signature as
      * described by ECDSA-Sig-Value in RFC 3279.  It is at max 3 * (1
@@ -369,6 +370,10 @@ t_cose_crypto_sign(const int32_t                     cose_algorithm_id,
     unsigned               key_size_bytes;
     MakeUsefulBufOnStack(  der_format_signature, T_COSE_MAX_SIG_SIZE + DER_SIG_ENCODE_OVER_HEAD);
     (void)crypto_ctx;
+
+    if (started) {
+        return T_COSE_ERR_SIGN_RESTART_NOT_SUPPORTED;
+    }
 
     /* This implementation supports only ECDSA so far. The
      * interface allows it to support other, but none are implemented.

--- a/crypto_adapters/t_cose_psa_crypto.c
+++ b/crypto_adapters/t_cose_psa_crypto.c
@@ -2,6 +2,7 @@
  * t_cose_psa_crypto.c
  *
  * Copyright 2019-2022, Laurence Lundblade
+ * Copyright (c) 2022, Arm Limited. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *
@@ -147,13 +148,15 @@ t_cose_crypto_sign(int32_t                cose_algorithm_id,
                    struct t_cose_key      signing_key,
                    struct q_useful_buf_c  hash_to_sign,
                    struct q_useful_buf    signature_buffer,
-                   struct q_useful_buf_c *signature)
+                   struct q_useful_buf_c *signature,
+                   struct t_cose_crypto_backend_ctx *crypto_ctx)
 {
     enum t_cose_err_t     return_value;
     psa_status_t          psa_result;
     psa_algorithm_t       psa_alg_id;
     mbedtls_svc_key_id_t  signing_key_psa;
     size_t                signature_len;
+    (void)crypto_ctx;
 
     psa_alg_id = cose_alg_id_to_psa_alg_id(cose_algorithm_id);
 

--- a/crypto_adapters/t_cose_psa_crypto.c
+++ b/crypto_adapters/t_cose_psa_crypto.c
@@ -149,7 +149,8 @@ t_cose_crypto_sign(int32_t                cose_algorithm_id,
                    struct q_useful_buf_c  hash_to_sign,
                    struct q_useful_buf    signature_buffer,
                    struct q_useful_buf_c *signature,
-                   struct t_cose_crypto_backend_ctx *crypto_ctx)
+                   struct t_cose_crypto_backend_ctx *crypto_ctx,
+                   bool                  *started)
 {
     enum t_cose_err_t     return_value;
     psa_status_t          psa_result;
@@ -157,6 +158,10 @@ t_cose_crypto_sign(int32_t                cose_algorithm_id,
     mbedtls_svc_key_id_t  signing_key_psa;
     size_t                signature_len;
     (void)crypto_ctx;
+
+    if (started) {
+        return T_COSE_ERR_SIGN_RESTART_NOT_SUPPORTED;
+    }
 
     psa_alg_id = cose_alg_id_to_psa_alg_id(cose_algorithm_id);
 

--- a/crypto_adapters/t_cose_test_crypto.c
+++ b/crypto_adapters/t_cose_test_crypto.c
@@ -73,7 +73,8 @@ t_cose_crypto_sign(int32_t                cose_algorithm_id,
                    struct q_useful_buf_c  hash_to_sign,
                    struct q_useful_buf    signature_buffer,
                    struct q_useful_buf_c *signature,
-                   struct t_cose_crypto_backend_ctx *crypto_ctx)
+                   struct t_cose_crypto_backend_ctx *crypto_ctx,
+                   bool                  *started)
 {
     (void)cose_algorithm_id;
     (void)signing_key;
@@ -81,6 +82,11 @@ t_cose_crypto_sign(int32_t                cose_algorithm_id,
     (void)signature_buffer;
     (void)signature;
     (void)crypto_ctx;
+
+    if (started) {
+        return T_COSE_ERR_SIGN_RESTART_NOT_SUPPORTED;
+    }
+
     return T_COSE_ERR_UNSUPPORTED_SIGNING_ALG;
 }
 

--- a/crypto_adapters/t_cose_test_crypto.c
+++ b/crypto_adapters/t_cose_test_crypto.c
@@ -2,6 +2,7 @@
  *  t_cose_test_crypto.c
  *
  * Copyright 2019-2020, Laurence Lundblade
+ * Copyright (c) 2022, Arm Limited. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *
@@ -71,13 +72,15 @@ t_cose_crypto_sign(int32_t                cose_algorithm_id,
                    struct t_cose_key      signing_key,
                    struct q_useful_buf_c  hash_to_sign,
                    struct q_useful_buf    signature_buffer,
-                   struct q_useful_buf_c *signature)
+                   struct q_useful_buf_c *signature,
+                   struct t_cose_crypto_backend_ctx *crypto_ctx)
 {
     (void)cose_algorithm_id;
     (void)signing_key;
     (void)hash_to_sign;
     (void)signature_buffer;
     (void)signature;
+    (void)crypto_ctx;
     return T_COSE_ERR_UNSUPPORTED_SIGNING_ALG;
 }
 

--- a/examples/t_cose_basic_example_mbedtls.c
+++ b/examples/t_cose_basic_example_mbedtls.c
@@ -288,6 +288,10 @@ int32_t one_step_sign_example(bool restartable)
 
     if (restartable) {
         t_cose_sign1_set_restart_context(&sign_ctx, &sign_rst_ctx);
+#ifdef MBEDTLS_ECP_RESTARTABLE
+        /* Set the number of max operations per iteration */
+        mbedtls_ecp_set_max_ops(682); /* include/mbedtls/ecp.h:493 */
+#endif
     }
 
     t_cose_sign1_set_signing_key(&sign_ctx, key_pair,  NULL_Q_USEFUL_BUF_C);
@@ -456,6 +460,10 @@ int two_step_sign_example(bool restartable)
 
     if (restartable) {
         t_cose_sign1_set_restart_context(&sign_ctx, &sign_rst_ctx);
+#ifdef MBEDTLS_ECP_RESTARTABLE
+        /* Set the number of max operations per iteration */
+        mbedtls_ecp_set_max_ops(682); /* include/mbedtls/ecp.h:493 */
+#endif
     }
 
     t_cose_sign1_set_signing_key(&sign_ctx, key_pair,  NULL_Q_USEFUL_BUF_C);

--- a/examples/t_cose_basic_example_mbedtls.c
+++ b/examples/t_cose_basic_example_mbedtls.c
@@ -1,0 +1,582 @@
+/*
+ *  t_cose_basic_example_mbed.c
+ *
+ * Copyright 2019-2020, Laurence Lundblade
+ * Copyright (c) 2022, Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * See BSD-3-Clause license in README.md
+ */
+
+
+#include "mbedtls/ecdsa.h"
+#include "mbedtls/entropy.h"
+#include "mbedtls/hmac_drbg.h"
+
+#include "t_cose/t_cose_common.h"
+#include "t_cose/t_cose_sign1_sign.h"
+#include "t_cose/t_cose_sign1_verify.h"
+#include "t_cose/q_useful_buf.h"
+
+#include <stdio.h>
+
+
+/**
+ * \file t_cose_basic_example_mbed.c
+ *
+ * \brief Example code for signing and verifying a COSE_Sign1 message using
+ *        Mbed TLS
+ *
+ * This file has simple code to sign a payload and verify it.
+ *
+ * This works with Mbed TLS. It assumes t_cose has been wired
+ * up to Mbed TLS and has code specific to this library to
+ * make a key pair that will be passed through t_cose. See t_cose
+ * README for more details on how integration with crypto libraries
+ * works.
+ */
+
+
+/*
+ * Some hard coded keys for the test cases here.
+ */
+#define PRIVATE_KEY_prime256v1 \
+0xf1, 0xb7, 0x14, 0x23, 0x43, 0x40, 0x2f, 0x3b, 0x5d, 0xe7, 0x31, 0x5e, 0xa8, \
+0x94, 0xf9, 0xda, 0x5c, 0xf5, 0x03, 0xff, 0x79, 0x38, 0xa3, 0x7c, 0xa1, 0x4e, \
+0xb0, 0x32, 0x86, 0x98, 0x84, 0x50
+
+#define PRIVATE_KEY_secp384r1 \
+0x03, 0xdf, 0x14, 0xf4, 0xb8, 0xa4, 0x3f, 0xd8, 0xab, 0x75, 0xa6, 0x04, 0x6b, \
+0xd2, 0xb5, 0xea, 0xa6, 0xfd, 0x10, 0xb2, 0xb2, 0x03, 0xfd, 0x8a, 0x78, 0xd7, \
+0x91, 0x6d, 0xe2, 0x0a, 0xa2, 0x41, 0xeb, 0x37, 0xec, 0x3d, 0x4c, 0x69, 0x3d, \
+0x23, 0xba, 0x2b, 0x4f, 0x6e, 0x5b, 0x66, 0xf5, 0x7f
+
+#define PRIVATE_KEY_secp521r1 \
+0x00, 0x45, 0xd2, 0xd1, 0x43, 0x94, 0x35, 0xfa, 0xb3, 0x33, 0xb1, 0xc6, 0xc8, \
+0xb5, 0x34, 0xf0, 0x96, 0x93, 0x96, 0xad, 0x64, 0xd5, 0xf5, 0x35, 0xd6, 0x5f, \
+0x68, 0xf2, 0xa1, 0x60, 0x65, 0x90, 0xbb, 0x15, 0xfd, 0x53, 0x22, 0xfc, 0x97, \
+0xa4, 0x16, 0xc3, 0x95, 0x74, 0x5e, 0x72, 0xc7, 0xc8, 0x51, 0x98, 0xc0, 0x92, \
+0x1a, 0xb3, 0xb8, 0xe9, 0x2d, 0xd9, 0x01, 0xb5, 0xa4, 0x21, 0x59, 0xad, 0xac, \
+0x6d
+
+/* The keypair for the sign operation */
+static  mbedtls_ecp_keypair ec;
+
+
+/**
+ * \brief Make an EC key pair in Mbed TLS library form.
+ *
+ * \param[in] cose_algorithm_id  The algorithm to sign with, for example
+ *                               \ref T_COSE_ALGORITHM_ES256.
+ * \param[out] key_pair          The key pair.
+ *
+ * The key made here is fixed and just useful for testing.
+ */
+enum t_cose_err_t make_mbed_ecdsa_key_pair(int32_t            cose_algorithm_id,
+                                           struct t_cose_key *key_pair)
+{
+    const uint8_t       *private_key;
+    size_t               private_key_len;
+    mbedtls_ecp_group_id grp_id;
+    int                  ret;
+
+    static const uint8_t private_key_256[] = {PRIVATE_KEY_prime256v1};
+    static const uint8_t private_key_384[] = {PRIVATE_KEY_secp384r1};
+    static const uint8_t private_key_521[] = {PRIVATE_KEY_secp521r1};
+
+    const mbedtls_md_info_t *md_info;
+    mbedtls_entropy_context entropy_ctx;
+    mbedtls_hmac_drbg_context drbg_ctx;
+
+    /* There is not a 1:1 mapping from alg to key type, but
+     * there is usually an obvious curve for an algorithm. That
+     * is what this does.
+     */
+
+    switch(cose_algorithm_id) {
+    case T_COSE_ALGORITHM_ES256:
+        private_key     = private_key_256;
+        private_key_len = sizeof(private_key_256);
+        grp_id = MBEDTLS_ECP_DP_SECP256R1;
+        break;
+
+    case T_COSE_ALGORITHM_ES384:
+        private_key     = private_key_384;
+        private_key_len = sizeof(private_key_384);
+        grp_id = MBEDTLS_ECP_DP_SECP384R1;
+        break;
+
+    case T_COSE_ALGORITHM_ES512:
+        private_key     = private_key_521;
+        private_key_len = sizeof(private_key_521);
+        grp_id = MBEDTLS_ECP_DP_SECP521R1;
+        break;
+
+    default:
+        return T_COSE_ERR_UNSUPPORTED_SIGNING_ALG;
+    }
+
+    /* Setup ECC key */
+    mbedtls_ecp_keypair_init(&ec);
+    ret = mbedtls_ecp_group_load(&ec.MBEDTLS_PRIVATE(grp), grp_id);
+    if (ret != 0) {
+        printf("mbedtls_ecp_group_load has failed\n");
+        return T_COSE_ERR_FAIL;
+    }
+
+    ret = mbedtls_mpi_read_binary(&ec.MBEDTLS_PRIVATE(d), private_key, private_key_len);
+    if (ret != 0) {
+        printf("mbedtls_mpi_read_binary has failed\n");
+        return T_COSE_ERR_FAIL;
+    }
+
+    ret = mbedtls_ecp_check_privkey(&ec.MBEDTLS_PRIVATE(grp), &ec.MBEDTLS_PRIVATE(d));
+    if (ret != 0) {
+        printf("mbedtls_ecp_check_privkey has failed\n");
+        return T_COSE_ERR_FAIL;
+    }
+
+    /* Only the private part is filled. Calculate public part. */
+    /* Initialize a local PRNG context */
+    mbedtls_entropy_init(&entropy_ctx);
+    md_info = mbedtls_md_info_from_type(MBEDTLS_MD_SHA256);
+    mbedtls_hmac_drbg_init(&drbg_ctx);
+    ret = mbedtls_hmac_drbg_seed(&drbg_ctx,
+                    md_info,
+                    mbedtls_entropy_func,
+                    &entropy_ctx,
+                    NULL, 0);
+    if (ret) {
+        mbedtls_hmac_drbg_free(&drbg_ctx);
+        return T_COSE_ERR_FAIL;
+    }
+
+    ret = mbedtls_ecp_mul(&ec.MBEDTLS_PRIVATE(grp), &ec.MBEDTLS_PRIVATE(Q),
+                            &ec.MBEDTLS_PRIVATE(d), &ec.MBEDTLS_PRIVATE(grp).G,
+                            mbedtls_hmac_drbg_random, &drbg_ctx);
+    mbedtls_hmac_drbg_free(&drbg_ctx);
+    if (ret) {
+        return T_COSE_ERR_FAIL;
+    }
+
+    key_pair->k.key_ptr = &ec;
+    key_pair->crypto_lib   = T_COSE_CRYPTO_LIB_MBEDTLS;
+
+    return T_COSE_SUCCESS;
+}
+
+
+/**
+ * \brief  Print a q_useful_buf_c on stdout in hex ASCII text.
+ *
+ * \param[in] string_label   A string label to output first
+ * \param[in] buf            The q_useful_buf_c to output.
+ *
+ * This is just for pretty printing.
+ */
+static void print_useful_buf(const char *string_label, struct q_useful_buf_c buf)
+{
+    if(string_label) {
+        printf("%s", string_label);
+    }
+
+    printf("    %ld bytes\n", buf.len);
+
+    printf("    ");
+
+    size_t i;
+    for(i = 0; i < buf.len; i++) {
+        uint8_t Z = ((uint8_t *)buf.ptr)[i];
+        printf("%02x ", Z);
+        if((i % 8) == 7) {
+            printf("\n    ");
+        }
+    }
+    printf("\n");
+
+    fflush(stdout);
+}
+
+/**
+ * \brief  Sign and verify example with one-step signing
+ *
+ * The one-step (plus init and key set up) signing uses more memory, but
+ * is simpler to use. In the code below constructed_payload_buffer is
+ * the extra buffer that two-step signing avoids.
+ */
+int32_t one_step_sign_example(void)
+{
+
+    struct t_cose_sign1_sign_ctx   sign_ctx;
+    enum t_cose_err_t              return_value;
+    Q_USEFUL_BUF_MAKE_STACK_UB(    signed_cose_buffer, 300);
+    struct q_useful_buf_c          signed_cose;
+    Q_USEFUL_BUF_MAKE_STACK_UB(    constructed_payload_buffer, 300);
+    struct q_useful_buf_c          constructed_payload;
+    struct q_useful_buf_c          returned_payload;
+    struct t_cose_key              key_pair;
+    struct t_cose_sign1_verify_ctx verify_ctx;
+    QCBOREncodeContext             cbor_encode;
+    QCBORError                     qcbor_result;
+    struct t_cose_crypto_backend_ctx mbedtls_crypto_backend_ctx;
+
+
+    /* ------   Construct the payload    ------
+     *
+     * The payload is constructed into its own continguous buffer.
+     * In this case the payload is CBOR formatm so it uses QCBOR to
+     * encode it, but CBOR is not
+     * required by COSE so it could be anything at all.
+     *
+     * The payload constructed here is a map of some label-value
+     * pairs similar to a CWT or EAT, but using string labels
+     * rather than integers. It is just a little example.
+     */
+    QCBOREncode_Init(&cbor_encode, constructed_payload_buffer);
+    QCBOREncode_OpenMap(&cbor_encode);
+    QCBOREncode_AddSZStringToMap(&cbor_encode, "BeingType", "Humanoid");
+    QCBOREncode_AddSZStringToMap(&cbor_encode, "Greeting", "We come in peace");
+    QCBOREncode_AddInt64ToMap(&cbor_encode, "ArmCount", 2);
+    QCBOREncode_AddInt64ToMap(&cbor_encode, "HeadCount", 1);
+    QCBOREncode_AddSZStringToMap(&cbor_encode, "BrainSize", "medium");
+    QCBOREncode_AddBoolToMap(&cbor_encode, "DrinksWater", true);
+    QCBOREncode_CloseMap(&cbor_encode);
+    qcbor_result = QCBOREncode_Finish(&cbor_encode, &constructed_payload);
+
+    printf("Encoded payload (size = %ld): %d (%s)\n",
+           constructed_payload.len,
+           qcbor_result,
+           qcbor_result ? "fail" : "success");
+    if(qcbor_result) {
+        return_value = (enum t_cose_err_t)qcbor_result;
+        goto Done;
+    }
+
+
+    /* ------   Make an ECDSA key pair    ------
+     *
+     * The key pair will be used for both signing and encryption. The
+     * data type is struct t_cose_key on the outside, but internally
+     * the format is that of the crypto library used, Mbed TLS in this
+     * case. They key is just passed through t_cose to the underlying
+     * crypto library.
+     *
+     * The making and destroying of the key pair is the only code
+     * dependent on the crypto library in this file.
+     */
+    return_value = make_mbed_ecdsa_key_pair(T_COSE_ALGORITHM_ES256, &key_pair);
+
+    printf("Made EC key with curve prime256v1: %d (%s)\n", return_value, return_value ? "fail" : "success");
+    if(return_value) {
+        goto Done;
+    }
+
+
+    /* ------   Initialize for signing    ------
+     *
+     * Initialize the signing context by telling it the signing
+     * algorithm and signing options. No options are set here hence
+     * the 0 value.
+     *
+     * Set up the signing key and kid (key ID). No kid is passed here
+     * hence the NULL_Q_USEFUL_BUF_C.
+     */
+
+    t_cose_sign1_sign_init(&sign_ctx, 0, T_COSE_ALGORITHM_ES256);
+
+    t_cose_sign1_set_signing_key(&sign_ctx, key_pair,  NULL_Q_USEFUL_BUF_C);
+    t_cose_sign1_set_crypto_context(&sign_ctx, &mbedtls_crypto_backend_ctx);
+
+    printf("Initialized t_cose and configured signing key\n");
+
+
+    /* ------   Sign    ------
+     *
+     * This performs encoding of the headers, the signing and formatting
+     * in one shot.
+     *
+     * With this API the payload ends up in memory twice, once as the
+     * input and once in the output. If the payload is large, this
+     * needs about double the size of the payload to work.
+     */
+    return_value = t_cose_sign1_sign(/* The context set up with signing key */
+                                     &sign_ctx,
+                                     /* Pointer and length of payload to be
+                                      * signed.
+                                      */
+                                     constructed_payload,
+                                     /* Non-const pointer and length of the
+                                      * buffer where the completed output is
+                                      * written to. The length here is that
+                                      * of the whole buffer.
+                                      */
+                                     signed_cose_buffer,
+                                     /* Const pointer and actual length of
+                                      * the completed, signed and encoded
+                                      * COSE_Sign1 message. This points
+                                      * into the output buffer and has the
+                                      * lifetime of the output buffer.
+                                      */
+                                     &signed_cose);
+
+    printf("Finished signing: %d (%s)\n", return_value, return_value ? "fail" : "success");
+    if(return_value) {
+        goto Done;
+    }
+
+    print_useful_buf("Completed COSE_Sign1 message:\n", signed_cose);
+
+
+    printf("\n");
+
+
+    /* ------   Set up for verification   ------
+     *
+     * Initialize the verification context.
+     *
+     * The verification key works the same way as the signing
+     * key. Internally it must be in the format for the crypto library
+     * used. It is passed straight through t_cose.
+     */
+    t_cose_sign1_verify_init(&verify_ctx, 0);
+
+    t_cose_sign1_set_verification_key(&verify_ctx, key_pair);
+
+    printf("Initialized t_cose for verification and set verification key\n");
+
+
+    /* ------   Perform the verification   ------
+     *
+     * Verification is relatively simple. The COSE_Sign1 message to
+     * verify is passed in and the payload is returned if verification
+     * is successful.  The key must be of the correct type for the
+     * algorithm used to sign the COSE_Sign1.
+     *
+     * The COSE header parameters will be returned if requested, but
+     * in this example they are not as NULL is passed for the location
+     * to put them.
+     */
+    return_value = t_cose_sign1_verify(&verify_ctx,
+                                       signed_cose,         /* COSE to verify */
+                                       &returned_payload,  /* Payload from signed_cose */
+                                       NULL);      /* Don't return parameters */
+
+    printf("Verification complete: %d (%s)\n", return_value, return_value ? "fail" : "success");
+    if(return_value) {
+        goto Done;
+    }
+
+    print_useful_buf("Signed payload:\n", returned_payload);
+
+
+Done:
+    return (int32_t)return_value;
+}
+
+
+
+
+/**
+ * \brief  Sign and verify example with two-step signing
+ *
+ * The two-step (plus init and key set up) signing has the payload
+ * constructed directly into the output buffer, uses less memory,
+ * but is more complicated to use.
+ */
+int two_step_sign_example(void)
+{
+    struct t_cose_sign1_sign_ctx   sign_ctx;
+    enum t_cose_err_t              return_value;
+    Q_USEFUL_BUF_MAKE_STACK_UB(    signed_cose_buffer, 300);
+    struct q_useful_buf_c          signed_cose;
+    struct q_useful_buf_c          payload;
+    struct t_cose_key              key_pair;
+    QCBOREncodeContext             cbor_encode;
+    QCBORError                     cbor_error;
+    struct t_cose_sign1_verify_ctx verify_ctx;
+    struct t_cose_crypto_backend_ctx mbedtls_crypto_backend_ctx;
+
+
+
+    /* ------   Make an ECDSA key pair    ------
+     *
+     * The key pair will be used for both signing and encryption. The
+     * data type is struct t_cose_key on the outside, but internally
+     * the format is that of the crypto library used, Mbed TLS in this
+     * case. They key is just passed through t_cose to the underlying
+     * crypto library.
+     *
+     * The making and destroying of the key pair is the only code
+     * dependent on the crypto library in this file.
+     */
+    return_value = make_mbed_ecdsa_key_pair(T_COSE_ALGORITHM_ES256, &key_pair);
+
+    printf("Made EC key with curve prime256v1: %d (%s)\n", return_value,
+           return_value ? "fail" : "success");
+    if(return_value) {
+        goto Done;
+    }
+
+
+    /* ------   Initialize for signing    ------
+     *
+     * Set up the QCBOR encoding context with the output buffer. This
+     * is where all the outputs including the payload goes. In this
+     * case the maximum size is small and known so a fixed length
+     * buffer is given. If it is not known then QCBOR and t_cose can
+     * run without a buffer to calculate the needed size. In all
+     * cases, if the buffer is too small QCBOR and t_cose will error
+     * out gracefully and not overrun any buffers.
+     *
+     * Initialize the signing context by telling it the signing
+     * algorithm and signing options. No options are set here hence
+     * the 0 value.
+     *
+     * Set up the signing key and kid (key ID). No kid is passed here
+     * hence the NULL_Q_USEFUL_BUF_C.
+     */
+
+    QCBOREncode_Init(&cbor_encode, signed_cose_buffer);
+
+    t_cose_sign1_sign_init(&sign_ctx, 0, T_COSE_ALGORITHM_ES256);
+
+    t_cose_sign1_set_signing_key(&sign_ctx, key_pair,  NULL_Q_USEFUL_BUF_C);
+    t_cose_sign1_set_crypto_context(&sign_ctx, &mbedtls_crypto_backend_ctx);
+
+    printf("Initialized QCBOR, t_cose and configured signing key\n");
+
+
+    /* ------   Encode the headers    ------
+     *
+     * This just outputs the COSE_Sign1 header parameters and gets set
+     * up for the payload to be output.
+     */
+    return_value = t_cose_sign1_encode_parameters(&sign_ctx, &cbor_encode);
+
+    printf("Encoded COSE headers: %d (%s)\n", return_value, return_value ? "fail" : "success");
+    if(return_value) {
+        goto Done;
+    }
+
+
+    /* ------   Output the payload    ------
+     *
+     * QCBOREncode functions are used to add the payload. It all goes
+     * directly into the output buffer without any temporary copies.
+     * QCBOR keeps track of the what is the payload so t_cose knows
+     * what to hash and sign.
+     *
+     * The encoded CBOR here can be very large and complex. The only
+     * limit is that the output buffer is large enough. If it is too
+     * small, one of the following two calls will report the error as
+     * QCBOR tracks encoding errors internally so the code calling it
+     * doesn't have to.
+     *
+     * The payload constructed here is a map of some label-value
+     * pairs similar to a CWT or EAT, but using string labels
+     * rather than integers. It is just a little example.
+     *
+     * A simpler alternative is to call t_cose_sign1_sign() instead of
+     * t_cose_sign1_encode_parameters() and
+     * t_cose_sign1_encode_signature(), however this requires memory
+     * to hold a copy of the payload and the output COSE_Sign1
+     * message. For that call the payload is just passed in as a
+     * buffer.
+     */
+    QCBOREncode_OpenMap(&cbor_encode);
+    QCBOREncode_AddSZStringToMap(&cbor_encode, "BeingType", "Humanoid");
+    QCBOREncode_AddSZStringToMap(&cbor_encode, "Greeting", "We come in peace");
+    QCBOREncode_AddInt64ToMap(&cbor_encode, "ArmCount", 2);
+    QCBOREncode_AddInt64ToMap(&cbor_encode, "HeadCount", 1);
+    QCBOREncode_AddSZStringToMap(&cbor_encode, "BrainSize", "medium");
+    QCBOREncode_AddBoolToMap(&cbor_encode, "DrinksWater", true);
+    QCBOREncode_CloseMap(&cbor_encode);
+
+    printf("Payload added\n");
+
+
+    /* ------   Sign    ------
+     *
+     * This call signals the end payload construction, causes the actual
+     * signing to run.
+     */
+    return_value = t_cose_sign1_encode_signature(&sign_ctx, &cbor_encode);
+
+    printf("Fnished signing: %d (%s)\n", return_value, return_value ? "fail" : "success");
+    if(return_value) {
+        goto Done;
+    }
+
+
+    /* ------   Complete CBOR Encoding   ------
+     *
+     * This closes out the CBOR encoding returning any errors that
+     * might have been recorded.
+     *
+     * The resulting signed message is returned in signed_cose. It is
+     * a pointer and length into the buffer give to
+     * QCBOREncode_Init().
+     */
+    cbor_error = QCBOREncode_Finish(&cbor_encode, &signed_cose);
+    printf("Finished CBOR encoding: %d (%s)\n", cbor_error, return_value ? "fail" : "success");
+    if(cbor_error) {
+        goto Done;
+    }
+
+    print_useful_buf("Completed COSE_Sign1 message:\n", signed_cose);
+
+
+    printf("\n");
+
+
+    /* ------   Set up for verification   ------
+     *
+     * Initialize the verification context.
+     *
+     * The verification key works the same way as the signing
+     * key. Internally it must be in the format for the crypto library
+     * used. It is passed straight through t_cose.
+     */
+    t_cose_sign1_verify_init(&verify_ctx, 0);
+
+    t_cose_sign1_set_verification_key(&verify_ctx, key_pair);
+
+    printf("Initialized t_cose for verification and set verification key\n");
+
+
+    /* ------   Perform the verification   ------
+     *
+     * Verification is relatively simple. The COSE_Sign1 message to
+     * verify is passed in and the payload is returned if verification
+     * is successful.  The key must be of the correct type for the
+     * algorithm used to sign the COSE_Sign1.
+     *
+     * The COSE header parameters will be returned if requested, but
+     * in this example they are not as NULL is passed for the location
+     * to put them.
+     */
+    return_value = t_cose_sign1_verify(&verify_ctx,
+                                       signed_cose,         /* COSE to verify */
+                                       &payload,  /* Payload from signed_cose */
+                                       NULL);      /* Don't return parameters */
+
+    printf("Verification complete: %d (%s)\n", return_value, return_value ? "fail" : "success");
+    if(return_value) {
+        goto Done;
+    }
+
+    print_useful_buf("Signed payload:\n", payload);
+
+Done:
+    return (int)return_value;
+}
+
+int main(int argc, const char * argv[])
+{
+    (void)argc; /* Avoid unused parameter error */
+    (void)argv;
+
+    one_step_sign_example();
+    two_step_sign_example();
+}

--- a/inc/t_cose/t_cose_common.h
+++ b/inc/t_cose/t_cose_common.h
@@ -345,6 +345,13 @@ enum t_cose_err_t {
     /** More than \ref T_COSE_MAX_TAGS_TO_RETURN unprocessed tags when
      * verifying a signature. */
     T_COSE_ERR_TOO_MANY_TAGS = 37,
+
+    /** A signing operation is in progress. The function returning this value
+     * can be called again until it returns \ref T_COSE_SUCCESS or error. */
+    T_COSE_ERR_SIG_IN_PROGRESS = 38,
+
+    /** The operation in this crypto adapter is not implemented.  */
+    T_COSE_ERR_SIGN_RESTART_NOT_SUPPORTED = 39,
 };
 
 

--- a/inc/t_cose/t_cose_common.h
+++ b/inc/t_cose/t_cose_common.h
@@ -2,6 +2,7 @@
  * t_cose_common.h
  *
  * Copyright 2019-2022, Laurence Lundblade
+ * Copyright (c) 2022, Arm Limited. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *
@@ -108,7 +109,10 @@ enum t_cose_crypto_lib_t {
     T_COSE_CRYPTO_LIB_OPENSSL = 1,
      /** \c key_handle is a \c psa_key_handle_t in Arm's Platform Security
       * Architecture */
-    T_COSE_CRYPTO_LIB_PSA = 2
+    T_COSE_CRYPTO_LIB_PSA = 2,
+     /** \c key_ptr points to a \c mbedtls_ecdsa_context, which is in turn
+      * a \c  mbedtls_ecp_keypair in Mbed TLS */
+    T_COSE_CRYPTO_LIB_MBEDTLS = 3
 };
 
 

--- a/inc/t_cose/t_cose_crypto_public.h
+++ b/inc/t_cose/t_cose_crypto_public.h
@@ -40,6 +40,40 @@ struct t_cose_crypto_backend_ctx {
 };
 
 
+/**
+ * The size of the output of SHA-256.
+ *
+ * (It is safe to define these independently here as they are
+ * well-known and fixed. There is no need to reference
+ * platform-specific headers and incur messy dependence.)
+ */
+#define T_COSE_CRYPTO_SHA256_SIZE 32
+
+/**
+ * The size of the output of SHA-384 in bytes.
+ */
+#define T_COSE_CRYPTO_SHA384_SIZE 48
+
+/**
+ * The size of the output of SHA-512 in bytes.
+ */
+#define T_COSE_CRYPTO_SHA512_SIZE 64
+
+
+/**
+ * The maximum needed to hold a hash. It is smaller and less stack is needed
+ * if the larger hashes are disabled.
+ */
+#ifndef T_COSE_DISABLE_ES512
+    #define T_COSE_CRYPTO_MAX_HASH_SIZE T_COSE_CRYPTO_SHA512_SIZE
+#else
+    #ifndef T_COSE_DISABLE_ES384
+        #define T_COSE_CRYPTO_MAX_HASH_SIZE T_COSE_CRYPTO_SHA384_SIZE
+    #else
+        #define T_COSE_CRYPTO_MAX_HASH_SIZE T_COSE_CRYPTO_SHA256_SIZE
+    #endif
+#endif
+
 #ifdef __cplusplus
 }
 #endif

--- a/inc/t_cose/t_cose_crypto_public.h
+++ b/inc/t_cose/t_cose_crypto_public.h
@@ -15,6 +15,25 @@
 #include <stddef.h>
 #include <stdint.h>
 
+#if defined(T_COSE_USE_PSA_CRYPTO)
+#include "psa/crypto.h"
+
+#elif defined(T_COSE_USE_MBEDTLS_CRYPTO)
+#include <mbedtls/ecdsa.h>
+#include <mbedtls/sha256.h>
+#include <mbedtls/sha512.h>
+
+#elif defined(T_COSE_USE_OPENSSL_CRYPTO)
+#include "openssl/evp.h"
+
+#elif defined(T_COSE_USE_B_CON_SHA256)
+/* This is code for use with Brad Conte's crypto.  See
+ * https://github.com/B-Con/crypto-algorithms and see the description
+ * of t_cose_crypto_hash
+ */
+#include "sha256.h"
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -25,7 +44,12 @@ extern "C" {
  */
 struct t_cose_crypto_backend_ctx {
 #ifdef T_COSE_USE_MBEDTLS_CRYPTO
+#ifdef MBEDTLS_ECP_RESTARTABLE
+    mbedtls_ecdsa_restart_ctx ecdsa_rst_ctx; /* Init by crypto adapter impl. */
+    mbedtls_ecdsa_context ecdsa_ctx;         /* Init by crypto adapter impl. */
+#else
     uint32_t unused; /* To prevent empty structure warning */
+#endif /* MBEDTLS_ECP_RESTARTABLE */
 
 #elif defined (T_COSE_USE_PSA_CRYPTO)
     uint32_t unused; /* To prevent empty structure warning */

--- a/inc/t_cose/t_cose_crypto_public.h
+++ b/inc/t_cose/t_cose_crypto_public.h
@@ -1,0 +1,40 @@
+/*
+ * t_cose_crypto_public.h
+ *
+ * Copyright 2019, Laurence Lundblade
+ * Copyright (c) 2022, Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * See BSD-3-Clause license in README.md
+ */
+#ifndef __T_COSE_CRYPTO_PUBLIC_H__
+#define __T_COSE_CRYPTO_PUBLIC_H__
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * The context for use by crypto backends. Its content is crypto backend
+ * specific.
+ */
+struct t_cose_crypto_backend_ctx {
+#ifdef T_COSE_USE_PSA_CRYPTO
+    uint32_t unused; /* To prevent empty structure warning */
+
+#elif defined(T_COSE_USE_OPENSSL_CRYPTO)
+    uint32_t unused; /* To prevent empty structure warning */
+
+#else
+    uint32_t unused; /* To prevent empty structure warning */
+
+#endif /* T_COSE_USE_MBED_CRYPTO */
+};
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __T_COSE_CRYPTO_PUBLIC_H__ */

--- a/inc/t_cose/t_cose_crypto_public.h
+++ b/inc/t_cose/t_cose_crypto_public.h
@@ -11,6 +11,10 @@
 #ifndef __T_COSE_CRYPTO_PUBLIC_H__
 #define __T_COSE_CRYPTO_PUBLIC_H__
 
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -20,7 +24,10 @@ extern "C" {
  * specific.
  */
 struct t_cose_crypto_backend_ctx {
-#ifdef T_COSE_USE_PSA_CRYPTO
+#ifdef T_COSE_USE_MBEDTLS_CRYPTO
+    uint32_t unused; /* To prevent empty structure warning */
+
+#elif defined (T_COSE_USE_PSA_CRYPTO)
     uint32_t unused; /* To prevent empty structure warning */
 
 #elif defined(T_COSE_USE_OPENSSL_CRYPTO)
@@ -29,7 +36,7 @@ struct t_cose_crypto_backend_ctx {
 #else
     uint32_t unused; /* To prevent empty structure warning */
 
-#endif /* T_COSE_USE_MBED_CRYPTO */
+#endif /* T_COSE_USE_MBEDTLS_CRYPTO */
 };
 
 

--- a/inc/t_cose/t_cose_sign1_sign.h
+++ b/inc/t_cose/t_cose_sign1_sign.h
@@ -3,6 +3,7 @@
  *
  * Copyright (c) 2018-2021, Laurence Lundblade. All rights reserved.
  * Copyright (c) 2020, Michael Eckel
+ * Copyright (c) 2022, Arm Limited. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *
@@ -17,6 +18,7 @@
 #include "qcbor/qcbor.h"
 #include "t_cose/q_useful_buf.h"
 #include "t_cose/t_cose_common.h"
+#include "t_cose/t_cose_crypto_public.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -77,6 +79,7 @@ struct t_cose_sign1_sign_ctx {
     uint32_t              content_type_uint;
     const char *          content_type_tstr;
 #endif
+    struct t_cose_crypto_backend_ctx     *crypto_ctx;
 };
 
 
@@ -146,6 +149,21 @@ static void
 t_cose_sign1_sign_init(struct t_cose_sign1_sign_ctx *context,
                        uint32_t                      option_flags,
                        int32_t                       cose_algorithm_id);
+
+/**
+ * \brief  Set the crypto backend specfic context for the signing operation.
+ *
+ * \param[in] context            The t_cose signing context.
+ * \param[in] crypto_ctx         Crypto backend context.
+ *
+ * See the documentation/declaration of \ref t_cose_crypto_backend_ctx in
+ * inc/t_cose/t_cose_crypto_public.h. If the structure is empty for the selected
+ * crypto backend (with the selected compile conditions) then this function
+ * doesn't have to be called.
+ */
+static void
+t_cose_sign1_set_crypto_context(struct t_cose_sign1_sign_ctx     *context,
+                                struct t_cose_crypto_backend_ctx *crypto_ctx);
 
 
 /**
@@ -432,6 +450,14 @@ t_cose_sign1_sign_init(struct t_cose_sign1_sign_ctx *me,
 
     me->cose_algorithm_id = cose_algorithm_id;
     me->option_flags      = option_flags;
+}
+
+
+static inline void
+t_cose_sign1_set_crypto_context(struct t_cose_sign1_sign_ctx     *me,
+                                struct t_cose_crypto_backend_ctx *crypto_ctx)
+{
+    me->crypto_ctx = crypto_ctx;
 }
 
 

--- a/inc/t_cose/t_cose_sign1_sign.h
+++ b/inc/t_cose/t_cose_sign1_sign.h
@@ -62,6 +62,16 @@ extern "C" {
  * and stack use by disabling features.
  */
 
+/**
+ * This is the context for restartable signing.
+ */
+struct t_cose_sign1_sign_restart_ctx {
+    QCBOREncodeContext    encode_context;
+    struct q_useful_buf_c tbs_hash;
+    uint8_t               c_buffer_for_tbs_hash[T_COSE_CRYPTO_MAX_HASH_SIZE];
+    struct q_useful_buf   buffer_for_tbs_hash;
+    bool                  started;
+};
 
 /**
  * This is the context for creating a \c COSE_Sign1 structure. The
@@ -70,7 +80,8 @@ extern "C" {
  */
 struct t_cose_sign1_sign_ctx {
     /* Private data structure */
-    struct q_useful_buf_c protected_parameters; /* Encoded protected paramssy */
+    struct t_cose_sign1_sign_restart_ctx *rst_ctx;
+    struct q_useful_buf_c protected_parameters; /* Encoded protected params */
     int32_t               cose_algorithm_id;
     struct t_cose_key     signing_key;
     uint32_t              option_flags;
@@ -149,6 +160,25 @@ static void
 t_cose_sign1_sign_init(struct t_cose_sign1_sign_ctx *context,
                        uint32_t                      option_flags,
                        int32_t                       cose_algorithm_id);
+
+
+/**
+ * \brief  Set the restart context for restartable signing.
+ *
+ * \param[in] context            The t_cose signing context.
+ * \param[in] rst_ctx            The t_cose restartable context.
+ *
+ * Initialize the \ref t_cose_sign1_sign_restart_ctx rst_ctx.
+ *
+ * Setting the \ref t_cose_sign1_sign_restart_ctx rst_ctx with this function
+ * will cause the function \ref t_cose_sign1_sign to execute the signing in a
+ * restartable manner.
+ */
+enum t_cose_err_t
+t_cose_sign1_set_restart_context(
+                        struct t_cose_sign1_sign_ctx         *context,
+                        struct t_cose_sign1_sign_restart_ctx *rst_ctx);
+
 
 /**
  * \brief  Set the crypto backend specfic context for the signing operation.

--- a/src/t_cose_crypto.h
+++ b/src/t_cose_crypto.h
@@ -288,27 +288,6 @@ t_cose_crypto_verify(int32_t               cose_algorithm_id,
                      struct q_useful_buf_c signature);
 
 
-
-
-#if defined(T_COSE_USE_PSA_CRYPTO)
-#include "psa/crypto.h"
-
-#elif defined(T_COSE_USE_MBEDTLS_CRYPTO)
-#include <mbedtls/sha256.h>
-#include <mbedtls/sha512.h>
-
-#elif defined(T_COSE_USE_OPENSSL_CRYPTO)
-#include "openssl/evp.h"
-
-#elif defined(T_COSE_USE_B_CON_SHA256)
-/* This is code for use with Brad Conte's crypto.  See
- * https://github.com/B-Con/crypto-algorithms and see the description
- * of t_cose_crypto_hash
- */
-#include "sha256.h"
-#endif
-
-
 /**
  * The context for use with the hash adaptation layer here.
  *

--- a/src/t_cose_crypto.h
+++ b/src/t_cose_crypto.h
@@ -2,6 +2,7 @@
  * t_cose_crypto.h
  *
  * Copyright 2019-2022, Laurence Lundblade
+ * Copyright (c) 2022, Arm Limited. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *
@@ -15,6 +16,7 @@
 #include <stdint.h>
 #include <stdbool.h>
 #include "t_cose/t_cose_common.h"
+#include "t_cose/t_cose_crypto_public.h"
 #include "t_cose/q_useful_buf.h"
 #include "t_cose_standard_constants.h"
 
@@ -174,6 +176,11 @@ t_cose_crypto_sig_size(int32_t            cose_algorithm_id,
  *                              the resulting signature is put.
  * \param[in] signature         Pointer and length of the signature
  *                              returned.
+ * \param[in] crypto_ctx        Pointer to a crypto backend specfic context or
+ *                              NULL. It depends on the crypto backend whether
+ *                              it is needed or not. The initialization of the
+ *                              data items is a shared responsibility between
+ *                              the caller and crypto adapter implementation.
  *
  * \retval T_COSE_SUCCESS
  *         Successfully created the signature.
@@ -216,7 +223,8 @@ t_cose_crypto_sign(int32_t                cose_algorithm_id,
                    struct t_cose_key      signing_key,
                    struct q_useful_buf_c  hash_to_sign,
                    struct q_useful_buf    signature_buffer,
-                   struct q_useful_buf_c *signature);
+                   struct q_useful_buf_c *signature,
+                   struct t_cose_crypto_backend_ctx *crypto_ctx);
 
 
 /**

--- a/src/t_cose_crypto.h
+++ b/src/t_cose_crypto.h
@@ -42,8 +42,8 @@ extern "C" {
  * for the various cryptographic libraries that are used on
  * various platforms and OSs. The functions are:
  *   - t_cose_t_crypto_sig_size()
- *   - t_cose_crypto_pub_key_sign()
- *   - t_cose_crypto_pub_key_verify()
+ *   - t_cose_crypto_sign()
+ *   - t_cose_crypto_verify()
  *   - t_cose_crypto_hash_start()
  *   - t_cose_crypto_hash_update()
  *   - t_cose_crypto_hash_finish()

--- a/src/t_cose_crypto.h
+++ b/src/t_cose_crypto.h
@@ -201,6 +201,8 @@ t_cose_crypto_sig_size(int32_t            cose_algorithm_id,
  *         General unspecific failure.
  * \retval T_COSE_ERR_TAMPERING_DETECTED
  *         Equivalent to \c PSA_ERROR_CORRUPTION_DETECTED.
+ * \retval T_COSE_ERR_SIGN_RESTART_NOT_SUPPORTED
+ *         Restartable signing is not implemented.
  *
  * This is called to do public key signing. The implementation will
  * vary from one platform / OS to another but should conform to the
@@ -224,7 +226,8 @@ t_cose_crypto_sign(int32_t                cose_algorithm_id,
                    struct q_useful_buf_c  hash_to_sign,
                    struct q_useful_buf    signature_buffer,
                    struct q_useful_buf_c *signature,
-                   struct t_cose_crypto_backend_ctx *crypto_ctx);
+                   struct t_cose_crypto_backend_ctx *crypto_ctx,
+                   bool                  *started);
 
 
 /**
@@ -381,41 +384,6 @@ struct t_cose_crypto_hash {
    #endif
 
 };
-
-
-/**
- * The size of the output of SHA-256.
- *
- * (It is safe to define these independently here as they are
- * well-known and fixed. There is no need to reference
- * platform-specific headers and incur messy dependence.)
- */
-#define T_COSE_CRYPTO_SHA256_SIZE 32
-
-/**
- * The size of the output of SHA-384 in bytes.
- */
-#define T_COSE_CRYPTO_SHA384_SIZE 48
-
-/**
- * The size of the output of SHA-512 in bytes.
- */
-#define T_COSE_CRYPTO_SHA512_SIZE 64
-
-
-/**
- * The maximum needed to hold a hash. It is smaller and less stack is needed
- * if the larger hashes are disabled.
- */
-#ifndef T_COSE_DISABLE_ES512
-    #define T_COSE_CRYPTO_MAX_HASH_SIZE T_COSE_CRYPTO_SHA512_SIZE
-#else
-    #ifndef T_COSE_DISABLE_ES384
-        #define T_COSE_CRYPTO_MAX_HASH_SIZE T_COSE_CRYPTO_SHA384_SIZE
-    #else
-        #define T_COSE_CRYPTO_MAX_HASH_SIZE T_COSE_CRYPTO_SHA256_SIZE
-    #endif
-#endif
 
 
 /**

--- a/src/t_cose_crypto.h
+++ b/src/t_cose_crypto.h
@@ -287,13 +287,17 @@ t_cose_crypto_verify(int32_t               cose_algorithm_id,
 
 
 
-#ifdef T_COSE_USE_PSA_CRYPTO
+#if defined(T_COSE_USE_PSA_CRYPTO)
 #include "psa/crypto.h"
 
-#elif T_COSE_USE_OPENSSL_CRYPTO
+#elif defined(T_COSE_USE_MBEDTLS_CRYPTO)
+#include <mbedtls/sha256.h>
+#include <mbedtls/sha512.h>
+
+#elif defined(T_COSE_USE_OPENSSL_CRYPTO)
 #include "openssl/evp.h"
 
-#elif T_COSE_USE_B_CON_SHA256
+#elif defined(T_COSE_USE_B_CON_SHA256)
 /* This is code for use with Brad Conte's crypto.  See
  * https://github.com/B-Con/crypto-algorithms and see the description
  * of t_cose_crypto_hash
@@ -332,7 +336,7 @@ t_cose_crypto_verify(int32_t               cose_algorithm_id,
  */
 struct t_cose_crypto_hash {
 
-    #ifdef T_COSE_USE_PSA_CRYPTO
+    #if defined(T_COSE_USE_PSA_CRYPTO)
         /* --- The context for PSA Crypto (MBed Crypto) --- */
 
         /* psa_hash_operation_t actually varied by the implementation of
@@ -347,13 +351,22 @@ struct t_cose_crypto_hash {
         psa_hash_operation_t ctx;
         psa_status_t         status;
 
-    #elif T_COSE_USE_OPENSSL_CRYPTO
+    #elif defined(T_COSE_USE_MBEDTLS_CRYPTO)
+        mbedtls_sha256_context sha256_ctx;
+        #if !defined T_COSE_DISABLE_ES512 || !defined T_COSE_DISABLE_ES384
+            /* SHA 384 uses the sha_512 context  */
+            mbedtls_sha512_context sha512_ctx;
+        #endif
+        int32_t cose_hash_alg_id;
+        int status;
+
+    #elif defined(T_COSE_USE_OPENSSL_CRYPTO)
         /* --- The context for OpenSSL crypto --- */
         EVP_MD_CTX  *evp_ctx;
         int          update_error; /* Used to track error return by SHAXXX_Update() */
         int32_t      cose_hash_alg_id; /* COSE integer ID for the hash alg */
 
-   #elif T_COSE_USE_B_CON_SHA256
+   #elif defined(T_COSE_USE_B_CON_SHA256)
         /* --- Specific context for Brad Conte's sha256.c --- */
         SHA256_CTX b_con_hash_context;
 

--- a/src/t_cose_sign1_sign.c
+++ b/src/t_cose_sign1_sign.c
@@ -2,6 +2,7 @@
  * t_cose_sign1_sign.c
  *
  * Copyright (c) 2018-2021, Laurence Lundblade. All rights reserved.
+ * Copyright (c) 2022, Arm Limited. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *
@@ -382,7 +383,8 @@ t_cose_sign1_encode_signature_aad_internal(struct t_cose_sign1_sign_ctx *me,
                                                me->signing_key,
                                                tbs_hash,
                                                buffer_for_signature,
-                                              &signature);
+                                              &signature,
+                                               me->crypto_ctx);
         }
 
 #ifndef T_COSE_DISABLE_SHORT_CIRCUIT_SIGN

--- a/test/run_tests.c
+++ b/test/run_tests.c
@@ -59,9 +59,13 @@ static test_entry s_tests[] = {
      * verification short circuited.  They must have a real crypto
      * library integrated. */
     TEST_ENTRY(sign_verify_basic_test),
+    TEST_ENTRY(sign_verify_basic_test_restartable),
     TEST_ENTRY(sign_verify_make_cwt_test),
+    TEST_ENTRY(sign_verify_make_cwt_test_restartable),
     TEST_ENTRY(sign_verify_sig_fail_test),
+    TEST_ENTRY(sign_verify_sig_fail_test_restartable),
     TEST_ENTRY(sign_verify_get_size_test),
+    TEST_ENTRY(sign_verify_get_size_test_restartable),
     TEST_ENTRY(known_good_test),
 #endif /* T_COSE_DISABLE_SIGN_VERIFY_TESTS */
 
@@ -73,24 +77,39 @@ static test_entry s_tests[] = {
      * tests are typically always run.
      */
     TEST_ENTRY(bad_parameters_test),
+    TEST_ENTRY(bad_parameters_test_restartable),
     TEST_ENTRY(crit_parameters_test),
+    TEST_ENTRY(crit_parameters_test_restartable),
 #ifndef T_COSE_DISABLE_CONTENT_TYPE
     TEST_ENTRY(content_type_test),
+    TEST_ENTRY(content_type_test_restartable),
 #endif
     TEST_ENTRY(all_header_parameters_test),
+    TEST_ENTRY(all_header_parameters_test_restartable),
     TEST_ENTRY(cose_example_test),
+    TEST_ENTRY(cose_example_test_restartable),
     TEST_ENTRY(short_circuit_signing_error_conditions_test),
+    TEST_ENTRY(short_circuit_signing_error_conditions_test_restartable),
     TEST_ENTRY(short_circuit_self_test),
+    TEST_ENTRY(short_circuit_self_test_restartable),
     TEST_ENTRY(short_circuit_self_detached_content_test),
+    TEST_ENTRY(short_circuit_self_detached_content_test_restartable),
     TEST_ENTRY(short_circuit_decode_only_test),
+    TEST_ENTRY(short_circuit_decode_only_test_restartable),
     TEST_ENTRY(short_circuit_make_cwt_test),
+    TEST_ENTRY(short_circuit_make_cwt_test_restartable),
     TEST_ENTRY(short_circuit_verify_fail_test),
+    TEST_ENTRY(short_circuit_verify_fail_test_restartable),
     TEST_ENTRY(tags_test),
+    TEST_ENTRY(tags_test_restartable),
     TEST_ENTRY(get_size_test),
+    TEST_ENTRY(get_size_test_restartable),
     TEST_ENTRY(indef_array_and_map_test),
+    TEST_ENTRY(indef_array_and_map_test_restartable),
 
 #ifdef T_COSE_ENABLE_HASH_FAIL_TEST
     TEST_ENTRY(short_circuit_hash_fail_test),
+    TEST_ENTRY(short_circuit_hash_fail_test_restartable),
 #endif /* T_COSE_DISABLE_HASH_FAIL_TEST */
 #endif /* T_COSE_DISABLE_SHORT_CIRCUIT_SIGN */
 

--- a/test/run_tests.c
+++ b/test/run_tests.c
@@ -2,6 +2,7 @@
  run_tests.c -- test aggregator and results reporting
 
  Copyright (c) 2018-2022, Laurence Lundblade. All rights reserved.
+ Copyright (c) 2022, Arm Limited. All rights reserved.
 
  SPDX-License-Identifier: BSD-3-Clause
 
@@ -155,6 +156,7 @@ int RunTestsTCose(const char    *szTestNames[],
 {
     // int (-32767 to 32767 according to C standard) used by conscious choice
     int nTestsFailed = 0;
+    int nTestsSkipped = 0;
     int nTestsRun = 0;
     UsefulBuf_MAKE_STACK_UB(StringStorage, 12);
 
@@ -190,13 +192,20 @@ int RunTestsTCose(const char    *szTestNames[],
             (*pfOutput)(t2->szTestName, poutCtx, 0);
         }
 
-        if(szTestResult) {
+        if(szTestResult > 0) {
             if(pfOutput) {
                 (*pfOutput)(" FAILED (returned ", poutCtx, 0);
                 (*pfOutput)(szTestResult, poutCtx, 0);
                 (*pfOutput)(")", poutCtx, 1);
             }
             nTestsFailed++;
+        } else if(szTestResult < 0) {
+            if(pfOutput) {
+                (*pfOutput)(" SKIPPED (returned ", poutCtx, 0);
+                (*pfOutput)(szTestResult, poutCtx, 0);
+                (*pfOutput)(")", poutCtx, 1);
+            }
+            nTestsSkipped++;
         } else {
             if(pfOutput) {
                 (*pfOutput)( " PASSED", poutCtx, 1);
@@ -237,13 +246,20 @@ int RunTestsTCose(const char    *szTestNames[],
             (*pfOutput)(t->szTestName, poutCtx, 0);
         }
 
-        if(nTestResult) {
+        if(nTestResult > 0) {
             if(pfOutput) {
                 (*pfOutput)(" FAILED (returned ", poutCtx, 0);
                 (*pfOutput)(NumToString(nTestResult, StringStorage), poutCtx, 0);
                 (*pfOutput)(")", poutCtx, 1);
             }
             nTestsFailed++;
+        } else if(nTestResult < 0) {
+            if(pfOutput) {
+                (*pfOutput)(" SKIPPED (returned ", poutCtx, 0);
+                (*pfOutput)(NumToString(nTestResult, StringStorage), poutCtx, 0);
+                (*pfOutput)(")", poutCtx, 1);
+            }
+            nTestsSkipped++;
         } else {
             if(pfOutput) {
                 (*pfOutput)( " PASSED", poutCtx, 1);
@@ -259,6 +275,8 @@ int RunTestsTCose(const char    *szTestNames[],
         (*pfOutput)( "SUMMARY: ", poutCtx, 0);
         (*pfOutput)( NumToString(nTestsRun, StringStorage), poutCtx, 0);
         (*pfOutput)( " tests run; ", poutCtx, 0);
+        (*pfOutput)( NumToString(nTestsSkipped, StringStorage), poutCtx, 0);
+        (*pfOutput)( " tests skipped", poutCtx, 1);
         (*pfOutput)( NumToString(nTestsFailed, StringStorage), poutCtx, 0);
         (*pfOutput)( " tests failed", poutCtx, 1);
     }

--- a/test/t_cose_make_mbedtls_test_key.c
+++ b/test/t_cose_make_mbedtls_test_key.c
@@ -73,6 +73,11 @@ enum t_cose_err_t make_ecdsa_key_pair(int32_t            cose_algorithm_id,
     static const uint8_t private_key_384[] = {PRIVATE_KEY_secp384r1};
     static const uint8_t private_key_521[] = {PRIVATE_KEY_secp521r1};
 
+#ifdef MBEDTLS_ECP_RESTARTABLE
+    /* Set the number of max operations per iteration */
+    mbedtls_ecp_set_max_ops(682); /* include/mbedtls/ecp.h:446 */
+#endif
+
     /* There is not a 1:1 mapping from alg to key type, but
      * there is usually an obvious curve for an algorithm. That
      * is what this does.

--- a/test/t_cose_make_mbedtls_test_key.c
+++ b/test/t_cose_make_mbedtls_test_key.c
@@ -1,0 +1,172 @@
+/*
+ *  t_cose_make_psa_test_key.c
+ *
+ * Copyright 2019-2020, Laurence Lundblade
+ * Copyright (c) 2022, Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * See BSD-3-Clause license in README.md
+ */
+
+
+#include <string.h>
+
+#include "t_cose_make_test_pub_key.h" /* The interface implemented here */
+#include "t_cose_standard_constants.h"
+#include "t_cose/t_cose_crypto_public.h"
+
+#include "mbedtls/ecdsa.h"
+#include "mbedtls/ctr_drbg.h"
+#include "mbedtls/entropy.h"
+#include "mbedtls/hmac_drbg.h"
+
+/*
+ * Some hard coded keys for the test cases here.
+ */
+#define PRIVATE_KEY_prime256v1 \
+0xd9, 0xb5, 0xe7, 0x1f, 0x77, 0x28, 0xbf, 0xe5, 0x63, 0xa9, 0xdc, 0x93, 0x75, \
+0x62, 0x27, 0x7e, 0x32, 0x7d, 0x98, 0xd9, 0x94, 0x80, 0xf3, 0xdc, 0x92, 0x41, \
+0xe5, 0x74, 0x2a, 0xc4, 0x58, 0x89
+
+#define PRIVATE_KEY_secp384r1 \
+ 0x63, 0x88, 0x1c, 0xbf, \
+ 0x86, 0x65, 0xec, 0x39, 0x27, 0x33, 0x24, 0x2e, 0x5a, 0xae, 0x63, 0x3a, \
+ 0xf5, 0xb1, 0xb4, 0x54, 0xcf, 0x7a, 0x55, 0x7e, 0x44, 0xe5, 0x7c, 0xca, \
+ 0xfd, 0xb3, 0x59, 0xf9, 0x72, 0x66, 0xec, 0x48, 0x91, 0xdf, 0x27, 0x79, \
+ 0x99, 0xbd, 0x1a, 0xbc, 0x09, 0x36, 0x49, 0x9c
+
+#define PRIVATE_KEY_secp521r1 \
+0x00, 0x4b, 0x35, 0x4d, \
+0xa4, 0xab, 0xf7, 0xa5, 0x4f, 0xac, 0xee, 0x06, 0x49, 0x4a, 0x97, 0x0e, \
+0xa6, 0x5f, 0x85, 0xf0, 0x6a, 0x2e, 0xfb, 0xf8, 0xdd, 0x60, 0x9a, 0xf1, \
+0x0b, 0x7a, 0x13, 0xf7, 0x90, 0xf8, 0x9f, 0x49, 0x02, 0xbf, 0x5d, 0x5d, \
+0x71, 0xa0, 0x90, 0x93, 0x11, 0xfd, 0x0c, 0xda, 0x7b, 0x6a, 0x5f, 0x7b, \
+0x82, 0x9d, 0x79, 0x61, 0xe1, 0x6b, 0x31, 0x0a, 0x30, 0x6f, 0x4d, 0xf3, \
+0x8b, 0xe3
+
+/* The keypair for the sign operation */
+static  mbedtls_ecp_keypair ec;
+
+/* There is a single instance of this context: we assume the tests are
+ * executed sequentially.
+ */
+static struct t_cose_crypto_backend_ctx mbedtls_crypto_backend_ctx;
+
+
+/*
+ * Public function, see t_cose_make_test_pub_key.h
+ */
+enum t_cose_err_t make_ecdsa_key_pair(int32_t            cose_algorithm_id,
+                                      struct t_cose_key *key_pair)
+{
+    const uint8_t       *private_key;
+    size_t               private_key_len;
+    mbedtls_ecp_group_id grp_id;
+    int                  ret;
+
+    const mbedtls_md_info_t *md_info;
+    mbedtls_entropy_context entropy_ctx;
+    mbedtls_hmac_drbg_context drbg_ctx;
+
+    static const uint8_t private_key_256[] = {PRIVATE_KEY_prime256v1};
+    static const uint8_t private_key_384[] = {PRIVATE_KEY_secp384r1};
+    static const uint8_t private_key_521[] = {PRIVATE_KEY_secp521r1};
+
+    /* There is not a 1:1 mapping from alg to key type, but
+     * there is usually an obvious curve for an algorithm. That
+     * is what this does.
+     */
+
+    switch (cose_algorithm_id) {
+    case COSE_ALGORITHM_ES256:
+        private_key     = private_key_256;
+        private_key_len = sizeof(private_key_256);
+        grp_id = MBEDTLS_ECP_DP_SECP256R1;
+        break;
+
+    case COSE_ALGORITHM_ES384:
+        private_key     = private_key_384;
+        private_key_len = sizeof(private_key_384);
+        grp_id = MBEDTLS_ECP_DP_SECP384R1;
+        break;
+
+    case COSE_ALGORITHM_ES512:
+        private_key     = private_key_521;
+        private_key_len = sizeof(private_key_521);
+        grp_id = MBEDTLS_ECP_DP_SECP521R1;
+        break;
+
+    default:
+        return T_COSE_ERR_UNSUPPORTED_SIGNING_ALG;
+    }
+
+    /* Setup ECC key */
+    mbedtls_ecp_keypair_init(&ec);
+    ret = mbedtls_ecp_group_load(&ec.MBEDTLS_PRIVATE(grp), grp_id);
+    if (ret != 0) {
+        return T_COSE_ERR_FAIL;
+    }
+
+    ret = mbedtls_mpi_read_binary(&ec.MBEDTLS_PRIVATE(d), private_key, private_key_len);
+    if (ret != 0) {
+        return T_COSE_ERR_FAIL;
+    }
+
+    ret = mbedtls_ecp_check_privkey(&ec.MBEDTLS_PRIVATE(grp), &ec.MBEDTLS_PRIVATE(d));
+    if (ret != 0) {
+        return T_COSE_ERR_FAIL;
+    }
+
+    /* Only the private part is filled. Calculate public part. */
+    /* Initialize a local PRNG context */
+    mbedtls_entropy_init(&entropy_ctx);
+    md_info = mbedtls_md_info_from_type(MBEDTLS_MD_SHA256);
+    mbedtls_hmac_drbg_init(&drbg_ctx);
+    ret = mbedtls_hmac_drbg_seed(&drbg_ctx,
+                    md_info,
+                    mbedtls_entropy_func,
+                    &entropy_ctx,
+                    NULL, 0);
+    if (ret) {
+        mbedtls_hmac_drbg_free(&drbg_ctx);
+        return T_COSE_ERR_FAIL;
+    }
+
+    ret = mbedtls_ecp_mul(&ec.MBEDTLS_PRIVATE(grp), &ec.MBEDTLS_PRIVATE(Q),
+                            &ec.MBEDTLS_PRIVATE(d), &ec.MBEDTLS_PRIVATE(grp).G,
+                            mbedtls_hmac_drbg_random, &drbg_ctx);
+    mbedtls_hmac_drbg_free(&drbg_ctx);
+    if (ret) {
+        return T_COSE_ERR_FAIL;
+    }
+
+    key_pair->k.key_ptr = &ec;
+    key_pair->crypto_lib   = T_COSE_CRYPTO_LIB_MBEDTLS;
+
+    return T_COSE_SUCCESS;
+}
+
+
+/*
+ * Public function, see t_cose_make_test_pub_key.h
+ */
+void free_ecdsa_key_pair(struct t_cose_key key_pair)
+{
+    memset(&ec, 0, sizeof(ec));
+    return;
+}
+
+
+/*
+ * Public function, see t_cose_make_test_pub_key.h
+ */
+int check_for_key_pair_leaks(void)
+{
+    return 0;
+}
+
+void t_cose_test_set_crypto_context(struct t_cose_sign1_sign_ctx *sign1_ctx)
+{
+    t_cose_sign1_set_crypto_context(sign1_ctx, &mbedtls_crypto_backend_ctx);
+}

--- a/test/t_cose_make_openssl_test_key.c
+++ b/test/t_cose_make_openssl_test_key.c
@@ -2,6 +2,7 @@
  *  t_cose_make_openssl_test_key.c
  *
  * Copyright 2019-2022, Laurence Lundblade
+ * Copyright (c) 2022, Arm Limited. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *
@@ -163,4 +164,9 @@ int check_for_key_pair_leaks()
        some coverage of the code even though there is no check here.
      */
     return 0;
+}
+
+void t_cose_test_set_crypto_context(struct t_cose_sign1_sign_ctx *sign1_ctx)
+{
+    (void)sign1_ctx;
 }

--- a/test/t_cose_make_psa_test_key.c
+++ b/test/t_cose_make_psa_test_key.c
@@ -2,6 +2,7 @@
  *  t_cose_make_psa_test_key.c
  *
  * Copyright 2019-2022, Laurence Lundblade
+ * Copyright (c) 2022, Arm Limited. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *
@@ -190,4 +191,9 @@ int check_for_key_pair_leaks()
            stats.MBEDTLS_PRIVATE(external_slots) +
            stats.MBEDTLS_PRIVATE(half_filled_slots) +
            stats.MBEDTLS_PRIVATE(cache_slots));
+}
+
+void t_cose_test_set_crypto_context(struct t_cose_sign1_sign_ctx *sign1_ctx)
+{
+    (void)sign1_ctx;
 }

--- a/test/t_cose_make_test_messages.c
+++ b/test/t_cose_make_test_messages.c
@@ -572,7 +572,8 @@ t_cose_sign1_test_message_output_signature(struct t_cose_sign1_sign_ctx *me,
                                           tbs_hash,
                                           buffer_for_signature,
                                          &signature,
-                                          me->crypto_ctx);
+                                          me->crypto_ctx,
+                                          me->rst_ctx ? &(me->rst_ctx->started) : NULL);
     } else {
 #ifndef T_COSE_DISABLE_SHORT_CIRCUIT_SIGN
         return_value = short_circuit_sign(me->cose_algorithm_id,

--- a/test/t_cose_make_test_messages.c
+++ b/test/t_cose_make_test_messages.c
@@ -2,6 +2,7 @@
  * t_cose_make_test_messages.c
  *
  * Copyright (c) 2019-2022, Laurence Lundblade. All rights reserved.
+ * Copyright (c) 2022, Arm Limited. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *
@@ -570,7 +571,8 @@ t_cose_sign1_test_message_output_signature(struct t_cose_sign1_sign_ctx *me,
                                           me->signing_key,
                                           tbs_hash,
                                           buffer_for_signature,
-                                         &signature);
+                                         &signature,
+                                          me->crypto_ctx);
     } else {
 #ifndef T_COSE_DISABLE_SHORT_CIRCUIT_SIGN
         return_value = short_circuit_sign(me->cose_algorithm_id,

--- a/test/t_cose_make_test_messages.h
+++ b/test/t_cose_make_test_messages.h
@@ -2,6 +2,7 @@
  * t_cose_make_test_messages.h
  *
  * Copyright (c) 2019-2022, Laurence Lundblade. All rights reserved.
+ * Copyright (c) 2022, Arm Limited. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *
@@ -143,7 +144,8 @@ t_cose_test_message_sign1_sign(struct t_cose_sign1_sign_ctx *me,
                                uint32_t                      test_message_options,
                                struct q_useful_buf_c         payload,
                                struct q_useful_buf           out_buf,
-                               struct q_useful_buf_c        *result);
+                               struct q_useful_buf_c        *result,
+                               int                          *sign_iteration_count);
 
 
 #ifdef __cplusplus

--- a/test/t_cose_make_test_pub_key.h
+++ b/test/t_cose_make_test_pub_key.h
@@ -2,6 +2,7 @@
  *  t_cose_make_test_pub_key.h
  *
  * Copyright 2019-2020, Laurence Lundblade
+ * Copyright (c) 2022, Arm Limited. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *
@@ -9,6 +10,8 @@
  */
 
 #include "t_cose/t_cose_common.h"
+#include "t_cose/t_cose_sign1_sign.h"
+
 #include <stdint.h>
 
 /**
@@ -37,5 +40,10 @@ void free_ecdsa_key_pair(struct t_cose_key key_pair);
  */
 int check_for_key_pair_leaks(void);
 
+
+/**
+ \brief Set a crypto backend dependent crypto context for the signing context.
+ */
+void t_cose_test_set_crypto_context(struct t_cose_sign1_sign_ctx *sign1_ctx);
 
 

--- a/test/t_cose_sign_verify_test.c
+++ b/test/t_cose_sign_verify_test.c
@@ -2,6 +2,7 @@
  *  t_cose_sign_verify_test.c
  *
  * Copyright 2019-2022, Laurence Lundblade
+ * Copyright (c) 2022, Arm Limited. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *
@@ -41,6 +42,7 @@ int_fast32_t sign_verify_basic_test_alg(int32_t cose_alg)
         return 1000 + (int32_t)result;
     }
     t_cose_sign1_set_signing_key(&sign_ctx, key_pair, NULL_Q_USEFUL_BUF_C);
+    t_cose_test_set_crypto_context(&sign_ctx);
 
     result = t_cose_sign1_sign(&sign_ctx,
                       Q_USEFUL_BUF_FROM_SZ_LITERAL("payload"),
@@ -143,6 +145,7 @@ int_fast32_t sign_verify_sig_fail_test()
 
     t_cose_sign1_sign_init(&sign_ctx, 0, T_COSE_ALGORITHM_ES256);
     t_cose_sign1_set_signing_key(&sign_ctx, key_pair, NULL_Q_USEFUL_BUF_C);
+    t_cose_test_set_crypto_context(&sign_ctx);
 
     result = t_cose_sign1_encode_parameters(&sign_ctx, &cbor_encode);
     if(result) {
@@ -233,6 +236,7 @@ int_fast32_t sign_verify_make_cwt_test()
     t_cose_sign1_set_signing_key(&sign_ctx,
                                   key_pair,
                                   Q_USEFUL_BUF_FROM_SZ_LITERAL("AsymmetricECDSA256"));
+    t_cose_test_set_crypto_context(&sign_ctx);
 
 
     /* -- Encoding context and output of parameters -- */
@@ -367,6 +371,7 @@ static int size_test(int32_t               cose_algorithm_id,
 
     t_cose_sign1_sign_init(&sign_ctx,  0,  cose_algorithm_id);
     t_cose_sign1_set_signing_key(&sign_ctx, key_pair, kid);
+    t_cose_test_set_crypto_context(&sign_ctx);
 
     return_value = t_cose_sign1_encode_parameters(&sign_ctx, &cbor_encode);
     if(return_value) {
@@ -399,6 +404,7 @@ static int size_test(int32_t               cose_algorithm_id,
 
     t_cose_sign1_sign_init(&sign_ctx,  0,  cose_algorithm_id);
     t_cose_sign1_set_signing_key(&sign_ctx, key_pair, kid);
+    t_cose_test_set_crypto_context(&sign_ctx);
 
     return_value = t_cose_sign1_encode_parameters(&sign_ctx, &cbor_encode);
     if(return_value) {
@@ -420,6 +426,7 @@ static int size_test(int32_t               cose_algorithm_id,
     /* ---- Again with one-call API to make COSE_Sign1 ---- */\
     t_cose_sign1_sign_init(&sign_ctx, 0, cose_algorithm_id);
     t_cose_sign1_set_signing_key(&sign_ctx, key_pair, kid);
+    t_cose_test_set_crypto_context(&sign_ctx);
     return_value = t_cose_sign1_sign(&sign_ctx,
                                      payload,
                                      signed_cose_buffer,

--- a/test/t_cose_sign_verify_test.c
+++ b/test/t_cose_sign_verify_test.c
@@ -296,7 +296,7 @@ int_fast32_t sign_verify_make_cwt_test()
     expected_rfc8392_first_part = Q_USEFUL_BUF_FROM_BYTE_ARRAY_LITERAL(rfc8392_first_part_bytes);
     actual_rfc8392_first_part = q_useful_buf_head(signed_cose, sizeof(rfc8392_first_part_bytes));
     if(q_useful_buf_compare(actual_rfc8392_first_part, expected_rfc8392_first_part)) {
-        return_value = -1;
+        return_value = 1;
         goto Done;
     }
 
@@ -394,7 +394,7 @@ static int size_test(int32_t               cose_algorithm_id,
     size_t expected_min = sig_size + payload.len + kid.len;
 
     if(calculated_size < expected_min || calculated_size > expected_min + 30) {
-        return -1;
+        return 1;
     }
 
 
@@ -420,7 +420,7 @@ static int size_test(int32_t               cose_algorithm_id,
 
     cbor_error = QCBOREncode_Finish(&cbor_encode, &actual_signed_cose);
     if(actual_signed_cose.len != calculated_size) {
-        return -2;
+        return 2;
     }
 
     /* ---- Again with one-call API to make COSE_Sign1 ---- */\
@@ -436,7 +436,7 @@ static int size_test(int32_t               cose_algorithm_id,
     }
 
     if(actual_signed_cose.len != calculated_size) {
-        return -3;
+        return 3;
     }
 
     return 0;

--- a/test/t_cose_sign_verify_test.h
+++ b/test/t_cose_sign_verify_test.h
@@ -2,6 +2,7 @@
  *  t_cose_sign_verify_test.h
  *
  * Copyright 2019, 2022, Laurence Lundblade
+ * Copyright (c) 2022, Arm Limited. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *
@@ -22,17 +23,37 @@
 
 
 /**
- * \brief Self test using integrated  crypto.
+ * \brief Self test using single step crypto API.
  *
- * \return non-zero on failure.
+ * \return Positive on failure.
+ * \return Negative on skip.
+ * \return 0 on Success.
  */
 int_fast32_t sign_verify_basic_test(void);
 
 
+/**
+ * \brief Self test using restartable crypto API.
+ *
+ * \return Positive on failure.
+ * \return Negative on skip.
+ * \return 0 on Success.
+ */
+int_fast32_t sign_verify_basic_test_restartable(void);
+
+
 /*
- * Sign some data, perturb the data and see that sig validation fails
+ * Sign some data, perturb the data and see that sig validation fails using
+ * single step crypto API.
  */
 int_fast32_t sign_verify_sig_fail_test(void);
+
+
+/*
+ * Sign some data, perturb the data and see that sig validation fails using
+ * restartable crypto API.
+ */
+int_fast32_t sign_verify_sig_fail_test_restartable(void);
 
 
 /*
@@ -42,10 +63,23 @@ int_fast32_t sign_verify_make_cwt_test(void);
 
 
 /*
- * Test the ability to calculate size of a COSE_Sign1
+ * Make a CWT using restartable crypto API and compare it to the one in the CWT
+ * RFC.
+ */
+int_fast32_t sign_verify_make_cwt_test_restartable(void);
+
+
+/*
+ * Test the ability to calculate size of a COSE_Sign1 using single step crypto
+ * API.
  */
 int_fast32_t sign_verify_get_size_test(void);
 
+/*
+ * Test the ability to calculate size of a COSE_Sign1 using restartable crypto
+ * API.
+ */
+int_fast32_t sign_verify_get_size_test_restartable(void);
 
 /*
  * Test against known good messages.

--- a/test/t_cose_test.c
+++ b/test/t_cose_test.c
@@ -1523,7 +1523,7 @@ int_fast32_t tags_test()
 }
 
 
-int32_t get_size_test()
+int_fast32_t get_size_test()
 {
     struct t_cose_sign1_sign_ctx   sign_ctx;
     QCBOREncodeContext             cbor_encode;
@@ -1620,7 +1620,7 @@ int32_t get_size_test()
 /*
  * Public function, see t_cose_test.h
  */
-int32_t indef_array_and_map_test()
+int_fast32_t indef_array_and_map_test()
 {
     enum t_cose_err_t  return_value;
     uint32_t           t_opts;

--- a/test/t_cose_test.h
+++ b/test/t_cose_test.h
@@ -145,14 +145,14 @@ int_fast32_t short_circuit_hash_fail_test(void);
 int_fast32_t tags_test(void);
 
 
-int32_t get_size_test(void);
+int_fast32_t get_size_test(void);
 
 
 /*
  * Test the decoding of COSE messages that use indefinite length
  * maps and arrays instead of definite length.
  */
-int32_t indef_array_and_map_test(void);
+int_fast32_t indef_array_and_map_test(void);
 
 
 #endif /* t_cose_test_h */

--- a/test/t_cose_test.h
+++ b/test/t_cose_test.h
@@ -2,6 +2,7 @@
  *  t_cose_test.h
  *
  * Copyright 2019-2022, Laurence Lundblade
+ * Copyright (c) 2022, Arm Limited. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *
@@ -36,6 +37,19 @@ int_fast32_t short_circuit_self_test(void);
 
 
 /**
+ * \brief Minimal message creation test using a short-circuit with the
+ *        restartable API.
+ *
+ * \return non-zero on failure.
+ *
+ * This test makes a simple COSE_Sign1 and verify it.  It uses
+ * short-circuit signatures so no keys or even integration with public
+ * key crypto is necessary.
+ */
+int_fast32_t short_circuit_self_test_restartable(void);
+
+
+/**
  * \brief COSE detached content test using a short-circuit signature.
  *
  * \return non-zero on failure.
@@ -45,6 +59,19 @@ int_fast32_t short_circuit_self_test(void);
  * key crypto is necessary.
  */
 int_fast32_t short_circuit_self_detached_content_test(void);
+
+
+/**
+ * \brief COSE detached content test using a short-circuit signature with the
+ *        restartable API.
+ *
+ * \return non-zero on failure.
+ *
+ * This test makes a detached content COSE_Sign1 and verify it.  It uses
+ * short-circuit signatures so no keys or even integration with public
+ * key crypto is necessary.
+ */
+int_fast32_t short_circuit_self_detached_content_test_restartable(void);
 
 
 /**
@@ -60,6 +87,19 @@ int_fast32_t short_circuit_verify_fail_test(void);
 
 
 /**
+ * \brief Test where payload bytes are corrupted and sig fails with restartable
+ *        API
+ *
+ * \return non-zero on failure.
+ *
+ * This test makes a simple COSE_Sign1 modifies the payload and sees that
+ * verification fails.  It uses short-circuit signatures so no keys or
+ * even integration with public key crypto is necessary.
+ */
+int_fast32_t short_circuit_verify_fail_test_restartable(void);
+
+
+/**
  * \brief Tests error condidtions for creating COSE_Sign1.
  *
  * \return non-zero on failure.
@@ -70,9 +110,26 @@ int_fast32_t short_circuit_verify_fail_test(void);
 int_fast32_t short_circuit_signing_error_conditions_test(void);
 
 
+/**
+ * \brief Tests error condidtions for creating COSE_Sign1 with restartable API.
+ *
+ * \return non-zero on failure.
+ *
+ * It uses short-circuit signatures so no keys or even integration
+ * with public key crypto is necessary.
+ */
+int_fast32_t short_circuit_signing_error_conditions_test_restartable(void);
+
+
 /* Make a CWT and see that it compares to the sample in the CWT RFC
  */
 int_fast32_t short_circuit_make_cwt_test(void);
+
+
+/* Make a CWT and see that it compares to the sample in the CWT RFC using
+ * restartable API
+ */
+int_fast32_t short_circuit_make_cwt_test_restartable(void);
 
 
 /*
@@ -84,6 +141,14 @@ int_fast32_t short_circuit_decode_only_test(void);
 
 
 /*
+ * Test the decode only mode, the mode where the
+ * headers are returned, but the signature is no
+ * verified. Using the restartable signing API.
+ */
+int_fast32_t short_circuit_decode_only_test_restartable(void);
+
+
+/*
 - protected header parameters not well formed CBOR
 - unprotected header parameters not well formed CBOR
 - unknown algorithm ID
@@ -92,10 +157,25 @@ int_fast32_t short_circuit_decode_only_test(void);
  */
 int_fast32_t bad_parameters_test(void);
 
+/*
+ * - protected header parameters not well formed CBOR
+ * - unprotected header parameters not well formed CBOR
+ * - unknown algorithm ID
+ * - No algorithm ID parameter
+ *
+ * All with restartable signing API
+ */
+int_fast32_t bad_parameters_test_restartable(void);
+
 
 /* Test that makes a CWT (CBOR Web Token)
  */
 int_fast32_t cose_example_test(void);
+
+
+/* Test that makes a CWT (CBOR Web Token) using restartable API.
+ */
+int_fast32_t cose_example_test_restartable(void);
 
 
 /*
@@ -105,15 +185,34 @@ int_fast32_t crit_parameters_test(void);
 
 
 /*
+ * Various tests involving the crit parameter using restartable signing API.
+ */
+int_fast32_t crit_parameters_test_restartable(void);
+
+
+/*
  Check that all types of headers are correctly returned.
  */
 int_fast32_t all_header_parameters_test(void);
 
 
 /*
+ * Check that all types of headers are correctly returned using the restartable
+ * signing API.
+ */
+int_fast32_t all_header_parameters_test_restartable(void);
+
+
+/*
  * Check that setting the content type works
  */
 int_fast32_t content_type_test(void);
+
+
+/*
+ * Check that setting the content type works with the restartable signing API
+ */
+int_fast32_t content_type_test_restartable(void);
 
 
 /*
@@ -135,6 +234,14 @@ int_fast32_t sign1_structure_decode_test(void);
  */
 int_fast32_t short_circuit_hash_fail_test(void);
 
+
+/*
+ * This forces / simulates failures in the hash algorithm implementation
+ * to test t_cose's handling of those condidtions, using the restartable sign
+ * API. For details see short_circuit_hash_fail_test.
+ */
+int_fast32_t short_circuit_hash_fail_test_restartable(void);
+
 #endif /* T_COSE_ENABLE_HASH_FAIL_TEST*/
 
 
@@ -144,8 +251,15 @@ int_fast32_t short_circuit_hash_fail_test(void);
  */
 int_fast32_t tags_test(void);
 
+/*
+ * Test tagging of COSE message with the restartable sign API
+ */
+int_fast32_t tags_test_restartable(void);
+
 
 int_fast32_t get_size_test(void);
+
+int_fast32_t get_size_test_restartable(void);
 
 
 /*
@@ -153,6 +267,12 @@ int_fast32_t get_size_test(void);
  * maps and arrays instead of definite length.
  */
 int_fast32_t indef_array_and_map_test(void);
+
+/*
+ * Test the decoding of COSE messages that use indefinite length
+ * maps and arrays instead of definite length using the restartable sign API.
+ */
+int_fast32_t indef_array_and_map_test_restartable(void);
 
 
 #endif /* t_cose_test_h */


### PR DESCRIPTION
This PR adds the functionality to sign a token in a restartable manner (see https://tls.mbed.org/kb/development/restartable-ecc)

The motivation is that for a supervisory software, that runs at an uninterruptible priority level, and generates an attestation token, It can be unacceptable to not respond for the entire process of signing.

This PR adds new API to t_cose to call signing in a restartable manner. For a certain crypto adapter it is possible to not implement the restartable behaviour. A new error code is added that can be returned by the implementation, if it is not supported. The PR also adds a crypto adapter for the Mbed TLS classic API (i.e. not the PSA Crypto API) and implements the restartable behaviour with the Mbed TLS crypto adapter.

I tried to break up the change to logical blocks, to keep the commit size reasonable. All the commits pass all the tests, and keep t_cose in a working state. I'm completely OK reviewing/merging the commits one by one, if that makes reviewing/discussing it easier.
