### PR TITLE
First version of crypto context

### DIFF
--- a/crypto_adapters/t_cose_openssl_crypto.c
+++ b/crypto_adapters/t_cose_openssl_crypto.c
@@ -348,6 +348,7 @@ Done:
 enum t_cose_err_t
 t_cose_crypto_sign(const int32_t                cose_algorithm_id,
                    const struct t_cose_key      signing_key,
+                   void                        *crypto_context,
                    const struct q_useful_buf_c  hash_to_sign,
                    const struct q_useful_buf    signature_buffer,
                    struct q_useful_buf_c       *signature)
@@ -366,6 +367,8 @@ t_cose_crypto_sign(const int32_t                cose_algorithm_id,
     int                    ossl_result;
     unsigned               key_size_bytes;
     MakeUsefulBufOnStack(  der_format_signature, T_COSE_MAX_SIG_SIZE + DER_SIG_ENCODE_OVER_HEAD);
+
+    (void)crypto_context; /* Crypto context not used */
 
     /* This implementation supports only ECDSA so far. The
      * interface allows it to support other, but none are implemented.

--- a/crypto_adapters/t_cose_psa_crypto.c
+++ b/crypto_adapters/t_cose_psa_crypto.c
@@ -145,6 +145,7 @@ t_cose_crypto_verify(int32_t               cose_algorithm_id,
 enum t_cose_err_t
 t_cose_crypto_sign(int32_t                cose_algorithm_id,
                    struct t_cose_key      signing_key,
+                   void                  *crypto_context,
                    struct q_useful_buf_c  hash_to_sign,
                    struct q_useful_buf    signature_buffer,
                    struct q_useful_buf_c *signature)
@@ -154,6 +155,8 @@ t_cose_crypto_sign(int32_t                cose_algorithm_id,
     psa_algorithm_t       psa_alg_id;
     mbedtls_svc_key_id_t  signing_key_psa;
     size_t                signature_len;
+
+    (void)crypto_context; /* Crypto context not used */
 
     psa_alg_id = cose_alg_id_to_psa_alg_id(cose_algorithm_id);
 

--- a/crypto_adapters/t_cose_test_crypto.c
+++ b/crypto_adapters/t_cose_test_crypto.c
@@ -13,6 +13,8 @@
 
 #include "t_cose_crypto.h"
 
+#include "t_cose_test_crypto.h"
+
 
 /*
  * This file is stub crypto for initial bring up and test of t_cose.
@@ -69,16 +71,34 @@ enum t_cose_err_t t_cose_crypto_sig_size(int32_t           cose_algorithm_id,
 enum t_cose_err_t
 t_cose_crypto_sign(int32_t                cose_algorithm_id,
                    struct t_cose_key      signing_key,
+                   void                  *crypto_context,
                    struct q_useful_buf_c  hash_to_sign,
                    struct q_useful_buf    signature_buffer,
                    struct q_useful_buf_c *signature)
 {
+    struct t_cose_test_crypto_context *me;
+
+    me = (struct t_cose_test_crypto_context *)crypto_context;
+
     (void)cose_algorithm_id;
     (void)signing_key;
     (void)hash_to_sign;
     (void)signature_buffer;
     (void)signature;
-    return T_COSE_ERR_UNSUPPORTED_SIGNING_ALG;
+
+    // TODO: turn this into short-circuit signing so it actually does something
+    
+    if(me != NULL && me->enable_restart) {
+
+        if(me->iteration_counter) {
+            me->iteration_counter--;
+            return T_COSE_ERR_SIG_IN_PROGRESS;
+        } else {
+            return T_COSE_SUCCESS;
+        }
+    } else {
+        return T_COSE_ERR_UNSUPPORTED_SIGNING_ALG;
+    }
 }
 
 
@@ -88,6 +108,7 @@ t_cose_crypto_sign(int32_t                cose_algorithm_id,
 enum t_cose_err_t
 t_cose_crypto_verify(int32_t                cose_algorithm_id,
                      struct t_cose_key      verification_key,
+                     void                  *crypto_context,
                      struct q_useful_buf_c  kid,
                      struct q_useful_buf_c  hash_to_verify,
                      struct q_useful_buf_c  signature)

--- a/crypto_adapters/t_cose_test_crypto.h
+++ b/crypto_adapters/t_cose_test_crypto.h
@@ -1,0 +1,31 @@
+//
+//  t_cose_test_crypto.h
+//  t_cose
+//
+//  Created by Laurence Lundblade on 5/30/22.
+//  Copyright © 2022 Laurence Lundblade. All rights reserved.
+//
+
+#ifndef t_cose_test_crypto_h
+#define t_cose_test_crypto_h
+
+
+struct t_cose_test_crypto_context {
+    bool       enable_restart;
+    int32_t    iteration_counter;
+};
+
+
+
+static inline void
+t_cose_test_crypto_restart_init(struct t_cose_test_crypto_context *me,
+                                bool                               enable_restart,
+                                int32_t                            restart_test_iterations)
+{
+    me->enable_restart = enable_restart;
+    me->iteration_counter = restart_test_iterations;
+}
+
+
+
+#endif /* t_cose_test_crypto_h */

--- a/inc/t_cose/t_cose_common.h
+++ b/inc/t_cose/t_cose_common.h
@@ -341,6 +341,13 @@ enum t_cose_err_t {
     /** More than \ref T_COSE_MAX_TAGS_TO_RETURN unprocessed tags when
      * verifying a signature. */
     T_COSE_ERR_TOO_MANY_TAGS = 37,
+
+    /** A signing operation is in progress. The function returning this value
+     * can be called again until it returns \ref T_COSE_SUCCESS or error. */
+    T_COSE_ERR_SIG_IN_PROGRESS = 38,
+
+    /** The operation in this crypto adapter is not implemented.  */
+    T_COSE_ERR_SIGN_RESTART_NOT_SUPPORTED = 39,
 };
 
 

--- a/inc/t_cose/t_cose_sign1_sign.h
+++ b/inc/t_cose/t_cose_sign1_sign.h
@@ -1,7 +1,7 @@
 /*
  * t_cose_sign1_sign.h
  *
- * Copyright (c) 2018-2021, Laurence Lundblade. All rights reserved.
+ * Copyright (c) 2018-2022, Laurence Lundblade. All rights reserved.
  * Copyright (c) 2020, Michael Eckel
  *
  * SPDX-License-Identifier: BSD-3-Clause
@@ -73,6 +73,7 @@ struct t_cose_sign1_sign_ctx {
     struct t_cose_key     signing_key;
     uint32_t              option_flags;
     struct q_useful_buf_c kid;
+    void                 *crypto_context;
 #ifndef T_COSE_DISABLE_CONTENT_TYPE
     uint32_t              content_type_uint;
     const char *          content_type_tstr;
@@ -215,6 +216,33 @@ t_cose_sign1_set_content_type_tstr(struct t_cose_sign1_sign_ctx *context,
 #endif /* T_COSE_DISABLE_CONTENT_TYPE */
 
 
+/**
+ * \brief  Set the crypto adapter context.
+ *
+ * \param[in] context            The t_cose signing context.
+ * \param[in] crypto_context            The crypto adapter context.
+ *
+ * The context pointer set here is passed to the signing operation called
+ * by t_cose. It is just passed through. t_cose does nothing with it.
+ *
+ * This can have many uses. It can provide configuration to the
+ * crypto adapter. It can provide memory or a context structure
+ * for the crypto adapter and algorithm implementation.
+ *
+ * Use of this is always specific to the cryptographic adapter.
+ * The caller must know which adapter is used, what the crypto
+ * context has in it and what can be done with it. The crypto
+ * adapter may provide some methods to initialize this context.
+ *
+ * One example use is for restartarble crypto, crypto that is called
+ * multiple times until it completes. The crypto context can
+ * contain anything that must be retained across calls to the
+ * sign function. It can also contain configuration to turn on
+ * or off the restartable crypto.
+ */
+static inline void
+t_cose_sign1_set_crypto_context(struct t_cose_sign1_sign_ctx *context,
+                                void                         *crypto_context);
 
 /**
  * \brief  Create and sign a \c COSE_Sign1 message with a payload in one call.
@@ -618,6 +646,15 @@ t_cose_sign1_set_content_type_tstr(struct t_cose_sign1_sign_ctx *me,
     me->content_type_tstr = content_type;
 }
 #endif
+
+
+static inline void
+t_cose_sign1_set_crypto_context(struct t_cose_sign1_sign_ctx *me,
+                                 void                         *crypto_context)
+{
+    me->crypto_context = crypto_context;
+}
+
 
 #ifdef __cplusplus
 }

--- a/inc/t_cose/t_cose_sign1_verify.h
+++ b/inc/t_cose/t_cose_sign1_verify.h
@@ -89,6 +89,8 @@ struct t_cose_parameters {
      * parameter is not present */
     struct q_useful_buf_c partial_iv;
 
+    void                  *crypto_context;
+
 #ifndef T_COSE_DISABLE_CONTENT_TYPE
     /** The content type as a MIME type like
      * "text/plain". \c NULL_Q_USEFUL_BUF_C if parameter is not present */
@@ -195,6 +197,7 @@ struct t_cose_sign1_verify_ctx {
     struct t_cose_key     verification_key;
     uint32_t              option_flags;
     uint64_t              auTags[T_COSE_MAX_TAGS_TO_RETURN];
+    void                 *crypto_context;
 };
 
 

--- a/src/t_cose_crypto.h
+++ b/src/t_cose_crypto.h
@@ -214,6 +214,7 @@ t_cose_crypto_sig_size(int32_t            cose_algorithm_id,
 enum t_cose_err_t
 t_cose_crypto_sign(int32_t                cose_algorithm_id,
                    struct t_cose_key      signing_key,
+                   void                  *crypto_context,
                    struct q_useful_buf_c  hash_to_sign,
                    struct q_useful_buf    signature_buffer,
                    struct q_useful_buf_c *signature);
@@ -272,6 +273,7 @@ t_cose_crypto_sign(int32_t                cose_algorithm_id,
 enum t_cose_err_t
 t_cose_crypto_verify(int32_t               cose_algorithm_id,
                      struct t_cose_key     verification_key,
+                     void                  *crypto_context,
                      struct q_useful_buf_c kid,
                      struct q_useful_buf_c hash_to_verify,
                      struct q_useful_buf_c signature);

--- a/src/t_cose_sign1_sign.c
+++ b/src/t_cose_sign1_sign.c
@@ -1,7 +1,7 @@
 /*
  * t_cose_sign1_sign.c
  *
- * Copyright (c) 2018-2021, Laurence Lundblade. All rights reserved.
+ * Copyright (c) 2018-2022, Laurence Lundblade. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *
@@ -380,6 +380,7 @@ t_cose_sign1_encode_signature_aad_internal(struct t_cose_sign1_sign_ctx *me,
             /* Perform the public key signing */
              return_value = t_cose_crypto_sign(me->cose_algorithm_id,
                                                me->signing_key,
+                                               me->crypto_context,
                                                tbs_hash,
                                                buffer_for_signature,
                                               &signature);

--- a/src/t_cose_sign1_verify.c
+++ b/src/t_cose_sign1_verify.c
@@ -346,6 +346,7 @@ t_cose_sign1_verify_internal(struct t_cose_sign1_verify_ctx *me,
     /* -- Verify the signature (if it wasn't short-circuit) -- */
     return_value = t_cose_crypto_verify(parameters.cose_algorithm_id,
                                         me->verification_key,
+                                        me->crypto_context,
                                         parameters.kid,
                                         tbs_hash,
                                         signature);

--- a/t_cose.xcodeproj/project.pbxproj
+++ b/t_cose.xcodeproj/project.pbxproj
@@ -187,6 +187,7 @@
 		E751F9EE27E1F85000EBA5FA /* crypto_values.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = crypto_values.h; path = ../../../../../usr/local/include/psa/crypto_values.h; sourceTree = "<group>"; };
 		E751F9F027E1F90F00EBA5FA /* libmbedcrypto.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libmbedcrypto.a; path = ../../../../../usr/local/lib/libmbedcrypto.a; sourceTree = "<group>"; };
 		E772028523CAEC84006E966E /* t_cose_psa_noss */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = t_cose_psa_noss; sourceTree = BUILT_PRODUCTS_DIR; };
+		E77BE9F52845847500571583 /* t_cose_test_crypto.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = t_cose_test_crypto.h; sourceTree = "<group>"; };
 		E7C960A527F7569500FB537C /* libqcbor.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libqcbor.a; path = ../../../../../usr/local/lib/libqcbor.a; sourceTree = "<group>"; };
 		E7E36E78226CB8400040613B /* t_cose_openssl */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = t_cose_openssl; sourceTree = BUILT_PRODUCTS_DIR; };
 		E7E36E7B226CB8400040613B /* main.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = main.c; sourceTree = "<group>"; };
@@ -363,6 +364,7 @@
 			isa = PBXGroup;
 			children = (
 				E73CDAD223AD4E6D00D262E0 /* t_cose_psa_crypto.c */,
+				E77BE9F52845847500571583 /* t_cose_test_crypto.h */,
 				E7E36EA4226CBB570040613B /* t_cose_test_crypto.c */,
 				E7E36EA3226CBB570040613B /* t_cose_openssl_crypto.c */,
 				E7F70AAC2270D650007CE07F /* b_con_hash */,

--- a/test/run_tests.c
+++ b/test/run_tests.c
@@ -87,6 +87,8 @@ static test_entry s_tests[] = {
     TEST_ENTRY(tags_test),
     TEST_ENTRY(get_size_test),
     TEST_ENTRY(indef_array_and_map_test),
+    TEST_ENTRY(restart_test),
+
 
 #ifdef T_COSE_ENABLE_HASH_FAIL_TEST
     TEST_ENTRY(short_circuit_hash_fail_test),

--- a/test/t_cose_make_test_messages.c
+++ b/test/t_cose_make_test_messages.c
@@ -568,6 +568,7 @@ t_cose_sign1_test_message_output_signature(struct t_cose_sign1_sign_ctx *me,
         /* Normal, non-short-circuit signing */
         return_value = t_cose_crypto_sign(me->cose_algorithm_id,
                                           me->signing_key,
+                                          me->crypto_context,
                                           tbs_hash,
                                           buffer_for_signature,
                                          &signature);

--- a/test/t_cose_test.c
+++ b/test/t_cose_test.c
@@ -1656,3 +1656,64 @@ int32_t indef_array_and_map_test()
 
     return 0;
 }
+
+#include "t_cose_test_crypto.h"
+
+
+int32_t restart_test(void)
+{
+    struct t_cose_test_crypto_context r_context;
+    struct t_cose_sign1_sign_ctx   sign_ctx;
+    enum t_cose_err_t               result;
+    Q_USEFUL_BUF_MAKE_STACK_UB(     signed_cose_buffer, 200);
+    struct q_useful_buf_c           signed_cose;
+    //struct t_cose_sign1_verify_ctx  verify_ctx;
+    //struct q_useful_buf_c           payload;
+    int                             counter;
+
+    t_cose_test_crypto_restart_init(&r_context, true, 5);
+
+    /* --- Make COSE Sign1 object --- */
+     t_cose_sign1_sign_init(&sign_ctx, 0, T_COSE_ALGORITHM_ES256);
+
+     /* No key necessary because short-circuit test mode is used */
+
+    t_cose_sign1_set_crypto_context(&sign_ctx, & r_context);
+
+    counter = 0;
+    do {
+        result = t_cose_sign1_sign(&sign_ctx,
+                                    s_input_payload,
+                                    signed_cose_buffer,
+                                   &signed_cose);
+        counter++;
+    } while(result == T_COSE_ERR_SIG_IN_PROGRESS);
+
+     if(result) {
+         return 1000 + (int32_t)result;
+     }
+     /* --- Done making COSE Sign1 object  --- */
+
+#if 0
+     /* --- Start verifying the COSE Sign1 object  --- */
+     /* Select short circuit signing */
+     t_cose_sign1_verify_init(&verify_ctx, T_COSE_OPT_ALLOW_SHORT_CIRCUIT);
+
+     /* No key necessary with short circuit */
+
+     /* Run the signature verification */
+     result = t_cose_sign1_verify(&verify_ctx,
+                                 /* COSE to verify */
+                                 signed_cose,
+                                 /* The returned payload */
+                                 &payload,
+                                 /* Don't return parameters */
+                                 NULL);
+     if(result) {
+         return 2000 + (int32_t)result;
+     }
+
+#endif
+
+    return 0;
+}

--- a/test/t_cose_test.h
+++ b/test/t_cose_test.h
@@ -155,4 +155,9 @@ int32_t get_size_test(void);
 int32_t indef_array_and_map_test(void);
 
 
+/*
+ *
+ */
+int32_t restart_test(void);
+
 #endif /* t_cose_test_h */


### PR DESCRIPTION
This allows for setting a crypto context that is passed through t_cose to the crypto adapter. The crypto adapter can do a lot of stuff with this.