### PR TITLE
Make signer/verify abstract interface better

### DIFF
--- a/inc/t_cose/t_cose_common.h
+++ b/inc/t_cose/t_cose_common.h
@@ -16,7 +16,8 @@
 #include <stdint.h>
 #include <stdbool.h>
 // TODO: don't think this is needed, but it was added
-//#include "t_cose/q_useful_buf.h"
+// This is now needed for sign_inputs (if it stays in common)
+#include "t_cose/q_useful_buf.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -740,6 +741,23 @@ enum t_cose_err_t {
  */
 bool
 t_cose_is_algorithm_supported(int32_t cose_algorithm_id);
+
+
+/* Structure that holds all the inputs for signing that is
+ * used in a few places (so it ends up in t_cose_common.h.
+ * It is public because it is part of the signer/verify
+ * call back interface.
+ *
+ * These are the inputs to create a Sig_structure
+ * from section 4.4 in RFC 9052.
+ */
+struct t_cose_sign_inputs {
+    struct q_useful_buf_c  body_protected;
+    struct q_useful_buf_c  aad;
+    struct q_useful_buf_c  sign_protected;
+    struct q_useful_buf_c  payload;
+};
+
 
 
 #ifdef __cplusplus

--- a/inc/t_cose/t_cose_common.h
+++ b/inc/t_cose/t_cose_common.h
@@ -750,6 +750,14 @@ t_cose_is_algorithm_supported(int32_t cose_algorithm_id);
  *
  * These are the inputs to create a Sig_structure
  * from section 4.4 in RFC 9052.
+ *
+ * aad and sign_protected may be \ref NULL_Q_USEFUL_BUF_C.
+ *
+ * payload is a CBOR encoded byte string that may
+ * contain CBOR or other.
+ *
+ * body_protected are the byte-string wrapped protected
+ * header parameters from the COSE_Sign or COSE_Sign1.
  */
 struct t_cose_sign_inputs {
     struct q_useful_buf_c  body_protected;

--- a/inc/t_cose/t_cose_signature_sign.h
+++ b/inc/t_cose/t_cose_signature_sign.h
@@ -100,12 +100,7 @@ struct t_cose_signature_sign;
  * \Param[in] option_flags           Option flags from t_cose_sign_verify_init().
  *                                   Primarily to check whether to make a
  *                                   COSE_Sign or COSE_Sign1.
- * \param[in] protected_body_headers The COSE_Sign body headers covered by the
- *                                   signature
- * \param[in] payload                The payload (regular or detached) that
- *                                   is covered by the signature.
- * \param[in] aad                    The aad covered by the signature. May
- *                                   be \ref NULL_Q_USEFUL_BUF_C
+ * \param[in] sign_inputs            Payload, aad and header parameters to sign.
  * \param[in] qcbor_encoder          The CBOR encoder context to ouput either
  *                                   a COSE_Signature or the simple byte
  *                                   string signature for a COSE_Sign1.
@@ -122,7 +117,7 @@ struct t_cose_signature_sign;
 typedef enum t_cose_err_t
 t_cose_signature_sign_callback(struct t_cose_signature_sign    *me,
                                uint32_t                         option_flags,
-                               const struct t_cose_sign_inputs *sign_input,
+                               const struct t_cose_sign_inputs *sign_inputs,
                                QCBOREncodeContext              *qcbor_encoder);
 
 

--- a/inc/t_cose/t_cose_signature_sign.h
+++ b/inc/t_cose/t_cose_signature_sign.h
@@ -120,12 +120,10 @@ struct t_cose_signature_sign;
  * being called in size calculation mode.
  */
 typedef enum t_cose_err_t
-t_cose_signature_sign_callback(struct t_cose_signature_sign *me,
-                               uint32_t                      option_flags,
-                               const struct q_useful_buf_c   protected_body_headers,
-                               const struct q_useful_buf_c   aad,
-                               const struct q_useful_buf_c   payload,
-                               QCBOREncodeContext           *qcbor_encoder);
+t_cose_signature_sign_callback(struct t_cose_signature_sign    *me,
+                               uint32_t                         option_flags,
+                               const struct t_cose_sign_inputs *sign_input,
+                               QCBOREncodeContext              *qcbor_encoder);
 
 
 /**

--- a/inc/t_cose/t_cose_signature_verify.h
+++ b/inc/t_cose/t_cose_signature_verify.h
@@ -19,7 +19,7 @@
 /*
  * This is the abstract base class that t_cose_sign_verify
  * calls to run signature verification. A concrete
- * implementation of this is needed.
+ * implementation of this must be created in actual use.
  *
  * Implementations may choose to support only COSE_Sign1,
  * only COSE_Signature/COSE_Sign or both. They are encouraged to
@@ -49,16 +49,16 @@ struct t_cose_signature_verify;
  * \param[in] params                  The place to put the decoded params.
  * \param[in] qcbor_decoder           The decoder instance from where the
  *                                     COSE_Signature is decoded.
- * \param[out] decoded_signature_parameters  Linked list of decoded parameters.
+ * \param[out] decoded_params  Returned linked list of decoded parameters.
  */
 typedef enum t_cose_err_t
-t_cose_signature_verify_callback(struct t_cose_signature_verify   *me,
-                                 uint32_t                          option_flags,
-                                 const struct t_cose_header_location loc,
-                                 const struct t_cose_sign_inputs *sign_inputs,
-                                 struct t_cose_parameter_storage  *params,
-                                 QCBORDecodeContext               *qcbor_decoder,
-                                 struct t_cose_parameter         **decoded_signature_parameters);
+t_cose_signature_verify_cb(struct t_cose_signature_verify     *me,
+                           uint32_t                            option_flags,
+                           const struct t_cose_header_location loc,
+                           const struct t_cose_sign_inputs    *sign_inputs,
+                           struct t_cose_parameter_storage    *params,
+                           QCBORDecodeContext                 *qcbor_decoder,
+                           struct t_cose_parameter           **decoded_params);
 
 
 /**
@@ -74,26 +74,28 @@ t_cose_signature_verify_callback(struct t_cose_signature_verify   *me,
  *                                     found.
  * \param[in] signature                The signature.
  *
- * This is very different from t_cose_signature_verify_callback
+ * This is very different from t_cose_signature_verify_cb()
  * because there is no header decoding to be done. Instead the headers
  * are decoded outside of this and passed in.
  */
 typedef enum t_cose_err_t
-t_cose_signature_verify1_callback(struct t_cose_signature_verify *me,
-                                  uint32_t                        option_flags,
-                                  const struct t_cose_sign_inputs *sign_inputs,
-                                  const struct t_cose_parameter  *parameter_list,
-                                  const struct q_useful_buf_c     signature);
+t_cose_signature_verify1_cb(struct t_cose_signature_verify *me,
+                            uint32_t                        option_flags,
+                            const struct t_cose_sign_inputs *sign_inputs,
+                            const struct t_cose_parameter  *parameter_list,
+                            const struct q_useful_buf_c     signature);
 
 
 /**
  * Data structture that must be the first part of every context of every concrete
- * implementation of t_cose_signature_verify.
+ * implementation of t_cose_signature_verify. Callback functions must not
+ * be NULL, but can be stubs that return an error when COSE_SIgn1 or COSE_Sign
+ * are not supported.
  */
 struct t_cose_signature_verify {
-    t_cose_signature_verify_callback  *callback; /* some will call this a vtable with two entries */
-    t_cose_signature_verify1_callback *callback1;
-    struct t_cose_signature_verify    *next_in_list; /* Linked list of signers */
+    t_cose_signature_verify_cb      *verify_cb;
+    t_cose_signature_verify1_cb     *verify1_cb;
+    struct t_cose_signature_verify  *next_in_list; /* Linked list of signers */
 };
 
 

--- a/inc/t_cose/t_cose_signature_verify.h
+++ b/inc/t_cose/t_cose_signature_verify.h
@@ -15,8 +15,6 @@
 
 #include "t_cose/t_cose_parameters.h"
 
-/* Warning: this is still early development. Documentation may be incorrect. */
-
 
 /*
  * This is the abstract base class that t_cose_sign_verify
@@ -47,9 +45,7 @@ struct t_cose_signature_verify;
  *                                    t_cose_signature_verify.
  * \param[in] option_flags          Option flags from t_cose_sign_verify_init(). Mostly for \ref T_COSE_OPT_DECODE_ONLY.
  * \param[in] loc                     The location of the signature inside the COSE_Sign.
- * \param[in] protected_body_headers  Body headers from COSE_Signature to verify
- * \param[in] payload                 The payload to verify (regular or detached)
- * \param[in] aad                     The aad to verify
+ * \param[in] sign_inputs             Payload, aad and header parameters to verify.
  * \param[in] params                  The place to put the decoded params.
  * \param[in] qcbor_decoder           The decoder instance from where the
  *                                     COSE_Signature is decoded.
@@ -73,10 +69,7 @@ t_cose_signature_verify_callback(struct t_cose_signature_verify   *me,
  *                                     t_cose_signature_verify_main that inplements
  *                                     t_cose_signature_verify.
  * \param[in] option_flags          Option flags from t_cose_sign_verify_init(). Mostly for \ref T_COSE_OPT_DECODE_ONLY.
- * \param[in] protected_body_headers   Encoded body headers from COSE_Signature to verify
- * \param[in] protected_signature_headers Headers from COSE_Signature.
- * \param[in] payload                  The payload to verify (regular or detached)
- * \param[in] aad                      The aad to verify
+ * \param[in] sign_inputs             Payload, aad and header parameters to verify.
  * \param[in] parameter_list           Parameter list in which algorithm and kid is
  *                                     found.
  * \param[in] signature                The signature.

--- a/inc/t_cose/t_cose_signature_verify.h
+++ b/inc/t_cose/t_cose_signature_verify.h
@@ -59,9 +59,7 @@ typedef enum t_cose_err_t
 t_cose_signature_verify_callback(struct t_cose_signature_verify   *me,
                                  uint32_t                          option_flags,
                                  const struct t_cose_header_location loc,
-                                 const struct q_useful_buf_c       protected_body_headers,
-                                 const struct q_useful_buf_c       payload,
-                                 const struct q_useful_buf_c       aad,
+                                 const struct t_cose_sign_inputs *sign_inputs,
                                  struct t_cose_parameter_storage  *params,
                                  QCBORDecodeContext               *qcbor_decoder,
                                  struct t_cose_parameter         **decoded_signature_parameters);
@@ -90,10 +88,7 @@ t_cose_signature_verify_callback(struct t_cose_signature_verify   *me,
 typedef enum t_cose_err_t
 t_cose_signature_verify1_callback(struct t_cose_signature_verify *me,
                                   uint32_t                        option_flags,
-                                  const struct q_useful_buf_c     protected_body_headers,
-                                  const struct q_useful_buf_c     protected_signature_headers,
-                                  const struct q_useful_buf_c     payload,
-                                  const struct q_useful_buf_c     aad,
+                                  const struct t_cose_sign_inputs *sign_inputs,
                                   const struct t_cose_parameter  *parameter_list,
                                   const struct q_useful_buf_c     signature);
 

--- a/src/t_cose_sign_verify.c
+++ b/src/t_cose_sign_verify.c
@@ -238,11 +238,11 @@ t_cose_sign_verify_private(struct t_cose_sign_verify_ctx  *me,
              * the main method of the cose_signature_verify. This
              * will compute the tbs value and call the crypto.
              */
-            verify_error = verifier->callback1(verifier,
-                                               me->option_flags,
-                                              &sign_inputs,
-                                               decoded_body_parameter_list,
-                                               signature);
+            verify_error = verifier->verify1_cb(verifier,
+                                                me->option_flags,
+                                               &sign_inputs,
+                                                decoded_body_parameter_list,
+                                                signature);
             if(verify_error == T_COSE_SUCCESS) {
                 break;
             }
@@ -274,13 +274,13 @@ t_cose_sign_verify_private(struct t_cose_sign_verify_ctx  *me,
 
                 /* This call decodes one array entry containing a
                  * COSE_Signature. */
-                return_value = verifier->callback(verifier,
-                                                  me->option_flags,
-                                                  header_location,
-                                                  &sign_inputs,
-                                                  me->p_storage,
-                                                 &decode_context,
-                                                 &decoded_sig_parameter_list);
+                return_value = verifier->verify_cb(verifier,
+                                                   me->option_flags,
+                                                   header_location,
+                                                   &sign_inputs,
+                                                   me->p_storage,
+                                                  &decode_context,
+                                                  &decoded_sig_parameter_list);
 
                 // TODO: this may not be in the right place
                 t_cose_parameter_list_append(decoded_body_parameter_list,

--- a/src/t_cose_signature_sign_eddsa.c
+++ b/src/t_cose_signature_sign_eddsa.c
@@ -73,9 +73,7 @@ t_cose_eddsa_sign(struct t_cose_signature_sign    *me_x,
      * If auxiliary_buffer.ptr is NULL this will succeed, computing
      * the necessary size.
      */
-    return_value = create_tbs(sign_inputs,
-                              me->auxiliary_buffer,
-                             &tbs);
+    return_value = create_tbs(sign_inputs, me->auxiliary_buffer, &tbs);
     if (return_value == T_COSE_ERR_TOO_SMALL) {
         /* Be a bit more specific about which buffer is too small */
         return_value = T_COSE_ERR_AUXILIARY_BUFFER_SIZE;

--- a/src/t_cose_signature_sign_eddsa.c
+++ b/src/t_cose_signature_sign_eddsa.c
@@ -19,8 +19,8 @@
 
 
 static void
-t_cose_eddsa_headers(struct t_cose_signature_sign   *me_x,
-                     struct t_cose_parameter       **params)
+t_cose_signature_sign_headers_eddsa_cb(struct t_cose_signature_sign   *me_x,
+                                       struct t_cose_parameter       **params)
 {
     // TODO: this is the same as the main signer (formerly the ecdsa signer) reuse?
     struct t_cose_signature_sign_eddsa *me =
@@ -36,38 +36,17 @@ t_cose_eddsa_headers(struct t_cose_signature_sign   *me_x,
 }
 
 
-/* While this is a private function, it is called externally
- * as a callback via a function pointer that is set up in
- * t_cose_eddsa_signer_init().  */
 static enum t_cose_err_t
-t_cose_eddsa_sign(struct t_cose_signature_sign    *me_x,
-                  uint32_t                         options,
-                  const struct t_cose_sign_inputs *sign_inputs,
-                  QCBOREncodeContext              *qcbor_encoder)
+t_cose_signature_sign1_eddsa_cb(struct t_cose_signature_sign    *me_x,
+                                const struct t_cose_sign_inputs *sign_inputs,
+                                QCBOREncodeContext              *qcbor_encoder)
 {
     struct t_cose_signature_sign_eddsa *me =
                                      (struct t_cose_signature_sign_eddsa *)me_x;
     enum t_cose_err_t           return_value;
     struct q_useful_buf_c       tbs;
     struct q_useful_buf_c       signature;
-    struct q_useful_buf_c       signer_protected_headers;
-    struct t_cose_parameter    *parameters;
     struct q_useful_buf         buffer_for_signature;
-
-
-    /* -- The headers if if is a COSE_Sign -- */
-    signer_protected_headers = NULLUsefulBufC;
-    if(T_COSE_OPT_IS_SIGN(options)) {
-        /* COSE_Sign, so making a COSE_Signature  */
-        QCBOREncode_OpenArray(qcbor_encoder);
-
-        t_cose_eddsa_headers(me_x, &parameters);
-        t_cose_parameter_list_append(parameters, me->added_signer_params);
-
-        t_cose_encode_headers(qcbor_encoder,
-                              parameters,
-                              &signer_protected_headers);
-    }
 
     /* Serialize the TBS data into the auxiliary buffer.
      * If auxiliary_buffer.ptr is NULL this will succeed, computing
@@ -82,47 +61,70 @@ t_cose_eddsa_sign(struct t_cose_signature_sign    *me_x,
         goto Done;
     }
 
-
     /* Record how much buffer we actually used / would have used,
-     * allowing the caller to allocate an appropriately sized buffer.
-     * This is particularly useful when buffer_for_signature.ptr is
-     * NULL and no signing is actually taking place yet.
-     */
-    me->auxiliary_buffer_size = tbs.len;
+      * allowing the caller to allocate an appropriately sized buffer.
+      * This is particularly useful when buffer_for_signature.ptr is
+      * NULL and no signing is actually taking place yet.
+      */
+     me->auxiliary_buffer_size = tbs.len;
 
-    QCBOREncode_OpenBytes(qcbor_encoder, &buffer_for_signature);
-
-
-    if (buffer_for_signature.ptr == NULL) {
-        /* Output size calculation. Only need signature size. */
-        signature.ptr = NULL;
-        // TODO: an eddsa-specific size calculator?
-        return_value  = t_cose_crypto_sig_size(T_COSE_ALGORITHM_EDDSA,
-                                               me->signing_key,
-                                               &signature.len);
-    } else if (me->auxiliary_buffer.ptr == NULL) {
-        /* Without a real auxiliary buffer, we have nothing to sign. */
-        return_value = T_COSE_ERR_NEED_AUXILIARY_BUFFER;
-    } else {
-        /* Perform the public key signing over the TBS bytes we just
-         * serialized.
-         */
-        return_value = t_cose_crypto_sign_eddsa(me->signing_key,
-                                                tbs,
-                                                buffer_for_signature,
-                                                &signature);
-    }
-
-    QCBOREncode_CloseBytes(qcbor_encoder, signature.len);
+     QCBOREncode_OpenBytes(qcbor_encoder, &buffer_for_signature);
 
 
-    /* -- If a COSE_Sign, close of the COSE_Signature */
-    if(T_COSE_OPT_IS_SIGN(options)) {
-        QCBOREncode_CloseArray(qcbor_encoder);
-    }
-    // TODO: lots of error handling
+     if (buffer_for_signature.ptr == NULL) {
+         /* Output size calculation. Only need signature size. */
+         signature.ptr = NULL;
+         // TODO: an eddsa-specific size calculator?
+         return_value  = t_cose_crypto_sig_size(T_COSE_ALGORITHM_EDDSA,
+                                                me->signing_key,
+                                                &signature.len);
+     } else if (me->auxiliary_buffer.ptr == NULL) {
+         /* Without a real auxiliary buffer, we have nothing to sign. */
+         return_value = T_COSE_ERR_NEED_AUXILIARY_BUFFER;
+     } else {
+         /* Perform the public key signing over the TBS bytes we just
+          * serialized.
+          */
+         return_value = t_cose_crypto_sign_eddsa(me->signing_key,
+                                                 tbs,
+                                                 buffer_for_signature,
+                                                 &signature);
+     }
+
+     QCBOREncode_CloseBytes(qcbor_encoder, signature.len);
 
 Done:
+    return return_value;
+
+}
+
+/* While this is a private function, it is called externally
+ * as a callback via a function pointer that is set up in
+ * t_cose_eddsa_signer_init().  */
+static enum t_cose_err_t
+t_cose_signature_sign_eddsa_cb(struct t_cose_signature_sign  *me_x,
+                               struct t_cose_sign_inputs     *sign_inputs,
+                               QCBOREncodeContext            *qcbor_encoder)
+{
+    struct t_cose_signature_sign_eddsa *me =
+                                     (struct t_cose_signature_sign_eddsa *)me_x;
+    enum t_cose_err_t           return_value;
+    struct t_cose_parameter    *parameters;
+
+    QCBOREncode_OpenArray(qcbor_encoder);
+
+    t_cose_signature_sign_headers_eddsa_cb(me_x, &parameters);
+    t_cose_parameter_list_append(parameters, me->added_signer_params);
+    t_cose_encode_headers(qcbor_encoder,
+                          parameters,
+                          &sign_inputs->sign_protected);
+
+    return_value = t_cose_signature_sign1_eddsa_cb(me_x,
+                                                   sign_inputs,
+                                                   qcbor_encoder);
+
+    QCBOREncode_CloseArray(qcbor_encoder);
+
     return return_value;
 }
 
@@ -131,6 +133,7 @@ void
 t_cose_signature_sign_eddsa_init(struct t_cose_signature_sign_eddsa *me)
 {
     memset(me, 0, sizeof(*me));
-    me->s.callback        = t_cose_eddsa_sign;
-    me->s.h_callback      = t_cose_eddsa_headers;
+    me->s.sign_cb    = t_cose_signature_sign_eddsa_cb;
+    me->s.sign1_cb   = t_cose_signature_sign1_eddsa_cb;
+    me->s.headers_cb = t_cose_signature_sign_headers_eddsa_cb;
 }

--- a/src/t_cose_signature_sign_eddsa.c
+++ b/src/t_cose_signature_sign_eddsa.c
@@ -40,12 +40,10 @@ t_cose_eddsa_headers(struct t_cose_signature_sign   *me_x,
  * as a callback via a function pointer that is set up in
  * t_cose_eddsa_signer_init().  */
 static enum t_cose_err_t
-t_cose_eddsa_sign(struct t_cose_signature_sign  *me_x,
-                  uint32_t                       options,
-                  const struct q_useful_buf_c    protected_body_headers,
-                  const struct q_useful_buf_c    aad,
-                  const struct q_useful_buf_c    signed_payload,
-                  QCBOREncodeContext            *qcbor_encoder)
+t_cose_eddsa_sign(struct t_cose_signature_sign    *me_x,
+                  uint32_t                         options,
+                  const struct t_cose_sign_inputs *sign_inputs,
+                  QCBOREncodeContext              *qcbor_encoder)
 {
     struct t_cose_signature_sign_eddsa *me =
                                      (struct t_cose_signature_sign_eddsa *)me_x;
@@ -54,7 +52,7 @@ t_cose_eddsa_sign(struct t_cose_signature_sign  *me_x,
     struct q_useful_buf_c       signature;
     struct q_useful_buf_c       signer_protected_headers;
     struct t_cose_parameter    *parameters;
-    struct q_useful_buf          buffer_for_signature;
+    struct q_useful_buf         buffer_for_signature;
 
 
     /* -- The headers if if is a COSE_Sign -- */
@@ -75,10 +73,7 @@ t_cose_eddsa_sign(struct t_cose_signature_sign  *me_x,
      * If auxiliary_buffer.ptr is NULL this will succeed, computing
      * the necessary size.
      */
-    return_value = create_tbs(protected_body_headers,
-                              aad,
-                              signer_protected_headers,
-                              signed_payload,
+    return_value = create_tbs(sign_inputs,
                               me->auxiliary_buffer,
                              &tbs);
     if (return_value == T_COSE_ERR_TOO_SMALL) {

--- a/src/t_cose_signature_sign_main.c
+++ b/src/t_cose_signature_sign_main.c
@@ -39,12 +39,10 @@ t_cose_main_headers(struct t_cose_signature_sign   *me_x,
  * as a callback via a function pointer that is set up in
  * t_cose_ecdsa_signer_init().  */
 static enum t_cose_err_t
-t_cose_main_sign(struct t_cose_signature_sign  *me_x,
-                  uint32_t                       options,
-                  const struct q_useful_buf_c    protected_body_headers,
-                  const struct q_useful_buf_c    aad,
-                  const struct q_useful_buf_c    signed_payload,
-                  QCBOREncodeContext            *qcbor_encoder)
+t_cose_main_sign(struct t_cose_signature_sign     *me_x,
+                  uint32_t                         options,
+                  const struct t_cose_sign_inputs *sign_inputs,
+                  QCBOREncodeContext              *qcbor_encoder)
 {
     struct t_cose_signature_sign_main *me =
                                      (struct t_cose_signature_sign_main *)me_x;
@@ -93,10 +91,7 @@ t_cose_main_sign(struct t_cose_signature_sign  *me_x,
          * t_cose_sign1_init() so it doesn't need to be checked here.
          */
         return_value = create_tbs_hash(me->cose_algorithm_id,
-                                       protected_body_headers,
-                                       signer_protected_headers,
-                                       aad,
-                                       signed_payload,
+                                       sign_inputs,
                                        buffer_for_tbs_hash,
                                        &tbs_hash);
         if(return_value) {

--- a/src/t_cose_signature_sign_main.c
+++ b/src/t_cose_signature_sign_main.c
@@ -17,10 +17,10 @@
 #include "t_cose/t_cose_parameters.h"
 #include "t_cose_util.h"
 
-
+/** This is an implementation of \ref t_cose_signature_sign_headers_cb */
 static void
-t_cose_main_headers(struct t_cose_signature_sign   *me_x,
-                     struct t_cose_parameter       **params)
+t_cose_signature_sign_headers_main_cb(struct t_cose_signature_sign   *me_x,
+                                      struct t_cose_parameter       **params)
 {
     struct t_cose_signature_sign_main *me =
                                     (struct t_cose_signature_sign_main *)me_x;
@@ -35,14 +35,11 @@ t_cose_main_headers(struct t_cose_signature_sign   *me_x,
 }
 
 
-/* While this is a private function, it is called externally
- * as a callback via a function pointer that is set up in
- * t_cose_ecdsa_signer_init().  */
+/** This is an implementation of \ref t_cose_signature_sign_cb */
 static enum t_cose_err_t
-t_cose_main_sign(struct t_cose_signature_sign     *me_x,
-                  uint32_t                         options,
-                  const struct t_cose_sign_inputs *sign_inputs,
-                  QCBOREncodeContext              *qcbor_encoder)
+t_cose_signature_sign1_main_cb(struct t_cose_signature_sign     *me_x,
+                               const struct t_cose_sign_inputs *sign_inputs,
+                               QCBOREncodeContext              *qcbor_encoder)
 {
     struct t_cose_signature_sign_main *me =
                                      (struct t_cose_signature_sign_main *)me_x;
@@ -51,25 +48,12 @@ t_cose_main_sign(struct t_cose_signature_sign     *me_x,
     struct q_useful_buf         buffer_for_signature;
     struct q_useful_buf_c       tbs_hash;
     struct q_useful_buf_c       signature;
-    struct q_useful_buf_c       signer_protected_headers;
-    struct t_cose_parameter    *parameters;
 
-
-    /* -- The headers if if is a COSE_Sign -- */
-    signer_protected_headers = NULL_Q_USEFUL_BUF_C;
-    if(T_COSE_OPT_IS_SIGN(options)) {
-        /* COSE_Sign, so making a COSE_Signature  */
-        QCBOREncode_OpenArray(qcbor_encoder);
-
-        t_cose_main_headers(me_x, &parameters);
-        t_cose_parameter_list_append(parameters, me->added_signer_params);
-
-        t_cose_encode_headers(qcbor_encoder,
-                              parameters,
-                              &signer_protected_headers);
-    }
-
-    /* -- The signature -- */
+    /* The signature gets written directly into the output buffer.
+     * The matching QCBOREncode_CloseBytes call further down still
+     * needs do a memmove to make space for the CBOR header, but
+     * at least we avoid the need to allocate an extra buffer.
+     */
     QCBOREncode_OpenBytes(qcbor_encoder, &buffer_for_signature);
 
     if (QCBOREncode_IsBufferNULL(qcbor_encoder)) {
@@ -88,7 +72,7 @@ t_cose_main_sign(struct t_cose_signature_sign     *me_x,
          * hash are the protected parameters, the payload that is
          * getting signed, the cose signature alg from which the hash
          * alg is determined. The cose_algorithm_id was checked in
-         * t_cose_sign1_init() so it doesn't need to be checked here.
+         * t_cose_sign_init() so it doesn't need to be checked here.
          */
         return_value = create_tbs_hash(me->cose_algorithm_id,
                                        sign_inputs,
@@ -98,39 +82,59 @@ t_cose_main_sign(struct t_cose_signature_sign     *me_x,
             goto Done;
         }
 
-        /* The signature gets written directly into the output buffer.
-         * The matching QCBOREncode_CloseBytes call further down still
-         * needs do a memmove to make space for the CBOR header, but
-         * at least we avoid the need to allocate an extra buffer.
-         */
-
         return_value = t_cose_crypto_sign(me->cose_algorithm_id,
                                           me->signing_key,
                                           tbs_hash,
                                           buffer_for_signature,
-                                          &signature);
-
+                                         &signature);
     }
     QCBOREncode_CloseBytes(qcbor_encoder, signature.len);
-
-
-    /* -- If a COSE_Sign, close of the COSE_Signature */
-    if(T_COSE_OPT_IS_SIGN(options)) {
-        QCBOREncode_CloseArray(qcbor_encoder);
-    }
-    // TODO: lots of error handling
 
 Done:
     return return_value;
 }
 
 
+/** This is an implementation of \ref t_cose_signature_sign1_cb */
+static enum t_cose_err_t
+t_cose_signature_sign_main_cb(struct t_cose_signature_sign  *me_x,
+                              struct t_cose_sign_inputs     *sign_inputs,
+                              QCBOREncodeContext            *qcbor_encoder)
+{
+    struct t_cose_signature_sign_main *me =
+                                     (struct t_cose_signature_sign_main *)me_x;
+    enum t_cose_err_t         return_value;
+    struct t_cose_parameter  *parameters;
+
+    /* Array that holds a COSE_Signature */
+    QCBOREncode_OpenArray(qcbor_encoder);
+
+    /* -- The headers for a COSE_Sign -- */
+    t_cose_signature_sign_headers_main_cb(me_x, &parameters);
+    t_cose_parameter_list_append(parameters, me->added_signer_params);
+    t_cose_encode_headers(qcbor_encoder,
+                          parameters,
+                          &sign_inputs->sign_protected);
+
+    /* The actual signature (this runs hash and public key crypto) */
+    return_value = t_cose_signature_sign1_main_cb(me_x,
+                                                  sign_inputs,
+                                                  qcbor_encoder);
+
+    /* Close the array for the COSE_Signature */
+    QCBOREncode_CloseArray(qcbor_encoder);
+
+    return return_value;
+}
+
+
 void
 t_cose_signature_sign_main_init(struct t_cose_signature_sign_main *me,
-                                int32_t                            cose_algorithm_id)
+                                const int32_t                      cose_algorithm_id)
 {
     memset(me, 0, sizeof(*me));
-    me->s.callback        = t_cose_main_sign;
-    me->s.h_callback      = t_cose_main_headers;
+    me->s.headers_cb      = t_cose_signature_sign_headers_main_cb;
+    me->s.sign_cb         = t_cose_signature_sign_main_cb;
+    me->s.sign1_cb        = t_cose_signature_sign1_main_cb;
     me->cose_algorithm_id = cose_algorithm_id;
 }

--- a/src/t_cose_signature_verify_eddsa.c
+++ b/src/t_cose_signature_verify_eddsa.c
@@ -27,10 +27,7 @@
 static enum t_cose_err_t
 t_cose_signature_verify1_eddsa(struct t_cose_signature_verify *me_x,
                                const uint32_t                  option_flags,
-                               const struct q_useful_buf_c     protected_body_headers,
-                               const struct q_useful_buf_c     protected_signature_headers,
-                               const struct q_useful_buf_c     payload,
-                               const struct q_useful_buf_c     aad,
+                               const struct t_cose_sign_inputs *sign_inputs,
                                const struct t_cose_parameter  *parameter_list,
                                const struct q_useful_buf_c     signature)
 {
@@ -61,10 +58,7 @@ t_cose_signature_verify1_eddsa(struct t_cose_signature_verify *me_x,
      * auxiliary_buffer, and we record the size the structure would
      * have occupied).
      */
-    return_value = create_tbs(protected_body_headers,
-                              aad,
-                              protected_signature_headers,
-                              payload,
+    return_value = create_tbs(sign_inputs,
                               me->auxiliary_buffer,
                              &tbs);
     if (return_value == T_COSE_ERR_TOO_SMALL) {
@@ -116,9 +110,7 @@ static enum t_cose_err_t
 t_cose_signature_verify_eddsa_cb(struct t_cose_signature_verify  *me_x,
                               const uint32_t                      option_flags,
                               const struct t_cose_header_location loc,
-                              const struct q_useful_buf_c         protected_body_headers,
-                              const struct q_useful_buf_c         payload,
-                              const struct q_useful_buf_c         aad,
+                              const struct t_cose_sign_inputs    *sign_inputs,
                               struct t_cose_parameter_storage    *param_storage,
                               QCBORDecodeContext                 *qcbor_decoder,
                               struct t_cose_parameter           **decoded_signature_parameters)
@@ -157,10 +149,7 @@ t_cose_signature_verify_eddsa_cb(struct t_cose_signature_verify  *me_x,
 
     return_value = t_cose_signature_verify1_eddsa(me_x,
                                                   option_flags,
-                                                  protected_body_headers,
-                                                  protected_parameters,
-                                                  payload,
-                                                  aad,
+                                                  sign_inputs,
                                                   *decoded_signature_parameters,
                                                   signature);
 Done:

--- a/src/t_cose_signature_verify_eddsa.c
+++ b/src/t_cose_signature_verify_eddsa.c
@@ -25,11 +25,11 @@
  * This is an implementation of t_cose_signature_verify1_callback.
  */
 static enum t_cose_err_t
-t_cose_signature_verify1_eddsa(struct t_cose_signature_verify *me_x,
-                               const uint32_t                  option_flags,
-                               const struct t_cose_sign_inputs *sign_inputs,
-                               const struct t_cose_parameter  *parameter_list,
-                               const struct q_useful_buf_c     signature)
+t_cose_signature_verify1_eddsa_cb(struct t_cose_signature_verify *me_x,
+                                  const uint32_t                  option_flags,
+                                  const struct t_cose_sign_inputs *sign_inputs,
+                                  const struct t_cose_parameter  *parameter_list,
+                                  const struct q_useful_buf_c     signature)
 {
     struct t_cose_signature_verify_eddsa *me =
                           (struct t_cose_signature_verify_eddsa *)me_x;
@@ -108,12 +108,12 @@ Done:
  */
 static enum t_cose_err_t
 t_cose_signature_verify_eddsa_cb(struct t_cose_signature_verify  *me_x,
-                              const uint32_t                      option_flags,
-                              const struct t_cose_header_location loc,
-                              const struct t_cose_sign_inputs    *sign_inputs,
-                              struct t_cose_parameter_storage    *param_storage,
-                              QCBORDecodeContext                 *qcbor_decoder,
-                              struct t_cose_parameter           **decoded_signature_parameters)
+                                 const uint32_t                      option_flags,
+                                 const struct t_cose_header_location loc,
+                                 const struct t_cose_sign_inputs    *sign_inputs,
+                                 struct t_cose_parameter_storage    *param_storage,
+                                 QCBORDecodeContext                 *qcbor_decoder,
+                                 struct t_cose_parameter           **decoded_signature_parameters)
 {
     const struct t_cose_signature_verify_eddsa *me =
                             (const struct t_cose_signature_verify_eddsa *)me_x;
@@ -147,11 +147,11 @@ t_cose_signature_verify_eddsa_cb(struct t_cose_signature_verify  *me_x,
     }
     /* --- Done decoding the COSE_Signature --- */
 
-    return_value = t_cose_signature_verify1_eddsa(me_x,
-                                                  option_flags,
-                                                  sign_inputs,
-                                                  *decoded_signature_parameters,
-                                                  signature);
+    return_value = t_cose_signature_verify1_eddsa_cb(me_x,
+                                                    option_flags,
+                                                    sign_inputs,
+                                                    *decoded_signature_parameters,
+                                                     signature);
 Done:
     return return_value;
 }
@@ -162,8 +162,8 @@ t_cose_signature_verify_eddsa_init(struct t_cose_signature_verify_eddsa *me,
                                    uint32_t option_flags)
 {
     memset(me, 0, sizeof(*me));
-    me->s.callback   = t_cose_signature_verify_eddsa_cb;
-    me->s.callback1  = t_cose_signature_verify1_eddsa;
+    me->s.verify_cb   = t_cose_signature_verify_eddsa_cb;
+    me->s.verify1_cb  = t_cose_signature_verify1_eddsa_cb;
     me->option_flags = option_flags;
 
     /* Start with large (but NULL) auxiliary buffer.

--- a/src/t_cose_signature_verify_main.c
+++ b/src/t_cose_signature_verify_main.c
@@ -24,14 +24,11 @@
  * This is an implementation of t_cose_signature_verify1_callback.
  */
 static enum t_cose_err_t
-t_cose_signature_verify1_main(struct t_cose_signature_verify *me_x,
-                               const uint32_t                  option_flags,
-                               const struct q_useful_buf_c     protected_body_headers,
-                               const struct q_useful_buf_c     protected_signature_headers,
-                               const struct q_useful_buf_c     payload,
-                               const struct q_useful_buf_c     aad,
-                               const struct t_cose_parameter  *parameter_list,
-                               const struct q_useful_buf_c     signature)
+t_cose_signature_verify1_main(struct t_cose_signature_verify   *me_x,
+                               const uint32_t                   option_flags,
+                               const struct t_cose_sign_inputs *sign_inputs,
+                               const struct t_cose_parameter   *parameter_list,
+                               const struct q_useful_buf_c      signature)
 {
     const struct t_cose_signature_verify_main *me =
                           (const struct t_cose_signature_verify_main *)me_x;
@@ -66,10 +63,7 @@ t_cose_signature_verify1_main(struct t_cose_signature_verify *me_x,
 
     /* --- Compute the hash of the to-be-signed bytes -- */
     return_value = create_tbs_hash(cose_algorithm_id,
-                                   protected_body_headers,
-                                   protected_signature_headers,
-                                   aad,
-                                   payload,
+                                   sign_inputs,
                                    tbs_hash_buffer,
                                    &tbs_hash);
     if(return_value != T_COSE_SUCCESS) {
@@ -101,9 +95,7 @@ static enum t_cose_err_t
 t_cose_signature_verify_main(struct t_cose_signature_verify     *me_x,
                               const uint32_t                      option_flags,
                               const struct t_cose_header_location loc,
-                              const struct q_useful_buf_c         protected_body_headers,
-                              const struct q_useful_buf_c         payload,
-                              const struct q_useful_buf_c         aad,
+                              const struct t_cose_sign_inputs    *sign_inputs,
                               struct t_cose_parameter_storage    *param_storage,
                               QCBORDecodeContext                 *qcbor_decoder,
                               struct t_cose_parameter           **decoded_signature_parameters)
@@ -142,13 +134,10 @@ t_cose_signature_verify_main(struct t_cose_signature_verify     *me_x,
 
 
     return_value = t_cose_signature_verify1_main(me_x,
-                                                  option_flags,
-                                                  protected_body_headers,
-                                                  protected_parameters,
-                                                  payload,
-                                                  aad,
-                                                  *decoded_signature_parameters,
-                                                  signature);
+                                                 option_flags,
+                                                 sign_inputs,
+                                                *decoded_signature_parameters,
+                                                 signature);
 Done:
     return return_value;
 }

--- a/src/t_cose_signature_verify_main.c
+++ b/src/t_cose_signature_verify_main.c
@@ -18,17 +18,15 @@
 #include "t_cose_crypto.h"
 
 
-/* Warning: this is still early development. Documentation may be incorrect. */
-
 /*
- * This is an implementation of t_cose_signature_verify1_callback.
+ * This is an implementation of \ref t_cose_signature_verify1_cb.
  */
 static enum t_cose_err_t
-t_cose_signature_verify1_main(struct t_cose_signature_verify   *me_x,
-                               const uint32_t                   option_flags,
-                               const struct t_cose_sign_inputs *sign_inputs,
-                               const struct t_cose_parameter   *parameter_list,
-                               const struct q_useful_buf_c      signature)
+t_cose_signature_verify1_main_cb(struct t_cose_signature_verify   *me_x,
+                                 const uint32_t                   option_flags,
+                                 const struct t_cose_sign_inputs *sign_inputs,
+                                 const struct t_cose_parameter   *parameter_list,
+                                 const struct q_useful_buf_c      signature)
 {
     const struct t_cose_signature_verify_main *me =
                           (const struct t_cose_signature_verify_main *)me_x;
@@ -89,16 +87,16 @@ Done:
           Signature validate
           Signature didn't validate
 
- This is an implementation of t_cose_signature_verify_callback
+ This is an implementation of t_cose_signature_verify_cb
  */
 static enum t_cose_err_t
-t_cose_signature_verify_main(struct t_cose_signature_verify     *me_x,
-                              const uint32_t                      option_flags,
-                              const struct t_cose_header_location loc,
-                              const struct t_cose_sign_inputs    *sign_inputs,
-                              struct t_cose_parameter_storage    *param_storage,
-                              QCBORDecodeContext                 *qcbor_decoder,
-                              struct t_cose_parameter           **decoded_signature_parameters)
+t_cose_signature_verify_main_cb(struct t_cose_signature_verify     *me_x,
+                                const uint32_t                      option_flags,
+                                const struct t_cose_header_location loc,
+                                const struct t_cose_sign_inputs    *sign_inputs,
+                                struct t_cose_parameter_storage    *param_storage,
+                                QCBORDecodeContext                 *qcbor_decoder,
+                                struct t_cose_parameter           **decoded_signature_parameters)
 {
     const struct t_cose_signature_verify_main *me =
                             (const struct t_cose_signature_verify_main *)me_x;
@@ -133,11 +131,11 @@ t_cose_signature_verify_main(struct t_cose_signature_verify     *me_x,
     /* --- Done decoding the COSE_Signature --- */
 
 
-    return_value = t_cose_signature_verify1_main(me_x,
-                                                 option_flags,
-                                                 sign_inputs,
-                                                *decoded_signature_parameters,
-                                                 signature);
+    return_value = t_cose_signature_verify1_main_cb(me_x,
+                                                    option_flags,
+                                                    sign_inputs,
+                                                   *decoded_signature_parameters,
+                                                    signature);
 Done:
     return return_value;
 }
@@ -147,6 +145,6 @@ void
 t_cose_signature_verify_main_init(struct t_cose_signature_verify_main *me)
 {
     memset(me, 0, sizeof(*me));
-    me->s.callback  = t_cose_signature_verify_main;
-    me->s.callback1 = t_cose_signature_verify1_main;
+    me->s.verify_cb  = t_cose_signature_verify_main_cb;
+    me->s.verify1_cb = t_cose_signature_verify1_main_cb;
 }

--- a/src/t_cose_util.c
+++ b/src/t_cose_util.c
@@ -173,24 +173,21 @@ enum t_cose_err_t create_tbm(UsefulBuf                       tbm_first_part_buf,
 // TODO: combine with create_tbm()
 // TODO: disable this when EdDSA is disabled?
 enum t_cose_err_t
-create_tbs(struct q_useful_buf_c  protected_parameters,
-           struct q_useful_buf_c  aad,
-           const struct q_useful_buf_c  sign_protected_parameters,
-           struct q_useful_buf_c  payload,
-           struct q_useful_buf    buffer_for_tbs,
-           struct q_useful_buf_c *tbs)
+create_tbs(const struct t_cose_sign_inputs *sign_inputs,
+           struct q_useful_buf       buffer_for_tbs,
+           struct q_useful_buf_c    *tbs)
 {
     QCBOREncodeContext  cbor_context;
     QCBOREncode_Init(&cbor_context, buffer_for_tbs);
 
     QCBOREncode_OpenArray(&cbor_context);
     QCBOREncode_AddSZString(&cbor_context, COSE_SIG_CONTEXT_STRING_SIGNATURE1);
-    QCBOREncode_AddBytes(&cbor_context, protected_parameters);
-    if(!q_useful_buf_c_is_null(sign_protected_parameters)) {
-        QCBOREncode_AddBytes(&cbor_context, sign_protected_parameters);
+    QCBOREncode_AddBytes(&cbor_context, sign_inputs->body_protected);
+    if(!q_useful_buf_c_is_null(sign_inputs->sign_protected)) {
+        QCBOREncode_AddBytes(&cbor_context, sign_inputs->sign_protected);
     }
-    QCBOREncode_AddBytes(&cbor_context, aad);
-    QCBOREncode_AddBytes(&cbor_context, payload);
+    QCBOREncode_AddBytes(&cbor_context, sign_inputs->aad);
+    QCBOREncode_AddBytes(&cbor_context, sign_inputs->payload);
     QCBOREncode_CloseArray(&cbor_context);
 
     QCBORError cbor_err = QCBOREncode_Finish(&cbor_context, tbs);
@@ -261,13 +258,10 @@ static void hash_bstr(struct t_cose_crypto_hash *hash_ctx,
  */
 // TODO: replace aad, payload, protected with one tbs_input structure
 enum t_cose_err_t
-create_tbs_hash(const int32_t                cose_algorithm_id,
-                const struct q_useful_buf_c  body_protected_parameters,
-                const struct q_useful_buf_c  sign_protected_parameters,
-                const struct q_useful_buf_c  aad,
-                const struct q_useful_buf_c  payload,
-                const struct q_useful_buf    buffer_for_hash,
-                struct q_useful_buf_c       *hash)
+create_tbs_hash(const int32_t             cose_algorithm_id,
+                const struct t_cose_sign_inputs *sign_inputs,
+                const struct q_useful_buf buffer_for_hash,
+                struct q_useful_buf_c    *hash)
 {
     /* Aproximate stack usage
      *                                             64-bit      32-bit
@@ -323,7 +317,7 @@ create_tbs_hash(const int32_t                cose_algorithm_id,
     /* Hand-constructed CBOR for the array of 4 and the context string.
      * \x84 or \x85 is an array of 4 or 5. \x6A is a text string of 10 bytes. */
     // TODO: maybe this can be optimized to one call to hash update
-    if(!q_useful_buf_c_is_null(sign_protected_parameters)) {
+    if(!q_useful_buf_c_is_null(sign_inputs->sign_protected)) {
         t_cose_crypto_hash_update(&hash_ctx, Q_USEFUL_BUF_FROM_SZ_LITERAL("\x85\x6A" COSE_SIG_CONTEXT_STRING_SIGNATURE1));
     } else {
         t_cose_crypto_hash_update(&hash_ctx, Q_USEFUL_BUF_FROM_SZ_LITERAL("\x84\x6A" COSE_SIG_CONTEXT_STRING_SIGNATURE1));
@@ -331,17 +325,17 @@ create_tbs_hash(const int32_t                cose_algorithm_id,
     }
 
     /* body_protected */
-    hash_bstr(&hash_ctx, body_protected_parameters);
+    hash_bstr(&hash_ctx, sign_inputs->body_protected);
 
-    if(!q_useful_buf_c_is_null(sign_protected_parameters)) {
-        hash_bstr(&hash_ctx, sign_protected_parameters);
+    if(!q_useful_buf_c_is_null(sign_inputs->sign_protected)) {
+        hash_bstr(&hash_ctx, sign_inputs->sign_protected);
     }
 
     /* external_aad */
-    hash_bstr(&hash_ctx, aad);
+    hash_bstr(&hash_ctx, sign_inputs->aad);
 
     /* payload */
-    hash_bstr(&hash_ctx, payload);
+    hash_bstr(&hash_ctx, sign_inputs->payload);
 
     /* Finish the hash and set up to return it */
     return_value = t_cose_crypto_hash_finish(&hash_ctx,

--- a/src/t_cose_util.c
+++ b/src/t_cose_util.c
@@ -256,7 +256,6 @@ static void hash_bstr(struct t_cose_crypto_hash *hash_ctx,
  * COSE_Sign1 structure. This is a little hard to to understand in the
  * spec.
  */
-// TODO: replace aad, payload, protected with one tbs_input structure
 enum t_cose_err_t
 create_tbs_hash(const int32_t             cose_algorithm_id,
                 const struct t_cose_sign_inputs *sign_inputs,

--- a/src/t_cose_util.h
+++ b/src/t_cose_util.h
@@ -143,11 +143,7 @@ enum t_cose_err_t create_tbm(struct q_useful_buf             tbm_first_part_buf,
 /**
  * Serialize the to-be-signed (TBS) bytes for COSE.
  *
- * \param[in] protected_parameters  Full, CBOR encoded, body protected parameters.
- * \param[in] aad                   Additional Authenitcated Data to be
- *                                  included in TBS.
- * \param[in] sign_protected_parameters  Signature, CBOR encoded, protected parameters.
- * \param[in] payload               The CBOR-encoded payload.
+ * \param[in] sign_inputs               The payload, AAD and header params to hash.
  * \param[in] buffer_for_tbs        Pointer and length of buffer into which
  *                                  the resulting TBS bytes is put.
  * \param[out] tbs                  Pointer and length of the
@@ -164,9 +160,6 @@ enum t_cose_err_t create_tbm(struct q_useful_buf             tbm_first_part_buf,
  * and a few other things. These are known as the to-be-signed or "TBS"
  * bytes. The exact specification is in [RFC 8152 section
  * 4.4](https://tools.ietf.org/html/rfc8152#section-4.4).
- *
- * \c aad can be \ref NULL_Q_USEFUL_BUF_C if not present.
- *  \c \sign_protected_parameters can be can be \ref NULL_Q_USEFUL_BUF_C if not present.
  */
 enum t_cose_err_t create_tbs(const struct t_cose_sign_inputs *sign_inputs,
                              struct q_useful_buf              buffer_for_tbs,
@@ -178,12 +171,7 @@ enum t_cose_err_t create_tbs(const struct t_cose_sign_inputs *sign_inputs,
  *
  * \param[in] cose_algorithm_id     The COSE signing algorithm ID. Used to
  *                                  determine which hash function to use.
- * \param[in] body_protected_parameters  Protected parameters from the body..
- * \param[in] sign_protected_parameters  Protected parameters from the COSE_Signer.
- *                                        May be NULL_Q_USEFUL_BUF_C for COSE_Sign1.
- * \param[in] aad                   Additional Authenitcated Data to be
- *                                  included in TBS.
- * \param[in] payload               The CBOR-encoded payload.
+ * \param[in] sign_inputs               The payload, AAD and header params to hash.
  * \param[in] buffer_for_hash       Pointer and length of buffer into which
  *                                  the resulting hash is put.
  * \param[out] hash                 Pointer and length of the
@@ -205,8 +193,6 @@ enum t_cose_err_t create_tbs(const struct t_cose_sign_inputs *sign_inputs,
  * and computes the hash of it. These are known as the to-be-signed or
  * "TBS" bytes. The exact specification is in [RFC 8152 section
  * 4.4](https://tools.ietf.org/html/rfc8152#section-4.4).
- *
- * \c aad can be \ref NULL_Q_USEFUL_BUF_C if not present.
  */
 enum t_cose_err_t create_tbs_hash(int32_t                   cose_algorithm_id,
                                   const struct t_cose_sign_inputs *sign_inputs,

--- a/src/t_cose_util.h
+++ b/src/t_cose_util.h
@@ -47,6 +47,8 @@ enum t_cose_tbm_payload_mode_t {
     T_COSE_TBM_BARE_PAYLOAD
 };
 
+
+
 /**
  * This value represents an invalid or in-error algorithm ID.  The
  * value selected is 0 as this is reserved in the IANA COSE algorithm
@@ -166,12 +168,9 @@ enum t_cose_err_t create_tbm(struct q_useful_buf             tbm_first_part_buf,
  * \c aad can be \ref NULL_Q_USEFUL_BUF_C if not present.
  *  \c \sign_protected_parameters can be can be \ref NULL_Q_USEFUL_BUF_C if not present.
  */
-enum t_cose_err_t create_tbs(struct q_useful_buf_c  protected_parameters,
-                             struct q_useful_buf_c  aad,
-                             const struct q_useful_buf_c  sign_protected_parameters,
-                             struct q_useful_buf_c  payload,
-                             struct q_useful_buf    buffer_for_tbs,
-                             struct q_useful_buf_c *tbs);
+enum t_cose_err_t create_tbs(const struct t_cose_sign_inputs *sign_inputs,
+                             struct q_useful_buf              buffer_for_tbs,
+                             struct q_useful_buf_c           *tbs);
 
 
 /**
@@ -209,13 +208,10 @@ enum t_cose_err_t create_tbs(struct q_useful_buf_c  protected_parameters,
  *
  * \c aad can be \ref NULL_Q_USEFUL_BUF_C if not present.
  */
-enum t_cose_err_t create_tbs_hash(int32_t                cose_algorithm_id,
-                                  struct q_useful_buf_c  body_protected_parameters,
-                                  struct q_useful_buf_c  sign_protected_parameters,
-                                  struct q_useful_buf_c  aad,
-                                  struct q_useful_buf_c  payload,
-                                  struct q_useful_buf    buffer_for_hash,
-                                  struct q_useful_buf_c *hash);
+enum t_cose_err_t create_tbs_hash(int32_t                   cose_algorithm_id,
+                                  const struct t_cose_sign_inputs *sign_inputs,
+                                  struct q_useful_buf       buffer_for_hash,
+                                  struct q_useful_buf_c    *hash);
 
 
 

--- a/test/t_cose_make_test_messages.c
+++ b/test/t_cose_make_test_messages.c
@@ -449,6 +449,7 @@ t_cose_sign1_test_message_output_signature(struct t_cose_sign1_sign_ctx *me,
     /* Buffer for the tbs hash. */
     Q_USEFUL_BUF_MAKE_STACK_UB(  buffer_for_tbs_hash, T_COSE_CRYPTO_MAX_HASH_SIZE);
     struct q_useful_buf_c        signed_payload;
+    struct t_cose_sign_inputs           sign_inputs;
 
     QCBOREncode_CloseBstrWrap2(cbor_encode_ctx, false, &signed_payload);
 
@@ -472,11 +473,13 @@ t_cose_sign1_test_message_output_signature(struct t_cose_sign1_sign_ctx *me,
      * cose_algorithm_id was checked in t_cose_sign1_init() so it
      * doesn't need to be checked here.
      */
+    sign_inputs.body_protected = me->protected_parameters;
+    sign_inputs.aad            = NULL_Q_USEFUL_BUF_C;
+    sign_inputs.sign_protected = NULL_Q_USEFUL_BUF_C;
+    sign_inputs.payload        = signed_payload;
+
     return_value = create_tbs_hash(me->cose_algorithm_id,
-                                   me->protected_parameters,
-                                   NULL_Q_USEFUL_BUF_C,
-                                   NULL_Q_USEFUL_BUF_C,
-                                   signed_payload,
+                                   &sign_inputs,
                                    buffer_for_tbs_hash,
                                    &tbs_hash);
     if(return_value != T_COSE_SUCCESS) {


### PR DESCRIPTION
Better and more consistent naming.

Separate out COSE_Sign1 from COSE_Signature/Sign better in the signer interface.