### PR TITLE
Reference RFC 9053 in Mac0 code

### DIFF
--- a/crypto_adapters/t_cose_psa_crypto.c
+++ b/crypto_adapters/t_cose_psa_crypto.c
@@ -473,7 +473,7 @@ t_cose_crypto_hmac_sign_setup(struct t_cose_crypto_hmac *hmac_ctx,
 
     /*
      * Verify if HMAC algorithm is valid.
-     * According to COSE (RFC 8152), only SHA-256, SHA-384 and SHA-512 are
+     * According to COSE (RFC 9053), only SHA-256, SHA-384 and SHA-512 are
      * supported in COSE_Mac0 with HMAC.
      */
     if((psa_alg != PSA_ALG_HMAC(PSA_ALG_SHA_256)) &&
@@ -549,7 +549,7 @@ t_cose_crypto_hmac_verify_setup(struct t_cose_crypto_hmac *hmac_ctx,
 
     /*
      * Verify if HMAC algorithm is valid.
-     * According to COSE (RFC 8152), only SHA-256, SHA-384 and SHA-512 are
+     * According to COSE (RFC 9053), only SHA-256, SHA-384 and SHA-512 are
      * supported in HMAC.
      */
     if((psa_alg != PSA_ALG_HMAC(PSA_ALG_SHA_256)) &&

--- a/inc/t_cose/t_cose_mac_compute.h
+++ b/inc/t_cose/t_cose_mac_compute.h
@@ -114,7 +114,7 @@ t_cose_mac_compute_detached(struct t_cose_mac_calculate_ctx *sign_ctx,
  * related for possible option flags.
  *
  * The algorithm ID space is from
- * [COSE (RFC8152)](https://tools.ietf.org/html/rfc8152) and the
+ * [COSE (RFC9053)](https://tools.ietf.org/html/rfc9053) and the
  * [IANA COSE Registry](https://www.iana.org/assignments/cose/cose.xhtml).
  * \ref T_COSE_ALGORITHM_HMAC256 is defined here for convenience.
  * So far, only HMAC is supported in \c COSE_Mac0.


### PR DESCRIPTION
Resolves issue #102

RFC 8152 is obsolete now, it has been replaced by RFC 9052 and 9053.
