### PR TITLE
Use struct instead of 4 params for sig input

### DIFF
--- a/inc/t_cose/t_cose_common.h
+++ b/inc/t_cose/t_cose_common.h
@@ -16,7 +16,8 @@
 #include <stdint.h>
 #include <stdbool.h>
 // TODO: don't think this is needed, but it was added
-//#include "t_cose/q_useful_buf.h"
+// This is now needed for sign_inputs (if it stays in common)
+#include "t_cose/q_useful_buf.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -740,6 +741,23 @@ enum t_cose_err_t {
  */
 bool
 t_cose_is_algorithm_supported(int32_t cose_algorithm_id);
+
+
+/* Structure that holds all the inputs for signing that is
+ * used in a few places (so it ends up in t_cose_common.h.
+ * It is public because it is part of the signer/verify
+ * call back interface.
+ *
+ * These are the inputs to create a Sig_structure
+ * from section 4.4 in RFC 9052.
+ */
+struct t_cose_sign_inputs {
+    struct q_useful_buf_c  body_protected;
+    struct q_useful_buf_c  aad;
+    struct q_useful_buf_c  sign_protected;
+    struct q_useful_buf_c  payload;
+};
+
 
 
 #ifdef __cplusplus

--- a/inc/t_cose/t_cose_signature_sign.h
+++ b/inc/t_cose/t_cose_signature_sign.h
@@ -120,12 +120,10 @@ struct t_cose_signature_sign;
  * being called in size calculation mode.
  */
 typedef enum t_cose_err_t
-t_cose_signature_sign_callback(struct t_cose_signature_sign *me,
-                               uint32_t                      option_flags,
-                               const struct q_useful_buf_c   protected_body_headers,
-                               const struct q_useful_buf_c   aad,
-                               const struct q_useful_buf_c   payload,
-                               QCBOREncodeContext           *qcbor_encoder);
+t_cose_signature_sign_callback(struct t_cose_signature_sign    *me,
+                               uint32_t                         option_flags,
+                               const struct t_cose_sign_inputs *sign_input,
+                               QCBOREncodeContext              *qcbor_encoder);
 
 
 /**

--- a/inc/t_cose/t_cose_signature_verify.h
+++ b/inc/t_cose/t_cose_signature_verify.h
@@ -59,9 +59,7 @@ typedef enum t_cose_err_t
 t_cose_signature_verify_callback(struct t_cose_signature_verify   *me,
                                  uint32_t                          option_flags,
                                  const struct t_cose_header_location loc,
-                                 const struct q_useful_buf_c       protected_body_headers,
-                                 const struct q_useful_buf_c       payload,
-                                 const struct q_useful_buf_c       aad,
+                                 const struct t_cose_sign_inputs *sign_inputs,
                                  struct t_cose_parameter_storage  *params,
                                  QCBORDecodeContext               *qcbor_decoder,
                                  struct t_cose_parameter         **decoded_signature_parameters);
@@ -90,10 +88,7 @@ t_cose_signature_verify_callback(struct t_cose_signature_verify   *me,
 typedef enum t_cose_err_t
 t_cose_signature_verify1_callback(struct t_cose_signature_verify *me,
                                   uint32_t                        option_flags,
-                                  const struct q_useful_buf_c     protected_body_headers,
-                                  const struct q_useful_buf_c     protected_signature_headers,
-                                  const struct q_useful_buf_c     payload,
-                                  const struct q_useful_buf_c     aad,
+                                  const struct t_cose_sign_inputs *sign_inputs,
                                   const struct t_cose_parameter  *parameter_list,
                                   const struct q_useful_buf_c     signature);
 

--- a/src/t_cose_signature_sign_eddsa.c
+++ b/src/t_cose_signature_sign_eddsa.c
@@ -40,12 +40,10 @@ t_cose_eddsa_headers(struct t_cose_signature_sign   *me_x,
  * as a callback via a function pointer that is set up in
  * t_cose_eddsa_signer_init().  */
 static enum t_cose_err_t
-t_cose_eddsa_sign(struct t_cose_signature_sign  *me_x,
-                  uint32_t                       options,
-                  const struct q_useful_buf_c    protected_body_headers,
-                  const struct q_useful_buf_c    aad,
-                  const struct q_useful_buf_c    signed_payload,
-                  QCBOREncodeContext            *qcbor_encoder)
+t_cose_eddsa_sign(struct t_cose_signature_sign    *me_x,
+                  uint32_t                         options,
+                  const struct t_cose_sign_inputs *sign_inputs,
+                  QCBOREncodeContext              *qcbor_encoder)
 {
     struct t_cose_signature_sign_eddsa *me =
                                      (struct t_cose_signature_sign_eddsa *)me_x;
@@ -54,7 +52,7 @@ t_cose_eddsa_sign(struct t_cose_signature_sign  *me_x,
     struct q_useful_buf_c       signature;
     struct q_useful_buf_c       signer_protected_headers;
     struct t_cose_parameter    *parameters;
-    struct q_useful_buf          buffer_for_signature;
+    struct q_useful_buf         buffer_for_signature;
 
 
     /* -- The headers if if is a COSE_Sign -- */
@@ -75,10 +73,7 @@ t_cose_eddsa_sign(struct t_cose_signature_sign  *me_x,
      * If auxiliary_buffer.ptr is NULL this will succeed, computing
      * the necessary size.
      */
-    return_value = create_tbs(protected_body_headers,
-                              aad,
-                              signer_protected_headers,
-                              signed_payload,
+    return_value = create_tbs(sign_inputs,
                               me->auxiliary_buffer,
                              &tbs);
     if (return_value == T_COSE_ERR_TOO_SMALL) {

--- a/src/t_cose_signature_sign_main.c
+++ b/src/t_cose_signature_sign_main.c
@@ -39,12 +39,10 @@ t_cose_main_headers(struct t_cose_signature_sign   *me_x,
  * as a callback via a function pointer that is set up in
  * t_cose_ecdsa_signer_init().  */
 static enum t_cose_err_t
-t_cose_main_sign(struct t_cose_signature_sign  *me_x,
-                  uint32_t                       options,
-                  const struct q_useful_buf_c    protected_body_headers,
-                  const struct q_useful_buf_c    aad,
-                  const struct q_useful_buf_c    signed_payload,
-                  QCBOREncodeContext            *qcbor_encoder)
+t_cose_main_sign(struct t_cose_signature_sign     *me_x,
+                  uint32_t                         options,
+                  const struct t_cose_sign_inputs *sign_inputs,
+                  QCBOREncodeContext              *qcbor_encoder)
 {
     struct t_cose_signature_sign_main *me =
                                      (struct t_cose_signature_sign_main *)me_x;
@@ -93,10 +91,7 @@ t_cose_main_sign(struct t_cose_signature_sign  *me_x,
          * t_cose_sign1_init() so it doesn't need to be checked here.
          */
         return_value = create_tbs_hash(me->cose_algorithm_id,
-                                       protected_body_headers,
-                                       signer_protected_headers,
-                                       aad,
-                                       signed_payload,
+                                       sign_inputs,
                                        buffer_for_tbs_hash,
                                        &tbs_hash);
         if(return_value) {

--- a/src/t_cose_signature_verify_eddsa.c
+++ b/src/t_cose_signature_verify_eddsa.c
@@ -27,10 +27,7 @@
 static enum t_cose_err_t
 t_cose_signature_verify1_eddsa(struct t_cose_signature_verify *me_x,
                                const uint32_t                  option_flags,
-                               const struct q_useful_buf_c     protected_body_headers,
-                               const struct q_useful_buf_c     protected_signature_headers,
-                               const struct q_useful_buf_c     payload,
-                               const struct q_useful_buf_c     aad,
+                               const struct t_cose_sign_inputs *sign_inputs,
                                const struct t_cose_parameter  *parameter_list,
                                const struct q_useful_buf_c     signature)
 {
@@ -61,10 +58,7 @@ t_cose_signature_verify1_eddsa(struct t_cose_signature_verify *me_x,
      * auxiliary_buffer, and we record the size the structure would
      * have occupied).
      */
-    return_value = create_tbs(protected_body_headers,
-                              aad,
-                              protected_signature_headers,
-                              payload,
+    return_value = create_tbs(sign_inputs,
                               me->auxiliary_buffer,
                              &tbs);
     if (return_value == T_COSE_ERR_TOO_SMALL) {
@@ -116,9 +110,7 @@ static enum t_cose_err_t
 t_cose_signature_verify_eddsa_cb(struct t_cose_signature_verify  *me_x,
                               const uint32_t                      option_flags,
                               const struct t_cose_header_location loc,
-                              const struct q_useful_buf_c         protected_body_headers,
-                              const struct q_useful_buf_c         payload,
-                              const struct q_useful_buf_c         aad,
+                              const struct t_cose_sign_inputs    *sign_inputs,
                               struct t_cose_parameter_storage    *param_storage,
                               QCBORDecodeContext                 *qcbor_decoder,
                               struct t_cose_parameter           **decoded_signature_parameters)
@@ -157,10 +149,7 @@ t_cose_signature_verify_eddsa_cb(struct t_cose_signature_verify  *me_x,
 
     return_value = t_cose_signature_verify1_eddsa(me_x,
                                                   option_flags,
-                                                  protected_body_headers,
-                                                  protected_parameters,
-                                                  payload,
-                                                  aad,
+                                                  sign_inputs,
                                                   *decoded_signature_parameters,
                                                   signature);
 Done:

--- a/src/t_cose_signature_verify_main.c
+++ b/src/t_cose_signature_verify_main.c
@@ -24,14 +24,11 @@
  * This is an implementation of t_cose_signature_verify1_callback.
  */
 static enum t_cose_err_t
-t_cose_signature_verify1_main(struct t_cose_signature_verify *me_x,
-                               const uint32_t                  option_flags,
-                               const struct q_useful_buf_c     protected_body_headers,
-                               const struct q_useful_buf_c     protected_signature_headers,
-                               const struct q_useful_buf_c     payload,
-                               const struct q_useful_buf_c     aad,
-                               const struct t_cose_parameter  *parameter_list,
-                               const struct q_useful_buf_c     signature)
+t_cose_signature_verify1_main(struct t_cose_signature_verify   *me_x,
+                               const uint32_t                   option_flags,
+                               const struct t_cose_sign_inputs *sign_inputs,
+                               const struct t_cose_parameter   *parameter_list,
+                               const struct q_useful_buf_c      signature)
 {
     const struct t_cose_signature_verify_main *me =
                           (const struct t_cose_signature_verify_main *)me_x;
@@ -66,10 +63,7 @@ t_cose_signature_verify1_main(struct t_cose_signature_verify *me_x,
 
     /* --- Compute the hash of the to-be-signed bytes -- */
     return_value = create_tbs_hash(cose_algorithm_id,
-                                   protected_body_headers,
-                                   protected_signature_headers,
-                                   aad,
-                                   payload,
+                                   sign_inputs,
                                    tbs_hash_buffer,
                                    &tbs_hash);
     if(return_value != T_COSE_SUCCESS) {
@@ -101,9 +95,7 @@ static enum t_cose_err_t
 t_cose_signature_verify_main(struct t_cose_signature_verify     *me_x,
                               const uint32_t                      option_flags,
                               const struct t_cose_header_location loc,
-                              const struct q_useful_buf_c         protected_body_headers,
-                              const struct q_useful_buf_c         payload,
-                              const struct q_useful_buf_c         aad,
+                              const struct t_cose_sign_inputs    *sign_inputs,
                               struct t_cose_parameter_storage    *param_storage,
                               QCBORDecodeContext                 *qcbor_decoder,
                               struct t_cose_parameter           **decoded_signature_parameters)
@@ -142,13 +134,10 @@ t_cose_signature_verify_main(struct t_cose_signature_verify     *me_x,
 
 
     return_value = t_cose_signature_verify1_main(me_x,
-                                                  option_flags,
-                                                  protected_body_headers,
-                                                  protected_parameters,
-                                                  payload,
-                                                  aad,
-                                                  *decoded_signature_parameters,
-                                                  signature);
+                                                 option_flags,
+                                                 sign_inputs,
+                                                *decoded_signature_parameters,
+                                                 signature);
 Done:
     return return_value;
 }

--- a/src/t_cose_util.c
+++ b/src/t_cose_util.c
@@ -173,24 +173,21 @@ enum t_cose_err_t create_tbm(UsefulBuf                       tbm_first_part_buf,
 // TODO: combine with create_tbm()
 // TODO: disable this when EdDSA is disabled?
 enum t_cose_err_t
-create_tbs(struct q_useful_buf_c  protected_parameters,
-           struct q_useful_buf_c  aad,
-           const struct q_useful_buf_c  sign_protected_parameters,
-           struct q_useful_buf_c  payload,
-           struct q_useful_buf    buffer_for_tbs,
-           struct q_useful_buf_c *tbs)
+create_tbs(const struct t_cose_sign_inputs *sign_inputs,
+           struct q_useful_buf       buffer_for_tbs,
+           struct q_useful_buf_c    *tbs)
 {
     QCBOREncodeContext  cbor_context;
     QCBOREncode_Init(&cbor_context, buffer_for_tbs);
 
     QCBOREncode_OpenArray(&cbor_context);
     QCBOREncode_AddSZString(&cbor_context, COSE_SIG_CONTEXT_STRING_SIGNATURE1);
-    QCBOREncode_AddBytes(&cbor_context, protected_parameters);
-    if(!q_useful_buf_c_is_null(sign_protected_parameters)) {
-        QCBOREncode_AddBytes(&cbor_context, sign_protected_parameters);
+    QCBOREncode_AddBytes(&cbor_context, sign_inputs->body_protected);
+    if(!q_useful_buf_c_is_null(sign_inputs->sign_protected)) {
+        QCBOREncode_AddBytes(&cbor_context, sign_inputs->sign_protected);
     }
-    QCBOREncode_AddBytes(&cbor_context, aad);
-    QCBOREncode_AddBytes(&cbor_context, payload);
+    QCBOREncode_AddBytes(&cbor_context, sign_inputs->aad);
+    QCBOREncode_AddBytes(&cbor_context, sign_inputs->payload);
     QCBOREncode_CloseArray(&cbor_context);
 
     QCBORError cbor_err = QCBOREncode_Finish(&cbor_context, tbs);
@@ -261,13 +258,10 @@ static void hash_bstr(struct t_cose_crypto_hash *hash_ctx,
  */
 // TODO: replace aad, payload, protected with one tbs_input structure
 enum t_cose_err_t
-create_tbs_hash(const int32_t                cose_algorithm_id,
-                const struct q_useful_buf_c  body_protected_parameters,
-                const struct q_useful_buf_c  sign_protected_parameters,
-                const struct q_useful_buf_c  aad,
-                const struct q_useful_buf_c  payload,
-                const struct q_useful_buf    buffer_for_hash,
-                struct q_useful_buf_c       *hash)
+create_tbs_hash(const int32_t             cose_algorithm_id,
+                const struct t_cose_sign_inputs *sign_inputs,
+                const struct q_useful_buf buffer_for_hash,
+                struct q_useful_buf_c    *hash)
 {
     /* Aproximate stack usage
      *                                             64-bit      32-bit
@@ -323,7 +317,7 @@ create_tbs_hash(const int32_t                cose_algorithm_id,
     /* Hand-constructed CBOR for the array of 4 and the context string.
      * \x84 or \x85 is an array of 4 or 5. \x6A is a text string of 10 bytes. */
     // TODO: maybe this can be optimized to one call to hash update
-    if(!q_useful_buf_c_is_null(sign_protected_parameters)) {
+    if(!q_useful_buf_c_is_null(sign_inputs->sign_protected)) {
         t_cose_crypto_hash_update(&hash_ctx, Q_USEFUL_BUF_FROM_SZ_LITERAL("\x85\x6A" COSE_SIG_CONTEXT_STRING_SIGNATURE1));
     } else {
         t_cose_crypto_hash_update(&hash_ctx, Q_USEFUL_BUF_FROM_SZ_LITERAL("\x84\x6A" COSE_SIG_CONTEXT_STRING_SIGNATURE1));
@@ -331,17 +325,17 @@ create_tbs_hash(const int32_t                cose_algorithm_id,
     }
 
     /* body_protected */
-    hash_bstr(&hash_ctx, body_protected_parameters);
+    hash_bstr(&hash_ctx, sign_inputs->body_protected);
 
-    if(!q_useful_buf_c_is_null(sign_protected_parameters)) {
-        hash_bstr(&hash_ctx, sign_protected_parameters);
+    if(!q_useful_buf_c_is_null(sign_inputs->sign_protected)) {
+        hash_bstr(&hash_ctx, sign_inputs->sign_protected);
     }
 
     /* external_aad */
-    hash_bstr(&hash_ctx, aad);
+    hash_bstr(&hash_ctx, sign_inputs->aad);
 
     /* payload */
-    hash_bstr(&hash_ctx, payload);
+    hash_bstr(&hash_ctx, sign_inputs->payload);
 
     /* Finish the hash and set up to return it */
     return_value = t_cose_crypto_hash_finish(&hash_ctx,

--- a/src/t_cose_util.h
+++ b/src/t_cose_util.h
@@ -47,6 +47,8 @@ enum t_cose_tbm_payload_mode_t {
     T_COSE_TBM_BARE_PAYLOAD
 };
 
+
+
 /**
  * This value represents an invalid or in-error algorithm ID.  The
  * value selected is 0 as this is reserved in the IANA COSE algorithm
@@ -166,12 +168,9 @@ enum t_cose_err_t create_tbm(struct q_useful_buf             tbm_first_part_buf,
  * \c aad can be \ref NULL_Q_USEFUL_BUF_C if not present.
  *  \c \sign_protected_parameters can be can be \ref NULL_Q_USEFUL_BUF_C if not present.
  */
-enum t_cose_err_t create_tbs(struct q_useful_buf_c  protected_parameters,
-                             struct q_useful_buf_c  aad,
-                             const struct q_useful_buf_c  sign_protected_parameters,
-                             struct q_useful_buf_c  payload,
-                             struct q_useful_buf    buffer_for_tbs,
-                             struct q_useful_buf_c *tbs);
+enum t_cose_err_t create_tbs(const struct t_cose_sign_inputs *sign_inputs,
+                             struct q_useful_buf              buffer_for_tbs,
+                             struct q_useful_buf_c           *tbs);
 
 
 /**
@@ -209,13 +208,10 @@ enum t_cose_err_t create_tbs(struct q_useful_buf_c  protected_parameters,
  *
  * \c aad can be \ref NULL_Q_USEFUL_BUF_C if not present.
  */
-enum t_cose_err_t create_tbs_hash(int32_t                cose_algorithm_id,
-                                  struct q_useful_buf_c  body_protected_parameters,
-                                  struct q_useful_buf_c  sign_protected_parameters,
-                                  struct q_useful_buf_c  aad,
-                                  struct q_useful_buf_c  payload,
-                                  struct q_useful_buf    buffer_for_hash,
-                                  struct q_useful_buf_c *hash);
+enum t_cose_err_t create_tbs_hash(int32_t                   cose_algorithm_id,
+                                  const struct t_cose_sign_inputs *sign_inputs,
+                                  struct q_useful_buf       buffer_for_hash,
+                                  struct q_useful_buf_c    *hash);
 
 
 

--- a/test/t_cose_make_test_messages.c
+++ b/test/t_cose_make_test_messages.c
@@ -449,6 +449,7 @@ t_cose_sign1_test_message_output_signature(struct t_cose_sign1_sign_ctx *me,
     /* Buffer for the tbs hash. */
     Q_USEFUL_BUF_MAKE_STACK_UB(  buffer_for_tbs_hash, T_COSE_CRYPTO_MAX_HASH_SIZE);
     struct q_useful_buf_c        signed_payload;
+    struct t_cose_sign_inputs           sign_inputs;
 
     QCBOREncode_CloseBstrWrap2(cbor_encode_ctx, false, &signed_payload);
 
@@ -472,11 +473,13 @@ t_cose_sign1_test_message_output_signature(struct t_cose_sign1_sign_ctx *me,
      * cose_algorithm_id was checked in t_cose_sign1_init() so it
      * doesn't need to be checked here.
      */
+    sign_inputs.body_protected = me->protected_parameters;
+    sign_inputs.aad            = NULL_Q_USEFUL_BUF_C;
+    sign_inputs.sign_protected = NULL_Q_USEFUL_BUF_C;
+    sign_inputs.payload        = signed_payload;
+
     return_value = create_tbs_hash(me->cose_algorithm_id,
-                                   me->protected_parameters,
-                                   NULL_Q_USEFUL_BUF_C,
-                                   NULL_Q_USEFUL_BUF_C,
-                                   signed_payload,
+                                   &sign_inputs,
                                    buffer_for_tbs_hash,
                                    &tbs_hash);
     if(return_value != T_COSE_SUCCESS) {


### PR DESCRIPTION
The main point of this is to save object code (and make interfaces a little prettier).  It saves about 150 bytes on both signature encode and decode.