### PR TITLE
Align Mac0 function names to convention

### DIFF
--- a/crypto_adapters/t_cose_openssl_crypto.c
+++ b/crypto_adapters/t_cose_openssl_crypto.c
@@ -672,9 +672,9 @@ t_cose_crypto_hash_finish(struct t_cose_crypto_hash *hash_ctx,
 }
 
 enum t_cose_err_t
-t_cose_crypto_hmac_sign_setup(struct t_cose_crypto_hmac *hmac_ctx,
-                              struct t_cose_key          signing_key,
-                              const int32_t              cose_alg_id)
+t_cose_crypto_hmac_compute_setup(struct t_cose_crypto_hmac *hmac_ctx,
+                                 struct t_cose_key          signing_key,
+                                 const int32_t              cose_alg_id)
 {
     (void)hmac_ctx;
     (void)signing_key;
@@ -692,9 +692,9 @@ t_cose_crypto_hmac_update(struct t_cose_crypto_hmac *hmac_ctx,
 }
 
 enum t_cose_err_t
-t_cose_crypto_hmac_sign_finish(struct t_cose_crypto_hmac *hmac_ctx,
-                               struct q_useful_buf        tag_buf,
-                               struct q_useful_buf_c     *tag)
+t_cose_crypto_hmac_compute_finish(struct t_cose_crypto_hmac *hmac_ctx,
+                                  struct q_useful_buf        tag_buf,
+                                  struct q_useful_buf_c     *tag)
 {
     (void)hmac_ctx;
     (void)tag_buf;
@@ -703,22 +703,21 @@ t_cose_crypto_hmac_sign_finish(struct t_cose_crypto_hmac *hmac_ctx,
 }
 
 enum t_cose_err_t
-t_cose_crypto_hmac_verify_setup(struct t_cose_crypto_hmac *hmac_ctx,
-                                const  int32_t             cose_alg_id,
-                                struct t_cose_key          verify_key)
+t_cose_crypto_hmac_validate_setup(struct t_cose_crypto_hmac *hmac_ctx,
+                                  const  int32_t             cose_alg_id,
+                                  struct t_cose_key          validation_key)
 {
     (void)hmac_ctx;
     (void)cose_alg_id;
-    (void)verify_key;
+    (void)validation_key;
     return T_COSE_ERR_UNSUPPORTED_SIGNING_ALG;
 }
 
 enum t_cose_err_t
-t_cose_crypto_hmac_verify_finish(struct t_cose_crypto_hmac *hmac_ctx,
-                                 struct q_useful_buf_c      tag)
+t_cose_crypto_hmac_validate_finish(struct t_cose_crypto_hmac *hmac_ctx,
+                                   struct q_useful_buf_c      tag)
 {
     (void)hmac_ctx;
     (void)tag;
     return T_COSE_ERR_UNSUPPORTED_SIGNING_ALG;
 }
-

--- a/crypto_adapters/t_cose_psa_crypto.c
+++ b/crypto_adapters/t_cose_psa_crypto.c
@@ -458,9 +458,9 @@ psa_status_to_t_cose_error_hmac(psa_status_t status)
  * See documentation in t_cose_crypto.h
  */
 enum t_cose_err_t
-t_cose_crypto_hmac_sign_setup(struct t_cose_crypto_hmac *hmac_ctx,
-                              struct t_cose_key          signing_key,
-                              const int32_t              cose_alg_id)
+t_cose_crypto_hmac_compute_setup(struct t_cose_crypto_hmac *hmac_ctx,
+                                 struct t_cose_key          signing_key,
+                                 const int32_t              cose_alg_id)
 {
     psa_algorithm_t psa_alg;
     psa_status_t psa_ret;
@@ -510,9 +510,9 @@ t_cose_crypto_hmac_update(struct t_cose_crypto_hmac *hmac_ctx,
  * See documentation in t_cose_crypto.h
  */
 enum t_cose_err_t
-t_cose_crypto_hmac_sign_finish(struct t_cose_crypto_hmac *hmac_ctx,
-                               struct q_useful_buf        tag_buf,
-                               struct q_useful_buf_c     *tag)
+t_cose_crypto_hmac_compute_finish(struct t_cose_crypto_hmac *hmac_ctx,
+                                  struct q_useful_buf        tag_buf,
+                                  struct q_useful_buf_c     *tag)
 {
     psa_status_t psa_ret;
 
@@ -530,9 +530,9 @@ t_cose_crypto_hmac_sign_finish(struct t_cose_crypto_hmac *hmac_ctx,
  * See documentation in t_cose_crypto.h
  */
 enum t_cose_err_t
-t_cose_crypto_hmac_verify_setup(struct t_cose_crypto_hmac *hmac_ctx,
-                                const  int32_t             cose_alg_id,
-                                struct t_cose_key          verify_key)
+t_cose_crypto_hmac_validate_setup(struct t_cose_crypto_hmac *hmac_ctx,
+                                  const  int32_t             cose_alg_id,
+                                  struct t_cose_key          validation_key)
 {
     psa_algorithm_t psa_alg;
     psa_status_t psa_ret;
@@ -561,8 +561,8 @@ t_cose_crypto_hmac_verify_setup(struct t_cose_crypto_hmac *hmac_ctx,
     hmac_ctx->op_ctx = psa_mac_operation_init();
 
     psa_ret = psa_mac_verify_setup(&hmac_ctx->op_ctx,
-                                    (psa_key_id_t)verify_key.k.key_handle,
-                                    psa_alg);
+                                   (psa_key_id_t)validation_key.k.key_handle,
+                                   psa_alg);
 
     return psa_status_to_t_cose_error_hmac(psa_ret);
 }
@@ -571,8 +571,8 @@ t_cose_crypto_hmac_verify_setup(struct t_cose_crypto_hmac *hmac_ctx,
  * See documentation in t_cose_crypto.h
  */
 enum t_cose_err_t
-t_cose_crypto_hmac_verify_finish(struct t_cose_crypto_hmac *hmac_ctx,
-                                 struct q_useful_buf_c      tag)
+t_cose_crypto_hmac_validate_finish(struct t_cose_crypto_hmac *hmac_ctx,
+                                   struct q_useful_buf_c      tag)
 {
     psa_status_t psa_ret;
 

--- a/crypto_adapters/t_cose_test_crypto.c
+++ b/crypto_adapters/t_cose_test_crypto.c
@@ -193,9 +193,9 @@ t_cose_crypto_hash_finish(struct t_cose_crypto_hash *hash_ctx,
 }
 
 enum t_cose_err_t
-t_cose_crypto_hmac_sign_setup(struct t_cose_crypto_hmac *hmac_ctx,
-                              struct t_cose_key          signing_key,
-                              const int32_t              cose_alg_id)
+t_cose_crypto_hmac_compute_setup(struct t_cose_crypto_hmac *hmac_ctx,
+                                 struct t_cose_key          signing_key,
+                                 const int32_t              cose_alg_id)
 {
     (void)hmac_ctx;
     (void)signing_key;
@@ -213,9 +213,9 @@ t_cose_crypto_hmac_update(struct t_cose_crypto_hmac *hmac_ctx,
 }
 
 enum t_cose_err_t
-t_cose_crypto_hmac_sign_finish(struct t_cose_crypto_hmac *hmac_ctx,
-                               struct q_useful_buf        tag_buf,
-                               struct q_useful_buf_c     *tag)
+t_cose_crypto_hmac_compute_finish(struct t_cose_crypto_hmac *hmac_ctx,
+                                  struct q_useful_buf        tag_buf,
+                                  struct q_useful_buf_c     *tag)
 {
     (void)hmac_ctx;
     (void)tag_buf;
@@ -224,19 +224,19 @@ t_cose_crypto_hmac_sign_finish(struct t_cose_crypto_hmac *hmac_ctx,
 }
 
 enum t_cose_err_t
-t_cose_crypto_hmac_verify_setup(struct t_cose_crypto_hmac *hmac_ctx,
-                                const  int32_t             cose_alg_id,
-                                struct t_cose_key          verify_key)
+t_cose_crypto_hmac_validate_setup(struct t_cose_crypto_hmac *hmac_ctx,
+                                  const  int32_t             cose_alg_id,
+                                  struct t_cose_key          validation_key)
 {
     (void)hmac_ctx;
     (void)cose_alg_id;
-    (void)verify_key;
+    (void)validation_key;
     return T_COSE_ERR_UNSUPPORTED_SIGNING_ALG;
 }
 
 enum t_cose_err_t
-t_cose_crypto_hmac_verify_finish(struct t_cose_crypto_hmac *hmac_ctx,
-                                 struct q_useful_buf_c      tag)
+t_cose_crypto_hmac_validate_finish(struct t_cose_crypto_hmac *hmac_ctx,
+                                   struct q_useful_buf_c      tag)
 {
     (void)hmac_ctx;
     (void)tag;

--- a/inc/t_cose/t_cose_mac_compute.h
+++ b/inc/t_cose/t_cose_mac_compute.h
@@ -79,25 +79,25 @@ struct t_cose_mac_calculate_ctx {
  */
 enum t_cose_err_t
 t_cose_mac_compute_private(struct t_cose_mac_calculate_ctx *context,
-                      bool                               payload_is_detached,
-                      struct q_useful_buf_c              aad,
-                      struct q_useful_buf_c              payload,
-                      struct q_useful_buf                out_buf,
-                      struct q_useful_buf_c             *result);
+                           bool                             payload_is_detached,
+                           struct q_useful_buf_c            aad,
+                           struct q_useful_buf_c            payload,
+                           struct q_useful_buf              out_buf,
+                           struct q_useful_buf_c           *result);
 
 static enum t_cose_err_t
 t_cose_mac_compute(struct t_cose_mac_calculate_ctx *sign_ctx,
-                    struct q_useful_buf_c        aad,
-                    struct q_useful_buf_c        payload,
-                    struct q_useful_buf          out_buf,
-                    struct q_useful_buf_c       *result);
+                   struct q_useful_buf_c            aad,
+                   struct q_useful_buf_c            payload,
+                   struct q_useful_buf              out_buf,
+                   struct q_useful_buf_c           *result);
 
 static enum t_cose_err_t
 t_cose_mac_compute_detached(struct t_cose_mac_calculate_ctx *sign_ctx,
-                          struct q_useful_buf_c            aad,
-                          struct q_useful_buf_c            datached_payload,
-                          struct q_useful_buf              out_buf,
-                          struct q_useful_buf_c           *result);
+                            struct q_useful_buf_c            aad,
+                            struct q_useful_buf_c            datached_payload,
+                            struct q_useful_buf              out_buf,
+                            struct q_useful_buf_c           *result);
 
 /**
  * \brief  Initialize to start creating a \c COSE_Mac0.
@@ -124,8 +124,8 @@ t_cose_mac_compute_detached(struct t_cose_mac_calculate_ctx *sign_ctx,
  */
 static void
 t_cose_mac_compute_init(struct t_cose_mac_calculate_ctx *context,
-                     uint32_t                    option_flags,
-                     int32_t                     cose_algorithm_id);
+                        uint32_t                         option_flags,
+                        int32_t                          cose_algorithm_id);
 
 /**
  * \brief  Set the key and kid (key ID) for signing.
@@ -143,13 +143,13 @@ t_cose_mac_compute_init(struct t_cose_mac_calculate_ctx *context,
  */
 static void
 t_cose_mac_set_computing_key(struct t_cose_mac_calculate_ctx *context,
-                            struct t_cose_key          signing_key,
-                            struct q_useful_buf_c      kid);
+                             struct t_cose_key                signing_key,
+                             struct q_useful_buf_c            kid);
 
 
 static void
 t_cose_mac_add_body_header_params(struct t_cose_mac_calculate_ctx *context,
-                                   struct t_cose_parameter *parameters);
+                                  struct t_cose_parameter         *parameters);
 
 
 /*
@@ -194,7 +194,7 @@ are replaced with t_cose_sign1_add_body_header_parameters()
  */
 enum t_cose_err_t
 t_cose_mac_encode_parameters(struct t_cose_mac_calculate_ctx *context,
-                              QCBOREncodeContext        *cbor_encode_ctx);
+                             QCBOREncodeContext              *cbor_encode_ctx);
 
 /**
  * \brief Finish a \c COSE_Mac0 message by outputting the authentication tag.
@@ -214,7 +214,7 @@ t_cose_mac_encode_parameters(struct t_cose_mac_calculate_ctx *context,
  */
 enum t_cose_err_t
 t_cose_mac_encode_tag(struct t_cose_mac_calculate_ctx *context,
-                       QCBOREncodeContext        *cbor_encode_ctx);
+                      QCBOREncodeContext              *cbor_encode_ctx);
 
 
 
@@ -226,8 +226,8 @@ t_cose_mac_encode_tag(struct t_cose_mac_calculate_ctx *context,
 
 static inline void
 t_cose_mac_compute_init(struct t_cose_mac_calculate_ctx *me,
-                     uint32_t                    option_flags,
-                     int32_t                     cose_algorithm_id)
+                        uint32_t                         option_flags,
+                        int32_t                          cose_algorithm_id)
 {
     memset(me, 0, sizeof(*me));
     me->cose_algorithm_id = cose_algorithm_id;
@@ -236,8 +236,8 @@ t_cose_mac_compute_init(struct t_cose_mac_calculate_ctx *me,
 
 static inline void
 t_cose_mac_set_computing_key(struct t_cose_mac_calculate_ctx *me,
-                            struct t_cose_key          signing_key,
-                            struct q_useful_buf_c      kid)
+                             struct t_cose_key                signing_key,
+                             struct q_useful_buf_c            kid)
 {
     me->kid         = kid;
     me->signing_key = signing_key;
@@ -246,7 +246,7 @@ t_cose_mac_set_computing_key(struct t_cose_mac_calculate_ctx *me,
 
 static inline void
 t_cose_mac_add_body_header_params(struct t_cose_mac_calculate_ctx *me,
-                                  struct t_cose_parameter *parameters)
+                                  struct t_cose_parameter         *parameters)
 {
     me->added_body_parameters = parameters;
 }
@@ -254,35 +254,33 @@ t_cose_mac_add_body_header_params(struct t_cose_mac_calculate_ctx *me,
 
 static inline enum t_cose_err_t
 t_cose_mac_compute(struct t_cose_mac_calculate_ctx *sign_ctx,
-                    struct q_useful_buf_c        aad,
-                    struct q_useful_buf_c        payload,
-                    struct q_useful_buf          out_buf,
-                    struct q_useful_buf_c       *result){
-    return t_cose_mac_compute_private(
-        sign_ctx,
-        false,
-        aad,
-        payload,
-        out_buf,
-        result
-    );
+                   struct q_useful_buf_c            aad,
+                   struct q_useful_buf_c            payload,
+                   struct q_useful_buf              out_buf,
+                   struct q_useful_buf_c           *result)
+{
+    return t_cose_mac_compute_private(sign_ctx,
+                                      false,
+                                      aad,
+                                      payload,
+                                      out_buf,
+                                      result);
 }
 
 static inline enum t_cose_err_t
 t_cose_mac_compute_detached(struct t_cose_mac_calculate_ctx *sign_ctx,
-                          struct q_useful_buf_c            aad,
-                          struct q_useful_buf_c            detached_payload,
-                          struct q_useful_buf              out_buf,
-                          struct q_useful_buf_c           *result){
+                            struct q_useful_buf_c            aad,
+                            struct q_useful_buf_c            detached_payload,
+                            struct q_useful_buf              out_buf,
+                            struct q_useful_buf_c           *result)
+{
     (void)aad;
-    return t_cose_mac_compute_private(
-        sign_ctx,
-        true,
-        NULL_Q_USEFUL_BUF_C,
-        detached_payload,
-        out_buf,
-        result
-    );
+    return t_cose_mac_compute_private(sign_ctx,
+                                      true,
+                                      NULL_Q_USEFUL_BUF_C,
+                                      detached_payload,
+                                      out_buf,
+                                      result);
 }
 #ifdef __cplusplus
 }

--- a/inc/t_cose/t_cose_mac_validate.h
+++ b/inc/t_cose/t_cose_mac_validate.h
@@ -50,7 +50,7 @@ struct t_cose_mac_validate_ctx {
  */
 static void
 t_cose_mac_validate_init(struct t_cose_mac_validate_ctx *context,
-                        int32_t                      option_flags);
+                         int32_t                         option_flags);
 
 
 /**
@@ -64,7 +64,7 @@ t_cose_mac_validate_init(struct t_cose_mac_validate_ctx *context,
  */
 static void
 t_cose_mac_set_validate_key(struct t_cose_mac_validate_ctx *context,
-                           struct t_cose_key            verify_key);
+                            struct t_cose_key               verify_key);
 
 /**
  * \brief Verify a COSE_Mac0
@@ -98,33 +98,36 @@ t_cose_mac_set_validate_key(struct t_cose_mac_validate_ctx *context,
  * If it is successful, the pointer of the CBOR-encoded payload is
  * returned.
  */
-static enum t_cose_err_t t_cose_mac_validate(struct t_cose_mac_validate_ctx *context,
-                                     struct q_useful_buf_c                   cose_mac,
-                                     struct q_useful_buf_c                   aad,
-                                     struct q_useful_buf_c                  *payload,
-                                     struct t_cose_parameter            **return_params);
+static enum t_cose_err_t
+t_cose_mac_validate(struct t_cose_mac_validate_ctx *context,
+                    struct q_useful_buf_c           cose_mac,
+                    struct q_useful_buf_c           aad,
+                    struct q_useful_buf_c          *payload,
+                    struct t_cose_parameter       **return_params);
 
-static enum t_cose_err_t t_cose_mac_validate_detached(struct t_cose_mac_validate_ctx *context,
-                                     struct q_useful_buf_c                        cose_mac,
-                                     struct q_useful_buf_c                       *detached_payload,
-                                     struct t_cose_parameter                 **return_params);
+static enum t_cose_err_t
+t_cose_mac_validate_detached(struct t_cose_mac_validate_ctx *context,
+                             struct q_useful_buf_c           cose_mac,
+                             struct q_useful_buf_c          *detached_payload,
+                             struct t_cose_parameter       **return_params);
 
-enum t_cose_err_t t_cose_mac_validate_private(struct t_cose_mac_validate_ctx *context,
-                                            struct q_useful_buf_c         cose_mac,
-                                            struct q_useful_buf_c         aad,
-                                            bool                          payload_is_detached,
-                                            struct q_useful_buf_c        *payload,
-                                            struct t_cose_parameter  **return_params);
+enum t_cose_err_t
+t_cose_mac_validate_private(struct t_cose_mac_validate_ctx *context,
+                            struct q_useful_buf_c           cose_mac,
+                            struct q_useful_buf_c           aad,
+                            bool                            payload_is_detached,
+                            struct q_useful_buf_c          *payload,
+                            struct t_cose_parameter       **return_params);
 
 /* ------------------------------------------------------------------------
  * Inline implementations of public functions defined above.
  */
 static inline void
 t_cose_mac_validate_init(struct t_cose_mac_validate_ctx *context,
-                        int32_t                      option_flags)
+                         int32_t                         option_flags)
 {
-    context->option_flags        = option_flags;
-    context->verification_key    = T_COSE_NULL_KEY;
+    context->option_flags              = option_flags;
+    context->verification_key          = T_COSE_NULL_KEY;
     context->parameter_storage.storage = context->__params;
     context->parameter_storage.size    = sizeof(context->__params)/sizeof(struct t_cose_parameter);
     context->parameter_storage.used    = 0;
@@ -132,41 +135,40 @@ t_cose_mac_validate_init(struct t_cose_mac_validate_ctx *context,
 
 static inline void
 t_cose_mac_set_validate_key(struct t_cose_mac_validate_ctx *context,
-                           struct t_cose_key            verify_key)
+                            struct t_cose_key               verify_key)
 {
     context->verification_key = verify_key;
 }
 
 static inline enum t_cose_err_t
 t_cose_mac_validate_detached(struct t_cose_mac_validate_ctx *context,
-                           struct q_useful_buf_c         cose_mac,
-                           struct q_useful_buf_c        *detached_payload,
-                        struct t_cose_parameter     **return_params){
-    return t_cose_mac_validate_private(
-        context,
-        cose_mac,
-        NULL_Q_USEFUL_BUF_C,
-        true,
-        detached_payload,
-        return_params
-    );
+                             struct q_useful_buf_c           cose_mac,
+                             struct q_useful_buf_c          *detached_payload,
+                             struct t_cose_parameter       **return_params)
+{
+    return t_cose_mac_validate_private(context,
+                                       cose_mac,
+                                       NULL_Q_USEFUL_BUF_C,
+                                       true,
+                                       detached_payload,
+                                       return_params);
 }
 
 static inline enum t_cose_err_t
 t_cose_mac_validate(struct t_cose_mac_validate_ctx *context,
-                      struct q_useful_buf_c         cose_mac,
-                      struct q_useful_buf_c         aad,
-                      struct q_useful_buf_c        *payload,
-                      struct t_cose_parameter  **return_params){
-    return t_cose_mac_validate_private(
-        context,
-        cose_mac,
-        aad,
-        false,
-        payload,
-        return_params
-    );
+                    struct q_useful_buf_c           cose_mac,
+                    struct q_useful_buf_c           aad,
+                    struct q_useful_buf_c          *payload,
+                    struct t_cose_parameter       **return_params)
+{
+    return t_cose_mac_validate_private(context,
+                                       cose_mac,
+                                       aad,
+                                       false,
+                                       payload,
+                                       return_params);
 }
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/t_cose_crypto.h
+++ b/src/t_cose_crypto.h
@@ -581,11 +581,11 @@ t_cose_crypto_hash_finish(struct t_cose_crypto_hash *hash_ctx,
                           struct q_useful_buf_c     *hash_result);
 
 /**
- * \brief Set up a multipart HMAC calculation operation
+ * \brief Set up a multipart HMAC calculation operation.
  *
- * \param[in,out] hmac_ctx           Pointer to the HMAC context.
- * \param[in] signing_key            The key for the HMAC operation
- * \param[in] cose_alg_id            The algorithm used in HMAC.
+ * \param[in,out] hmac_ctx      Pointer to the HMAC context.
+ * \param[in] signing_key       The key for the HMAC operation
+ * \param[in] cose_alg_id       The algorithm used in HMAC.
  *
  * \retval T_COSE_SUCCESS
  *         Tag calculation succeeds.
@@ -597,15 +597,15 @@ t_cose_crypto_hash_finish(struct t_cose_crypto_hash *hash_ctx,
  *         Some general failure of the HMAC function.
  */
 enum t_cose_err_t
-t_cose_crypto_hmac_sign_setup(struct t_cose_crypto_hmac *hmac_ctx,
-                              struct t_cose_key          signing_key,
-                              const int32_t              cose_alg_id);
+t_cose_crypto_hmac_compute_setup(struct t_cose_crypto_hmac *hmac_ctx,
+                                 struct t_cose_key          signing_key,
+                                 const int32_t              cose_alg_id);
 
 /**
- * \brief Add a message fragment to a multipart HMAC operation
+ * \brief Add a message fragment to a multipart HMAC operation.
  *
- * \param[in,out] hmac_ctx           Pointer to the HMAC context.
- * \param[in] payload                Pointer and length of payload
+ * \param[in,out] hmac_ctx      Pointer to the HMAC context.
+ * \param[in] payload           Pointer and length of payload
  *
  * \retval T_COSE_SUCCESS
  *         Tag calculation succeeds.
@@ -623,11 +623,11 @@ t_cose_crypto_hmac_update(struct t_cose_crypto_hmac *hmac_ctx,
 /**
  * \brief Finish the calculation of the HMAC of a message.
  *
- * \param[in,out] hmac_ctx           Pointer to the HMAC context.
- * \param[in] tag_buf                Pointer and length into which
- *                                   the resulting tag is put.
- * \param[out] tag                   Pointer and length of the
- *                                   resulting tag.
+ * \param[in,out] hmac_ctx      Pointer to the HMAC context.
+ * \param[in] tag_buf           Pointer and length into which
+ *                              the resulting tag is put.
+ * \param[out] tag              Pointer and length of the
+ *                              resulting tag.
  *
  * \retval T_COSE_SUCCESS
  *         Tag calculation succeeds.
@@ -639,16 +639,16 @@ t_cose_crypto_hmac_update(struct t_cose_crypto_hmac *hmac_ctx,
  *         Some general failure of the HMAC function.
  */
 enum t_cose_err_t
-t_cose_crypto_hmac_sign_finish(struct t_cose_crypto_hmac *hmac_ctx,
-                               struct q_useful_buf        tag_buf,
-                               struct q_useful_buf_c     *tag);
+t_cose_crypto_hmac_compute_finish(struct t_cose_crypto_hmac *hmac_ctx,
+                                  struct q_useful_buf        tag_buf,
+                                  struct q_useful_buf_c     *tag);
 
 /**
- * \brief Set up a multipart HMAC verification operation
+ * \brief Set up a multipart HMAC validation operation.
  *
- * \param[in,out] hmac_ctx           Pointer to the HMAC context.
- * \param[in] cose_alg_id            The algorithm used in HMAC.
- * \param[in] verify_key             Key for HMAC verification
+ * \param[in,out] hmac_ctx      Pointer to the HMAC context.
+ * \param[in] cose_alg_id       The algorithm used in HMAC.
+ * \param[in] validation_key    Key for HMAC validation.
  *
  * \retval T_COSE_SUCCESS
  *         Operation succeeds.
@@ -660,15 +660,15 @@ t_cose_crypto_hmac_sign_finish(struct t_cose_crypto_hmac *hmac_ctx,
  *         Some general failure of the HMAC function.
  */
 enum t_cose_err_t
-t_cose_crypto_hmac_verify_setup(struct t_cose_crypto_hmac *hmac_ctx,
-                                const  int32_t             cose_alg_id,
-                                struct t_cose_key          verify_key);
+t_cose_crypto_hmac_validate_setup(struct t_cose_crypto_hmac *hmac_ctx,
+                                  const  int32_t             cose_alg_id,
+                                  struct t_cose_key          validation_key);
 
 /**
- * \brief Finish the verification of the HMAC of a message.
+ * \brief Finish the validation of the HMAC of a message.
  *
- * \param[in,out] hmac_ctx           Pointer to the HMAC context.
- * \param[in] tag                    Pointer and length of the tag.
+ * \param[in,out] hmac_ctx      Pointer to the HMAC context.
+ * \param[in] tag               Pointer and length of the tag.
  *
  * \retval T_COSE_SUCCESS
  *         Tag calculation succeeds.
@@ -677,11 +677,11 @@ t_cose_crypto_hmac_verify_setup(struct t_cose_crypto_hmac *hmac_ctx,
  * \retval T_COSE_ERR_FAIL
  *         Some general failure of the HMAC function.
  * \retval PSA_ERROR_INVALID_SIGNATURE
- *         HMAC verification failed.
+ *         HMAC validation failed.
  */
 enum t_cose_err_t
-t_cose_crypto_hmac_verify_finish(struct t_cose_crypto_hmac *hmac_ctx,
-                                 struct q_useful_buf_c      tag);
+t_cose_crypto_hmac_validate_finish(struct t_cose_crypto_hmac *hmac_ctx,
+                                   struct q_useful_buf_c      tag);
 
 /**
  * \brief Indicate whether a COSE algorithm is ECDSA or not.

--- a/src/t_cose_mac_compute.c
+++ b/src/t_cose_mac_compute.c
@@ -25,11 +25,11 @@
 
 enum t_cose_err_t
 t_cose_mac_compute_private(struct t_cose_mac_calculate_ctx *context,
-                      bool                               payload_is_detached,
-                      struct q_useful_buf_c              aad,
-                      struct q_useful_buf_c              payload,
-                      struct q_useful_buf                out_buf,
-                      struct q_useful_buf_c             *result)
+                           bool                             payload_is_detached,
+                           struct q_useful_buf_c            aad,
+                           struct q_useful_buf_c            payload,
+                           struct q_useful_buf              out_buf,
+                           struct q_useful_buf_c           *result)
 {
     (void)payload_is_detached;
     (void)aad;
@@ -68,11 +68,10 @@ Done:
 enum t_cose_err_t
 t_cose_mac_encode_parameters(struct t_cose_mac_calculate_ctx *me,
                              QCBOREncodeContext              *cbor_encode_ctx)
-
 {
-    size_t                            tag_len;
-    enum t_cose_err_t                 return_value;
-    struct t_cose_parameter        param_storage[2];
+    size_t                  tag_len;
+    enum t_cose_err_t       return_value;
+    struct t_cose_parameter param_storage[2];
 
     /*
      * Check the algorithm now by getting the algorithm as an early
@@ -99,11 +98,9 @@ t_cose_mac_encode_parameters(struct t_cose_mac_calculate_ctx *me,
 
     t_cose_parameter_list_append(&param_storage[0], me->added_body_parameters);
 
-    return_value = t_cose_encode_headers(
-        cbor_encode_ctx,
-        &param_storage[0],
-       &me->protected_parameters
-    );
+    return_value = t_cose_encode_headers(cbor_encode_ctx,
+                                         &param_storage[0],
+                                         &me->protected_parameters);
 
     /* --- Get started on the payload --- */
     QCBOREncode_BstrWrap(cbor_encode_ctx);
@@ -123,7 +120,6 @@ t_cose_mac_encode_parameters(struct t_cose_mac_calculate_ctx *me,
 enum t_cose_err_t
 t_cose_mac_encode_tag(struct t_cose_mac_calculate_ctx *me,
                       QCBOREncodeContext              *cbor_encode_ctx)
-
 {
     enum t_cose_err_t            return_value;
     QCBORError                   cbor_err;
@@ -182,9 +178,9 @@ t_cose_mac_encode_tag(struct t_cose_mac_calculate_ctx *me,
      * Calculate the tag of the first part of ToBeMaced and the wrapped
      * payload, to save a bigger buffer containing the entire ToBeMaced.
      */
-    return_value = t_cose_crypto_hmac_sign_setup(&hmac_ctx,
-                                                 me->signing_key,
-                                                 me->cose_algorithm_id);
+    return_value = t_cose_crypto_hmac_compute_setup(&hmac_ctx,
+                                                    me->signing_key,
+                                                    me->cose_algorithm_id);
     if(return_value) {
         goto Done;
     }
@@ -206,7 +202,7 @@ t_cose_mac_encode_tag(struct t_cose_mac_calculate_ctx *me,
         goto Done;
     }
 
-    return_value = t_cose_crypto_hmac_sign_finish(&hmac_ctx, tag_buf, &tag);
+    return_value = t_cose_crypto_hmac_compute_finish(&hmac_ctx, tag_buf, &tag);
     if(return_value) {
         goto Done;
     }

--- a/src/t_cose_mac_validate.c
+++ b/src/t_cose_mac_validate.c
@@ -34,12 +34,13 @@
  * at the level above COSE.
  */
 static inline enum t_cose_err_t
-process_tags(struct t_cose_mac_validate_ctx *me, QCBORDecodeContext *decode_context)
+process_tags(struct t_cose_mac_validate_ctx *me,
+             QCBORDecodeContext             *decode_context)
 {
     /* Aproximate stack usage
-     *                                             64-bit      32-bit
-     *   local vars                                    20          16
-     *   TOTAL                                         20          16
+     *                  64-bit      32-bit
+     *   local vars     20          16
+     *   TOTAL          20          16
      */
     uint64_t uTag;
     uint32_t item_tag_index = 0;
@@ -69,7 +70,6 @@ process_tags(struct t_cose_mac_validate_ctx *me, QCBORDecodeContext *decode_cont
     /* If the protocol using COSE doesn't say one way or another about the
      * tag, then either is OK.
      */
-
 
     /* Initialize auTags, the returned tags, to CBOR_TAG_INVALID64 */
 #if CBOR_TAG_INVALID64 != 0xffffffffffffffff
@@ -115,12 +115,13 @@ process_tags(struct t_cose_mac_validate_ctx *me, QCBORDecodeContext *decode_cont
 /*
  * Public function. See t_cose_mac.h
  */
-enum t_cose_err_t t_cose_mac_validate_private(struct t_cose_mac_validate_ctx *context,
-                                            struct q_useful_buf_c         cose_mac,
-                                            struct q_useful_buf_c         aad,
-                                            bool                          payload_is_detached,
-                                            struct q_useful_buf_c        *payload,
-                                            struct t_cose_parameter  **return_params)
+enum t_cose_err_t
+t_cose_mac_validate_private(struct t_cose_mac_validate_ctx *context,
+                            struct q_useful_buf_c           cose_mac,
+                            struct q_useful_buf_c           aad,
+                            bool                            payload_is_detached,
+                            struct q_useful_buf_c          *payload,
+                            struct t_cose_parameter       **return_params)
 {
     (void)aad;
     (void)payload_is_detached;
@@ -135,7 +136,7 @@ enum t_cose_err_t t_cose_mac_validate_private(struct t_cose_mac_validate_ctx *co
     Q_USEFUL_BUF_MAKE_STACK_UB(   tbm_first_part_buf,
                                   T_COSE_SIZE_OF_TBM);
     struct t_cose_crypto_hmac     hmac_ctx;
-    struct t_cose_parameter   *decoded_params;
+    struct t_cose_parameter      *decoded_params;
 
     *payload = NULL_Q_USEFUL_BUF_C;
     decoded_params = NULL; // TODO: check that this is right and necessary
@@ -144,7 +145,9 @@ enum t_cose_err_t t_cose_mac_validate_private(struct t_cose_mac_validate_ctx *co
 
     /* --- The array of 4 and tags --- */
     QCBORDecode_EnterArray(&decode_context, NULL);
-    return_value = qcbor_decode_error_to_t_cose_error(QCBORDecode_GetError(&decode_context), T_COSE_ERR_MAC0_FORMAT);
+    return_value = qcbor_decode_error_to_t_cose_error(
+                                        QCBORDecode_GetError(&decode_context),
+                                        T_COSE_ERR_MAC0_FORMAT);
     if(return_value != T_COSE_SUCCESS) {
         goto Done;
     }
@@ -159,8 +162,8 @@ enum t_cose_err_t t_cose_mac_validate_private(struct t_cose_mac_validate_ctx *co
                           l,
                           NULL,
                           NULL,
-                        &context->parameter_storage,
-                        &decoded_params,
+                          &context->parameter_storage,
+                          &decoded_params,
                           &protected_parameters);
 
     /* --- The payload --- */
@@ -177,7 +180,8 @@ enum t_cose_err_t t_cose_mac_validate_private(struct t_cose_mac_validate_ctx *co
      * makes sure there were no extra bytes. Also that the payload
      * and signature were decoded correctly. */
     qcbor_error = QCBORDecode_Finish(&decode_context);
-    return_value = qcbor_decode_error_to_t_cose_error(qcbor_error, T_COSE_ERR_MAC0_FORMAT);
+    return_value = qcbor_decode_error_to_t_cose_error(qcbor_error,
+                                                      T_COSE_ERR_MAC0_FORMAT);
     if(return_value != T_COSE_SUCCESS) {
         goto Done;
     }
@@ -214,7 +218,7 @@ enum t_cose_err_t t_cose_mac_validate_private(struct t_cose_mac_validate_ctx *co
      * Calculate the tag of the first part of ToBeMaced and the wrapped
      * payload, to save a bigger buffer containing the entire ToBeMaced.
      */
-    return_value = t_cose_crypto_hmac_verify_setup(&hmac_ctx,
+    return_value = t_cose_crypto_hmac_validate_setup(&hmac_ctx,
                                   t_cose_find_parameter_alg_id(decoded_params),
                                   context->verification_key);
     if(return_value) {
@@ -234,7 +238,7 @@ enum t_cose_err_t t_cose_mac_validate_private(struct t_cose_mac_validate_ctx *co
         goto Done;
     }
 
-    return_value = t_cose_crypto_hmac_verify_finish(&hmac_ctx, tag);
+    return_value = t_cose_crypto_hmac_validate_finish(&hmac_ctx, tag);
 
 Done:
     if(return_params != NULL) {
@@ -249,6 +253,5 @@ Done:
 /* So some of the build checks don't get confused by an empty object file */
 void t_cose_mac_validate_placeholder(void)
 {}
-
 
 #endif /* !T_COSE_DISABLE_MAC0 */

--- a/test/run_tests.c
+++ b/test/run_tests.c
@@ -75,9 +75,9 @@ static test_entry s_tests[] = {
 #endif /* T_COSE_DISABLE_SIGN1 */
 
 #ifndef T_COSE_DISABLE_MAC0
-    TEST_ENTRY(sign_verify_mac_basic_test),
-    TEST_ENTRY(sign_verify_mac_sig_fail_test),
-    TEST_ENTRY(sign_verify_get_size_mac_test),
+    TEST_ENTRY(compute_validate_mac_basic_test),
+    TEST_ENTRY(compute_validate_mac_sig_fail_test),
+    TEST_ENTRY(compute_validate_get_size_mac_test),
 #endif /* T_COSE_DISABLE_MAC0 */
 
 #endif /* T_COSE_DISABLE_SIGN_VERIFY_TESTS */

--- a/test/t_cose_compute_validate_mac_test.c
+++ b/test/t_cose_compute_validate_mac_test.c
@@ -20,7 +20,7 @@
 /*
  * Sign and validate a test COSE_Mac0 message with the selected MAC algorithm.
  */
-static int_fast32_t compute_validate_basic_test_alg_mac(uint8_t cose_alg)
+static int_fast32_t compute_validate_basic_test_alg_mac(int32_t cose_alg)
 {
     struct t_cose_mac_calculate_ctx   sign_ctx;
     int32_t                      return_value;
@@ -122,7 +122,7 @@ int_fast32_t compute_validate_mac_sig_fail_test()
     enum t_cose_err_t            result;
     Q_USEFUL_BUF_MAKE_STACK_UB(  signed_cose_buffer, 300);
     struct q_useful_buf_c        signed_cose;
-    struct t_cose_key            key_pair;
+    struct t_cose_key            key;
     struct q_useful_buf_c        payload;
     QCBORError                   cbor_error;
     struct t_cose_mac_validate_ctx verify_ctx;
@@ -132,7 +132,7 @@ int_fast32_t compute_validate_mac_sig_fail_test()
     /* Make an HMAC key that will be used for both signing and
      * verification.
      */
-    result = make_hmac_key(T_COSE_ALGORITHM_HMAC256,&key_pair);
+    result = make_hmac_key(T_COSE_ALGORITHM_HMAC256, &key);
     if(result) {
         return 1000 + (int32_t)result;
     }
@@ -140,7 +140,7 @@ int_fast32_t compute_validate_mac_sig_fail_test()
     QCBOREncode_Init(&cbor_encode, signed_cose_buffer);
 
     t_cose_mac_compute_init(&sign_ctx, 0, T_COSE_ALGORITHM_HMAC256);
-    t_cose_mac_set_computing_key(&sign_ctx, key_pair, NULL_Q_USEFUL_BUF_C);
+    t_cose_mac_set_computing_key(&sign_ctx, key, NULL_Q_USEFUL_BUF_C);
 
     result = t_cose_mac_encode_parameters(&sign_ctx, &cbor_encode);
     if(result) {
@@ -174,7 +174,7 @@ int_fast32_t compute_validate_mac_sig_fail_test()
 
     t_cose_mac_validate_init(&verify_ctx, 0);
 
-    t_cose_mac_set_validate_key(&verify_ctx, key_pair);
+    t_cose_mac_set_validate_key(&verify_ctx, key);
 
     result = t_cose_mac_validate(&verify_ctx,
                                 signed_cose, /* COSE to verify */
@@ -189,7 +189,7 @@ int_fast32_t compute_validate_mac_sig_fail_test()
     return_value = 0;
 
 Done:
-    free_key(key_pair);
+    free_key(key);
 
     return return_value;
 }
@@ -197,7 +197,7 @@ Done:
 
 static int size_test(int32_t               cose_algorithm_id,
                      struct q_useful_buf_c kid,
-                     struct t_cose_key     key_pair)
+                     struct t_cose_key     key)
 {
     struct t_cose_mac_calculate_ctx sign_ctx;
     QCBOREncodeContext         cbor_encode;
@@ -217,7 +217,7 @@ static int size_test(int32_t               cose_algorithm_id,
     QCBOREncode_Init(&cbor_encode, nil_buf);
 
     t_cose_mac_compute_init(&sign_ctx,  0,  cose_algorithm_id);
-    t_cose_mac_set_computing_key(&sign_ctx, key_pair, kid);
+    t_cose_mac_set_computing_key(&sign_ctx, key, kid);
 
     return_value = t_cose_mac_encode_parameters(&sign_ctx, &cbor_encode);
     if(return_value) {
@@ -240,7 +240,7 @@ static int size_test(int32_t               cose_algorithm_id,
     QCBOREncode_Init(&cbor_encode, signed_cose_buffer);
 
     t_cose_mac_compute_init(&sign_ctx, 0, cose_algorithm_id);
-    t_cose_mac_set_computing_key(&sign_ctx, key_pair, kid);
+    t_cose_mac_set_computing_key(&sign_ctx, key, kid);
 
     return_value = t_cose_mac_encode_parameters(&sign_ctx, &cbor_encode);
     if(return_value) {
@@ -261,7 +261,7 @@ static int size_test(int32_t               cose_algorithm_id,
 
     /* ---- Again with one-call API to make COSE_Mac0 ---- */\
     t_cose_mac_compute_init(&sign_ctx, 0, cose_algorithm_id);
-    t_cose_mac_set_computing_key(&sign_ctx, key_pair, kid);
+    t_cose_mac_set_computing_key(&sign_ctx, key, kid);
     return_value = t_cose_mac_compute(&sign_ctx,
                                          NULL_Q_USEFUL_BUF_C,
                                          payload,
@@ -285,46 +285,46 @@ static int size_test(int32_t               cose_algorithm_id,
 int_fast32_t compute_validate_get_size_mac_test()
 {
     enum t_cose_err_t return_value;
-    struct t_cose_key key_pair;
+    struct t_cose_key key;
     int32_t           result;
 
-    return_value = make_hmac_key(T_COSE_ALGORITHM_HMAC256, &key_pair);
+    return_value = make_hmac_key(T_COSE_ALGORITHM_HMAC256, &key);
     if(return_value) {
         return 10000 + (int32_t)return_value;
     }
 
-    result = size_test(T_COSE_ALGORITHM_HMAC256, NULL_Q_USEFUL_BUF_C, key_pair);
-    free_key(key_pair);
+    result = size_test(T_COSE_ALGORITHM_HMAC256, NULL_Q_USEFUL_BUF_C, key);
+    free_key(key);
     if(result) {
         return 20000 + result;
     }
 
-    return_value = make_hmac_key(T_COSE_ALGORITHM_HMAC384, &key_pair);
+    return_value = make_hmac_key(T_COSE_ALGORITHM_HMAC384, &key);
     if(return_value) {
         return 30000 + (int32_t)return_value;
     }
 
-    result = size_test(T_COSE_ALGORITHM_HMAC384, NULL_Q_USEFUL_BUF_C, key_pair);
-    free_key(key_pair);
+    result = size_test(T_COSE_ALGORITHM_HMAC384, NULL_Q_USEFUL_BUF_C, key);
+    free_key(key);
     if(result) {
         return 40000 + result;
     }
 
-    return_value = make_hmac_key(T_COSE_ALGORITHM_HMAC512, &key_pair);
+    return_value = make_hmac_key(T_COSE_ALGORITHM_HMAC512, &key);
     if(return_value) {
         return 50000 + (int32_t)return_value;
     }
 
-    result = size_test(T_COSE_ALGORITHM_HMAC512, NULL_Q_USEFUL_BUF_C, key_pair);
+    result = size_test(T_COSE_ALGORITHM_HMAC512, NULL_Q_USEFUL_BUF_C, key);
     if(result) {
-        free_key(key_pair);
+        free_key(key);
         return 60000 + result;
     }
 
     result = size_test(T_COSE_ALGORITHM_HMAC512,
                        Q_USEFUL_BUF_FROM_SZ_LITERAL("greasy kid stuff"),
-                       key_pair);
-    free_key(key_pair);
+                       key);
+    free_key(key);
     if(result) {
         return 70000 + result;
     }

--- a/test/t_cose_compute_validate_mac_test.c
+++ b/test/t_cose_compute_validate_mac_test.c
@@ -15,14 +15,12 @@
 #include "t_cose_make_test_pub_key.h"
 #include "t_cose_compute_validate_mac_test.h"
 
-#include "t_cose_crypto.h" /* Just for t_cose_crypto_sig_size() */
-
 #ifndef T_COSE_DISABLE_MAC0
 
 /*
- * Public function, see t_cose_compute_validate_mac_test.h
+ * Sign and validate a test COSE_Mac0 message with the selected MAC algorithm.
  */
-int_fast32_t sign_verify_basic_test_alg_mac(uint8_t cose_alg)
+static int_fast32_t compute_validate_basic_test_alg_mac(uint8_t cose_alg)
 {
     struct t_cose_mac_calculate_ctx   sign_ctx;
     int32_t                      return_value;
@@ -90,21 +88,21 @@ Done:
 /*
  * Public function, see t_cose_compute_validate_mac_test.h
  */
-int_fast32_t sign_verify_mac_basic_test()
+int_fast32_t compute_validate_mac_basic_test()
 {
     int_fast32_t return_value;
 
-    return_value  = sign_verify_basic_test_alg_mac(T_COSE_ALGORITHM_HMAC256);
+    return_value  = compute_validate_basic_test_alg_mac(T_COSE_ALGORITHM_HMAC256);
     if(return_value) {
         return 20000 + return_value;
     }
 
-    return_value  = sign_verify_basic_test_alg_mac(T_COSE_ALGORITHM_HMAC384);
+    return_value  = compute_validate_basic_test_alg_mac(T_COSE_ALGORITHM_HMAC384);
     if(return_value) {
         return 30000 + return_value;
     }
 
-    return_value  = sign_verify_basic_test_alg_mac(T_COSE_ALGORITHM_HMAC512);
+    return_value  = compute_validate_basic_test_alg_mac(T_COSE_ALGORITHM_HMAC512);
     if(return_value) {
         return 50000 + return_value;
     }
@@ -116,7 +114,7 @@ int_fast32_t sign_verify_mac_basic_test()
 /*
  * Public function, see t_cose_compute_validate_mac_test.h
  */
-int_fast32_t sign_verify_mac_sig_fail_test()
+int_fast32_t compute_validate_mac_sig_fail_test()
 {
     struct t_cose_mac_calculate_ctx   sign_ctx;
     QCBOREncodeContext           cbor_encode;
@@ -196,9 +194,7 @@ Done:
     return return_value;
 }
 
-/*
- * Public function, see t_cose_compute_validate_mac_test.h
- */
+
 static int size_test(int32_t               cose_algorithm_id,
                      struct q_useful_buf_c kid,
                      struct t_cose_key     key_pair)
@@ -286,7 +282,7 @@ static int size_test(int32_t               cose_algorithm_id,
 /*
  * Public function, see t_cose_compute_validate_mac_test.h
  */
-int_fast32_t sign_verify_get_size_mac_test()
+int_fast32_t compute_validate_get_size_mac_test()
 {
     enum t_cose_err_t return_value;
     struct t_cose_key key_pair;

--- a/test/t_cose_compute_validate_mac_test.h
+++ b/test/t_cose_compute_validate_mac_test.h
@@ -23,22 +23,22 @@
 
 
 /**
- * \brief Self test using integrated  crypto.
+ * \brief Self test using integrated crypto.
  *
  * \return non-zero on failure.
  */
-int_fast32_t sign_verify_mac_basic_test(void);
+int_fast32_t compute_validate_mac_basic_test(void);
 
 
 /*
- * Sign some data, perturb the data and see that sig validation fails
+ * Sign some data, perturb the data and see that sig validation fails.
  */
-int_fast32_t sign_verify_mac_sig_fail_test(void);
+int_fast32_t compute_validate_mac_sig_fail_test(void);
 
 
 /*
- * Test the ability to calculate size of a COSE_Mac0
+ * Test the ability to calculate size of a COSE_Mac0.
  */
-int_fast32_t sign_verify_get_size_mac_test(void);
+int_fast32_t compute_validate_get_size_mac_test(void);
 
 #endif /* t_cose_compute_validate_mac_test_h */

--- a/test/t_cose_make_openssl_test_key.c
+++ b/test/t_cose_make_openssl_test_key.c
@@ -167,9 +167,10 @@ int check_for_key_pair_leaks()
     return 0;
 }
 
-enum t_cose_err_t make_hmac_key(uint8_t cose_alg, struct t_cose_key *res_key)
+enum t_cose_err_t make_hmac_key(int32_t            cose_algorithm_id,
+                                struct t_cose_key *key)
 {
-    (void)cose_alg;
-    (void)res_key;
+    (void)cose_algorithm_id;
+    (void)key;
     return T_COSE_ERR_UNSUPPORTED_SIGNING_ALG;
 }

--- a/test/t_cose_make_psa_test_key.c
+++ b/test/t_cose_make_psa_test_key.c
@@ -178,12 +178,16 @@ enum t_cose_err_t make_ecdsa_key_pair(int32_t            cose_algorithm_id,
     return T_COSE_SUCCESS;
 }
 
-enum t_cose_err_t make_hmac_key(uint8_t cose_alg, struct t_cose_key *res_key)
+/*
+ * Public function, see t_cose_make_test_pub_key.h
+ */
+enum t_cose_err_t make_hmac_key(int32_t            cose_algorithm_id,
+                                struct t_cose_key *key)
 {
     psa_status_t         crypto_result;
     psa_key_handle_t     key_handle;
     psa_algorithm_t      key_alg;
-    const uint8_t       *key;
+    const uint8_t       *key_buf;
     size_t               key_len;
     psa_key_attributes_t key_attributes;
 
@@ -192,20 +196,20 @@ enum t_cose_err_t make_hmac_key(uint8_t cose_alg, struct t_cose_key *res_key)
     static const uint8_t key_384[] = {KEY_hmac384};
     static const uint8_t key_512[] = {KEY_hmac512};
 
-    switch(cose_alg) {
+    switch(cose_algorithm_id) {
     case T_COSE_ALGORITHM_HMAC256:
-        key      = key_256;
+        key_buf  = key_256;
         key_len  = sizeof(key_256);
         key_alg  = PSA_ALG_HMAC(PSA_ALG_SHA_256);
         break;
 
     case T_COSE_ALGORITHM_HMAC384:
-        key     = key_384;
+        key_buf = key_384;
         key_len = sizeof(key_384);
         key_alg = PSA_ALG_HMAC(PSA_ALG_SHA_384);
         break;
     case T_COSE_ALGORITHM_HMAC512:
-        key     = key_512;
+        key_buf = key_512;
         key_len = sizeof(key_512);
         key_alg = PSA_ALG_HMAC(PSA_ALG_SHA_512);
         break;
@@ -243,7 +247,7 @@ enum t_cose_err_t make_hmac_key(uint8_t cose_alg, struct t_cose_key *res_key)
     psa_set_key_algorithm(&key_attributes, key_alg);
 
     crypto_result = psa_import_key(&key_attributes,
-                                    key,
+                                    key_buf,
                                     key_len,
                                    &key_handle);
 
@@ -258,8 +262,8 @@ enum t_cose_err_t make_hmac_key(uint8_t cose_alg, struct t_cose_key *res_key)
      * an linked library. If it is defined, the structure will
      * probably be less than 64 bits, so it can still fit in a
      * t_cose_key. */
-    res_key->k.key_handle = key_handle;
-    res_key->crypto_lib   = T_COSE_CRYPTO_LIB_PSA;
+    key->k.key_handle = key_handle;
+    key->crypto_lib   = T_COSE_CRYPTO_LIB_PSA;
 
     return T_COSE_SUCCESS;
 }

--- a/test/t_cose_make_test_pub_key.h
+++ b/test/t_cose_make_test_pub_key.h
@@ -21,13 +21,18 @@
 
 
 /**
- * \brief make an ECDSA key pair for testing suited to algorim
+ * \brief make an ECDSA key pair for testing suited to algorithm
  *
  */
 enum t_cose_err_t make_ecdsa_key_pair(int32_t            cose_algorithm_id,
                                       struct t_cose_key *key_pair);
 
-enum t_cose_err_t make_hmac_key(uint8_t cose_alg, struct t_cose_key *key);
+/**
+ * \brief make a HMAC secret key for testing suited to algorithm
+ *
+ */
+enum t_cose_err_t make_hmac_key(int32_t            cose_algorithm_id,
+                                struct t_cose_key *key);
 
 void free_key(struct t_cose_key key_pair);
 
@@ -38,6 +43,3 @@ void free_key(struct t_cose_key key_pair);
  \return 0 if no leaks, non-zero if there is a leak.
  */
 int check_for_key_pair_leaks(void);
-
-
-


### PR DESCRIPTION
Resolving issue #103 

- align MAC function names to convention
- fix alignment differences in MAC code for consistency and better readability