### PR TITLE
Fix rarely occurring memory leak when using OpenSSL

### DIFF
--- a/crypto_adapters/t_cose_openssl_crypto.c
+++ b/crypto_adapters/t_cose_openssl_crypto.c
@@ -779,6 +779,7 @@ t_cose_crypto_hash_finish(struct t_cose_crypto_hash *hash_ctx,
     unsigned int hash_result_len;
 
     if(!hash_ctx->update_error) {
+        EVP_MD_CTX_free(hash_ctx->evp_ctx);
         return T_COSE_ERR_HASH_GENERAL_FAIL;
     }
 


### PR DESCRIPTION
The hash context memory was leaking when there was the hash function failed.  That is, the leak only occurred when there was already an unrecoverable failure.