### PR TITLE
improve signer/verifier interface

### DIFF
--- a/inc/t_cose/t_cose_signature_verify.h
+++ b/inc/t_cose/t_cose_signature_verify.h
@@ -19,7 +19,7 @@
 /*
  * This is the abstract base class that t_cose_sign_verify
  * calls to run signature verification. A concrete
- * implementation of this is needed.
+ * implementation of this must be created in actual use.
  *
  * Implementations may choose to support only COSE_Sign1,
  * only COSE_Signature/COSE_Sign or both. They are encouraged to
@@ -49,16 +49,16 @@ struct t_cose_signature_verify;
  * \param[in] params                  The place to put the decoded params.
  * \param[in] qcbor_decoder           The decoder instance from where the
  *                                     COSE_Signature is decoded.
- * \param[out] decoded_signature_parameters  Linked list of decoded parameters.
+ * \param[out] decoded_params  Returned linked list of decoded parameters.
  */
 typedef enum t_cose_err_t
-t_cose_signature_verify_callback(struct t_cose_signature_verify   *me,
-                                 uint32_t                          option_flags,
-                                 const struct t_cose_header_location loc,
-                                 const struct t_cose_sign_inputs *sign_inputs,
-                                 struct t_cose_parameter_storage  *params,
-                                 QCBORDecodeContext               *qcbor_decoder,
-                                 struct t_cose_parameter         **decoded_signature_parameters);
+t_cose_signature_verify_cb(struct t_cose_signature_verify     *me,
+                           uint32_t                            option_flags,
+                           const struct t_cose_header_location loc,
+                           const struct t_cose_sign_inputs    *sign_inputs,
+                           struct t_cose_parameter_storage    *params,
+                           QCBORDecodeContext                 *qcbor_decoder,
+                           struct t_cose_parameter           **decoded_params);
 
 
 /**
@@ -74,26 +74,28 @@ t_cose_signature_verify_callback(struct t_cose_signature_verify   *me,
  *                                     found.
  * \param[in] signature                The signature.
  *
- * This is very different from t_cose_signature_verify_callback
+ * This is very different from t_cose_signature_verify_cb()
  * because there is no header decoding to be done. Instead the headers
  * are decoded outside of this and passed in.
  */
 typedef enum t_cose_err_t
-t_cose_signature_verify1_callback(struct t_cose_signature_verify *me,
-                                  uint32_t                        option_flags,
-                                  const struct t_cose_sign_inputs *sign_inputs,
-                                  const struct t_cose_parameter  *parameter_list,
-                                  const struct q_useful_buf_c     signature);
+t_cose_signature_verify1_cb(struct t_cose_signature_verify *me,
+                            uint32_t                        option_flags,
+                            const struct t_cose_sign_inputs *sign_inputs,
+                            const struct t_cose_parameter  *parameter_list,
+                            const struct q_useful_buf_c     signature);
 
 
 /**
  * Data structture that must be the first part of every context of every concrete
- * implementation of t_cose_signature_verify.
+ * implementation of t_cose_signature_verify. Callback functions must not
+ * be NULL, but can be stubs that return an error when COSE_SIgn1 or COSE_Sign
+ * are not supported.
  */
 struct t_cose_signature_verify {
-    t_cose_signature_verify_callback  *callback; /* some will call this a vtable with two entries */
-    t_cose_signature_verify1_callback *callback1;
-    struct t_cose_signature_verify    *next_in_list; /* Linked list of signers */
+    t_cose_signature_verify_cb      *verify_cb;
+    t_cose_signature_verify1_cb     *verify1_cb;
+    struct t_cose_signature_verify  *next_in_list; /* Linked list of signers */
 };
 
 

--- a/src/t_cose_sign_verify.c
+++ b/src/t_cose_sign_verify.c
@@ -238,11 +238,11 @@ t_cose_sign_verify_private(struct t_cose_sign_verify_ctx  *me,
              * the main method of the cose_signature_verify. This
              * will compute the tbs value and call the crypto.
              */
-            verify_error = verifier->callback1(verifier,
-                                               me->option_flags,
-                                              &sign_inputs,
-                                               decoded_body_parameter_list,
-                                               signature);
+            verify_error = verifier->verify1_cb(verifier,
+                                                me->option_flags,
+                                               &sign_inputs,
+                                                decoded_body_parameter_list,
+                                                signature);
             if(verify_error == T_COSE_SUCCESS) {
                 break;
             }
@@ -274,13 +274,13 @@ t_cose_sign_verify_private(struct t_cose_sign_verify_ctx  *me,
 
                 /* This call decodes one array entry containing a
                  * COSE_Signature. */
-                return_value = verifier->callback(verifier,
-                                                  me->option_flags,
-                                                  header_location,
-                                                  &sign_inputs,
-                                                  me->p_storage,
-                                                 &decode_context,
-                                                 &decoded_sig_parameter_list);
+                return_value = verifier->verify_cb(verifier,
+                                                   me->option_flags,
+                                                   header_location,
+                                                   &sign_inputs,
+                                                   me->p_storage,
+                                                  &decode_context,
+                                                  &decoded_sig_parameter_list);
 
                 // TODO: this may not be in the right place
                 t_cose_parameter_list_append(decoded_body_parameter_list,

--- a/src/t_cose_signature_sign_eddsa.c
+++ b/src/t_cose_signature_sign_eddsa.c
@@ -19,8 +19,8 @@
 
 
 static void
-t_cose_eddsa_headers(struct t_cose_signature_sign   *me_x,
-                     struct t_cose_parameter       **params)
+t_cose_signature_sign_headers_eddsa_cb(struct t_cose_signature_sign   *me_x,
+                                       struct t_cose_parameter       **params)
 {
     // TODO: this is the same as the main signer (formerly the ecdsa signer) reuse?
     struct t_cose_signature_sign_eddsa *me =
@@ -36,38 +36,17 @@ t_cose_eddsa_headers(struct t_cose_signature_sign   *me_x,
 }
 
 
-/* While this is a private function, it is called externally
- * as a callback via a function pointer that is set up in
- * t_cose_eddsa_signer_init().  */
 static enum t_cose_err_t
-t_cose_eddsa_sign(struct t_cose_signature_sign    *me_x,
-                  uint32_t                         options,
-                  const struct t_cose_sign_inputs *sign_inputs,
-                  QCBOREncodeContext              *qcbor_encoder)
+t_cose_signature_sign1_eddsa_cb(struct t_cose_signature_sign    *me_x,
+                                const struct t_cose_sign_inputs *sign_inputs,
+                                QCBOREncodeContext              *qcbor_encoder)
 {
     struct t_cose_signature_sign_eddsa *me =
                                      (struct t_cose_signature_sign_eddsa *)me_x;
     enum t_cose_err_t           return_value;
     struct q_useful_buf_c       tbs;
     struct q_useful_buf_c       signature;
-    struct q_useful_buf_c       signer_protected_headers;
-    struct t_cose_parameter    *parameters;
     struct q_useful_buf         buffer_for_signature;
-
-
-    /* -- The headers if if is a COSE_Sign -- */
-    signer_protected_headers = NULLUsefulBufC;
-    if(T_COSE_OPT_IS_SIGN(options)) {
-        /* COSE_Sign, so making a COSE_Signature  */
-        QCBOREncode_OpenArray(qcbor_encoder);
-
-        t_cose_eddsa_headers(me_x, &parameters);
-        t_cose_parameter_list_append(parameters, me->added_signer_params);
-
-        t_cose_encode_headers(qcbor_encoder,
-                              parameters,
-                              &signer_protected_headers);
-    }
 
     /* Serialize the TBS data into the auxiliary buffer.
      * If auxiliary_buffer.ptr is NULL this will succeed, computing
@@ -82,47 +61,70 @@ t_cose_eddsa_sign(struct t_cose_signature_sign    *me_x,
         goto Done;
     }
 
-
     /* Record how much buffer we actually used / would have used,
-     * allowing the caller to allocate an appropriately sized buffer.
-     * This is particularly useful when buffer_for_signature.ptr is
-     * NULL and no signing is actually taking place yet.
-     */
-    me->auxiliary_buffer_size = tbs.len;
+      * allowing the caller to allocate an appropriately sized buffer.
+      * This is particularly useful when buffer_for_signature.ptr is
+      * NULL and no signing is actually taking place yet.
+      */
+     me->auxiliary_buffer_size = tbs.len;
 
-    QCBOREncode_OpenBytes(qcbor_encoder, &buffer_for_signature);
-
-
-    if (buffer_for_signature.ptr == NULL) {
-        /* Output size calculation. Only need signature size. */
-        signature.ptr = NULL;
-        // TODO: an eddsa-specific size calculator?
-        return_value  = t_cose_crypto_sig_size(T_COSE_ALGORITHM_EDDSA,
-                                               me->signing_key,
-                                               &signature.len);
-    } else if (me->auxiliary_buffer.ptr == NULL) {
-        /* Without a real auxiliary buffer, we have nothing to sign. */
-        return_value = T_COSE_ERR_NEED_AUXILIARY_BUFFER;
-    } else {
-        /* Perform the public key signing over the TBS bytes we just
-         * serialized.
-         */
-        return_value = t_cose_crypto_sign_eddsa(me->signing_key,
-                                                tbs,
-                                                buffer_for_signature,
-                                                &signature);
-    }
-
-    QCBOREncode_CloseBytes(qcbor_encoder, signature.len);
+     QCBOREncode_OpenBytes(qcbor_encoder, &buffer_for_signature);
 
 
-    /* -- If a COSE_Sign, close of the COSE_Signature */
-    if(T_COSE_OPT_IS_SIGN(options)) {
-        QCBOREncode_CloseArray(qcbor_encoder);
-    }
-    // TODO: lots of error handling
+     if (buffer_for_signature.ptr == NULL) {
+         /* Output size calculation. Only need signature size. */
+         signature.ptr = NULL;
+         // TODO: an eddsa-specific size calculator?
+         return_value  = t_cose_crypto_sig_size(T_COSE_ALGORITHM_EDDSA,
+                                                me->signing_key,
+                                                &signature.len);
+     } else if (me->auxiliary_buffer.ptr == NULL) {
+         /* Without a real auxiliary buffer, we have nothing to sign. */
+         return_value = T_COSE_ERR_NEED_AUXILIARY_BUFFER;
+     } else {
+         /* Perform the public key signing over the TBS bytes we just
+          * serialized.
+          */
+         return_value = t_cose_crypto_sign_eddsa(me->signing_key,
+                                                 tbs,
+                                                 buffer_for_signature,
+                                                 &signature);
+     }
+
+     QCBOREncode_CloseBytes(qcbor_encoder, signature.len);
 
 Done:
+    return return_value;
+
+}
+
+/* While this is a private function, it is called externally
+ * as a callback via a function pointer that is set up in
+ * t_cose_eddsa_signer_init().  */
+static enum t_cose_err_t
+t_cose_signature_sign_eddsa_cb(struct t_cose_signature_sign  *me_x,
+                               struct t_cose_sign_inputs     *sign_inputs,
+                               QCBOREncodeContext            *qcbor_encoder)
+{
+    struct t_cose_signature_sign_eddsa *me =
+                                     (struct t_cose_signature_sign_eddsa *)me_x;
+    enum t_cose_err_t           return_value;
+    struct t_cose_parameter    *parameters;
+
+    QCBOREncode_OpenArray(qcbor_encoder);
+
+    t_cose_signature_sign_headers_eddsa_cb(me_x, &parameters);
+    t_cose_parameter_list_append(parameters, me->added_signer_params);
+    t_cose_encode_headers(qcbor_encoder,
+                          parameters,
+                          &sign_inputs->sign_protected);
+
+    return_value = t_cose_signature_sign1_eddsa_cb(me_x,
+                                                   sign_inputs,
+                                                   qcbor_encoder);
+
+    QCBOREncode_CloseArray(qcbor_encoder);
+
     return return_value;
 }
 
@@ -131,6 +133,7 @@ void
 t_cose_signature_sign_eddsa_init(struct t_cose_signature_sign_eddsa *me)
 {
     memset(me, 0, sizeof(*me));
-    me->s.callback        = t_cose_eddsa_sign;
-    me->s.h_callback      = t_cose_eddsa_headers;
+    me->s.sign_cb    = t_cose_signature_sign_eddsa_cb;
+    me->s.sign1_cb   = t_cose_signature_sign1_eddsa_cb;
+    me->s.headers_cb = t_cose_signature_sign_headers_eddsa_cb;
 }

--- a/src/t_cose_signature_sign_eddsa.c
+++ b/src/t_cose_signature_sign_eddsa.c
@@ -18,6 +18,7 @@
 #include "t_cose_util.h"
 
 
+/** This is an implementation of \ref t_cose_signature_sign_headers_cb */
 static void
 t_cose_signature_sign_headers_eddsa_cb(struct t_cose_signature_sign   *me_x,
                                        struct t_cose_parameter       **params)
@@ -36,6 +37,7 @@ t_cose_signature_sign_headers_eddsa_cb(struct t_cose_signature_sign   *me_x,
 }
 
 
+/** This is an implementation of \ref t_cose_signature_sign_cb */
 static enum t_cose_err_t
 t_cose_signature_sign1_eddsa_cb(struct t_cose_signature_sign    *me_x,
                                 const struct t_cose_sign_inputs *sign_inputs,
@@ -98,9 +100,7 @@ Done:
 
 }
 
-/* While this is a private function, it is called externally
- * as a callback via a function pointer that is set up in
- * t_cose_eddsa_signer_init().  */
+/** This is an implementation of \ref t_cose_signature_sign1_cb */
 static enum t_cose_err_t
 t_cose_signature_sign_eddsa_cb(struct t_cose_signature_sign  *me_x,
                                struct t_cose_sign_inputs     *sign_inputs,

--- a/src/t_cose_signature_sign_main.c
+++ b/src/t_cose_signature_sign_main.c
@@ -17,10 +17,10 @@
 #include "t_cose/t_cose_parameters.h"
 #include "t_cose_util.h"
 
-
+/** This is an implementation of \ref t_cose_signature_sign_headers_cb */
 static void
-t_cose_main_headers(struct t_cose_signature_sign   *me_x,
-                     struct t_cose_parameter       **params)
+t_cose_signature_sign_headers_main_cb(struct t_cose_signature_sign   *me_x,
+                                      struct t_cose_parameter       **params)
 {
     struct t_cose_signature_sign_main *me =
                                     (struct t_cose_signature_sign_main *)me_x;
@@ -35,14 +35,11 @@ t_cose_main_headers(struct t_cose_signature_sign   *me_x,
 }
 
 
-/* While this is a private function, it is called externally
- * as a callback via a function pointer that is set up in
- * t_cose_ecdsa_signer_init().  */
+/** This is an implementation of \ref t_cose_signature_sign_cb */
 static enum t_cose_err_t
-t_cose_main_sign(struct t_cose_signature_sign     *me_x,
-                  uint32_t                         options,
-                  const struct t_cose_sign_inputs *sign_inputs,
-                  QCBOREncodeContext              *qcbor_encoder)
+t_cose_signature_sign1_main_cb(struct t_cose_signature_sign     *me_x,
+                               const struct t_cose_sign_inputs *sign_inputs,
+                               QCBOREncodeContext              *qcbor_encoder)
 {
     struct t_cose_signature_sign_main *me =
                                      (struct t_cose_signature_sign_main *)me_x;
@@ -51,25 +48,12 @@ t_cose_main_sign(struct t_cose_signature_sign     *me_x,
     struct q_useful_buf         buffer_for_signature;
     struct q_useful_buf_c       tbs_hash;
     struct q_useful_buf_c       signature;
-    struct q_useful_buf_c       signer_protected_headers;
-    struct t_cose_parameter    *parameters;
 
-
-    /* -- The headers if if is a COSE_Sign -- */
-    signer_protected_headers = NULL_Q_USEFUL_BUF_C;
-    if(T_COSE_OPT_IS_SIGN(options)) {
-        /* COSE_Sign, so making a COSE_Signature  */
-        QCBOREncode_OpenArray(qcbor_encoder);
-
-        t_cose_main_headers(me_x, &parameters);
-        t_cose_parameter_list_append(parameters, me->added_signer_params);
-
-        t_cose_encode_headers(qcbor_encoder,
-                              parameters,
-                              &signer_protected_headers);
-    }
-
-    /* -- The signature -- */
+    /* The signature gets written directly into the output buffer.
+     * The matching QCBOREncode_CloseBytes call further down still
+     * needs do a memmove to make space for the CBOR header, but
+     * at least we avoid the need to allocate an extra buffer.
+     */
     QCBOREncode_OpenBytes(qcbor_encoder, &buffer_for_signature);
 
     if (QCBOREncode_IsBufferNULL(qcbor_encoder)) {
@@ -88,7 +72,7 @@ t_cose_main_sign(struct t_cose_signature_sign     *me_x,
          * hash are the protected parameters, the payload that is
          * getting signed, the cose signature alg from which the hash
          * alg is determined. The cose_algorithm_id was checked in
-         * t_cose_sign1_init() so it doesn't need to be checked here.
+         * t_cose_sign_init() so it doesn't need to be checked here.
          */
         return_value = create_tbs_hash(me->cose_algorithm_id,
                                        sign_inputs,
@@ -98,39 +82,59 @@ t_cose_main_sign(struct t_cose_signature_sign     *me_x,
             goto Done;
         }
 
-        /* The signature gets written directly into the output buffer.
-         * The matching QCBOREncode_CloseBytes call further down still
-         * needs do a memmove to make space for the CBOR header, but
-         * at least we avoid the need to allocate an extra buffer.
-         */
-
         return_value = t_cose_crypto_sign(me->cose_algorithm_id,
                                           me->signing_key,
                                           tbs_hash,
                                           buffer_for_signature,
-                                          &signature);
-
+                                         &signature);
     }
     QCBOREncode_CloseBytes(qcbor_encoder, signature.len);
-
-
-    /* -- If a COSE_Sign, close of the COSE_Signature */
-    if(T_COSE_OPT_IS_SIGN(options)) {
-        QCBOREncode_CloseArray(qcbor_encoder);
-    }
-    // TODO: lots of error handling
 
 Done:
     return return_value;
 }
 
 
+/** This is an implementation of \ref t_cose_signature_sign1_cb */
+static enum t_cose_err_t
+t_cose_signature_sign_main_cb(struct t_cose_signature_sign  *me_x,
+                              struct t_cose_sign_inputs     *sign_inputs,
+                              QCBOREncodeContext            *qcbor_encoder)
+{
+    struct t_cose_signature_sign_main *me =
+                                     (struct t_cose_signature_sign_main *)me_x;
+    enum t_cose_err_t         return_value;
+    struct t_cose_parameter  *parameters;
+
+    /* Array that holds a COSE_Signature */
+    QCBOREncode_OpenArray(qcbor_encoder);
+
+    /* -- The headers for a COSE_Sign -- */
+    t_cose_signature_sign_headers_main_cb(me_x, &parameters);
+    t_cose_parameter_list_append(parameters, me->added_signer_params);
+    t_cose_encode_headers(qcbor_encoder,
+                          parameters,
+                          &sign_inputs->sign_protected);
+
+    /* The actual signature (this runs hash and public key crypto) */
+    return_value = t_cose_signature_sign1_main_cb(me_x,
+                                                  sign_inputs,
+                                                  qcbor_encoder);
+
+    /* Close the array for the COSE_Signature */
+    QCBOREncode_CloseArray(qcbor_encoder);
+
+    return return_value;
+}
+
+
 void
 t_cose_signature_sign_main_init(struct t_cose_signature_sign_main *me,
-                                int32_t                            cose_algorithm_id)
+                                const int32_t                      cose_algorithm_id)
 {
     memset(me, 0, sizeof(*me));
-    me->s.callback        = t_cose_main_sign;
-    me->s.h_callback      = t_cose_main_headers;
+    me->s.headers_cb      = t_cose_signature_sign_headers_main_cb;
+    me->s.sign_cb         = t_cose_signature_sign_main_cb;
+    me->s.sign1_cb        = t_cose_signature_sign1_main_cb;
     me->cose_algorithm_id = cose_algorithm_id;
 }

--- a/src/t_cose_signature_sign_main.c
+++ b/src/t_cose_signature_sign_main.c
@@ -77,7 +77,7 @@ t_cose_signature_sign1_main_cb(struct t_cose_signature_sign     *me_x,
         return_value = create_tbs_hash(me->cose_algorithm_id,
                                        sign_inputs,
                                        buffer_for_tbs_hash,
-                                       &tbs_hash);
+                                      &tbs_hash);
         if(return_value) {
             goto Done;
         }
@@ -130,7 +130,7 @@ t_cose_signature_sign_main_cb(struct t_cose_signature_sign  *me_x,
 
 void
 t_cose_signature_sign_main_init(struct t_cose_signature_sign_main *me,
-                                const int32_t                      cose_algorithm_id)
+                                const int32_t               cose_algorithm_id)
 {
     memset(me, 0, sizeof(*me));
     me->s.headers_cb      = t_cose_signature_sign_headers_main_cb;

--- a/src/t_cose_signature_verify_eddsa.c
+++ b/src/t_cose_signature_verify_eddsa.c
@@ -25,11 +25,11 @@
  * This is an implementation of t_cose_signature_verify1_callback.
  */
 static enum t_cose_err_t
-t_cose_signature_verify1_eddsa(struct t_cose_signature_verify *me_x,
-                               const uint32_t                  option_flags,
-                               const struct t_cose_sign_inputs *sign_inputs,
-                               const struct t_cose_parameter  *parameter_list,
-                               const struct q_useful_buf_c     signature)
+t_cose_signature_verify1_eddsa_cb(struct t_cose_signature_verify *me_x,
+                                  const uint32_t                  option_flags,
+                                  const struct t_cose_sign_inputs *sign_inputs,
+                                  const struct t_cose_parameter  *parameter_list,
+                                  const struct q_useful_buf_c     signature)
 {
     struct t_cose_signature_verify_eddsa *me =
                           (struct t_cose_signature_verify_eddsa *)me_x;
@@ -108,12 +108,12 @@ Done:
  */
 static enum t_cose_err_t
 t_cose_signature_verify_eddsa_cb(struct t_cose_signature_verify  *me_x,
-                              const uint32_t                      option_flags,
-                              const struct t_cose_header_location loc,
-                              const struct t_cose_sign_inputs    *sign_inputs,
-                              struct t_cose_parameter_storage    *param_storage,
-                              QCBORDecodeContext                 *qcbor_decoder,
-                              struct t_cose_parameter           **decoded_signature_parameters)
+                                 const uint32_t                      option_flags,
+                                 const struct t_cose_header_location loc,
+                                 const struct t_cose_sign_inputs    *sign_inputs,
+                                 struct t_cose_parameter_storage    *param_storage,
+                                 QCBORDecodeContext                 *qcbor_decoder,
+                                 struct t_cose_parameter           **decoded_signature_parameters)
 {
     const struct t_cose_signature_verify_eddsa *me =
                             (const struct t_cose_signature_verify_eddsa *)me_x;
@@ -147,11 +147,11 @@ t_cose_signature_verify_eddsa_cb(struct t_cose_signature_verify  *me_x,
     }
     /* --- Done decoding the COSE_Signature --- */
 
-    return_value = t_cose_signature_verify1_eddsa(me_x,
-                                                  option_flags,
-                                                  sign_inputs,
-                                                  *decoded_signature_parameters,
-                                                  signature);
+    return_value = t_cose_signature_verify1_eddsa_cb(me_x,
+                                                    option_flags,
+                                                    sign_inputs,
+                                                    *decoded_signature_parameters,
+                                                     signature);
 Done:
     return return_value;
 }
@@ -162,8 +162,8 @@ t_cose_signature_verify_eddsa_init(struct t_cose_signature_verify_eddsa *me,
                                    uint32_t option_flags)
 {
     memset(me, 0, sizeof(*me));
-    me->s.callback   = t_cose_signature_verify_eddsa_cb;
-    me->s.callback1  = t_cose_signature_verify1_eddsa;
+    me->s.verify_cb   = t_cose_signature_verify_eddsa_cb;
+    me->s.verify1_cb  = t_cose_signature_verify1_eddsa_cb;
     me->option_flags = option_flags;
 
     /* Start with large (but NULL) auxiliary buffer.

--- a/src/t_cose_signature_verify_eddsa.c
+++ b/src/t_cose_signature_verify_eddsa.c
@@ -18,12 +18,7 @@
 #include "t_cose_crypto.h"
 
 
-/* Warning: this is still early development. Documentation may be incorrect. */
-
-
-/*
- * This is an implementation of t_cose_signature_verify1_callback.
- */
+/** This is an implementation of \ref t_cose_signature_verify1_cb. */
 static enum t_cose_err_t
 t_cose_signature_verify1_eddsa_cb(struct t_cose_signature_verify *me_x,
                                   const uint32_t                  option_flags,
@@ -106,14 +101,15 @@ Done:
 
  This is an implementation of t_cose_signature_verify_callback
  */
+/** This is an implementation of \ref t_cose_signature_verify_cb. */
 static enum t_cose_err_t
 t_cose_signature_verify_eddsa_cb(struct t_cose_signature_verify  *me_x,
-                                 const uint32_t                      option_flags,
+                                 const uint32_t                   option_flags,
                                  const struct t_cose_header_location loc,
-                                 const struct t_cose_sign_inputs    *sign_inputs,
-                                 struct t_cose_parameter_storage    *param_storage,
-                                 QCBORDecodeContext                 *qcbor_decoder,
-                                 struct t_cose_parameter           **decoded_signature_parameters)
+                                 const struct t_cose_sign_inputs *sign_inputs,
+                                 struct t_cose_parameter_storage *param_storage,
+                                 QCBORDecodeContext             *qcbor_decoder,
+                                 struct t_cose_parameter       **decoded_params)
 {
     const struct t_cose_signature_verify_eddsa *me =
                             (const struct t_cose_signature_verify_eddsa *)me_x;
@@ -130,7 +126,7 @@ t_cose_signature_verify_eddsa_cb(struct t_cose_signature_verify  *me_x,
                                          me->reader,
                                          me->reader_ctx,
                                          param_storage,
-                                         decoded_signature_parameters,
+                                         decoded_params,
                                         &protected_parameters);
     if(return_value != T_COSE_SUCCESS) {
         goto Done;
@@ -148,9 +144,9 @@ t_cose_signature_verify_eddsa_cb(struct t_cose_signature_verify  *me_x,
     /* --- Done decoding the COSE_Signature --- */
 
     return_value = t_cose_signature_verify1_eddsa_cb(me_x,
-                                                    option_flags,
-                                                    sign_inputs,
-                                                    *decoded_signature_parameters,
+                                                     option_flags,
+                                                     sign_inputs,
+                                                    *decoded_params,
                                                      signature);
 Done:
     return return_value;

--- a/src/t_cose_signature_verify_main.c
+++ b/src/t_cose_signature_verify_main.c
@@ -18,17 +18,15 @@
 #include "t_cose_crypto.h"
 
 
-/* Warning: this is still early development. Documentation may be incorrect. */
-
 /*
- * This is an implementation of t_cose_signature_verify1_callback.
+ * This is an implementation of \ref t_cose_signature_verify1_cb.
  */
 static enum t_cose_err_t
-t_cose_signature_verify1_main(struct t_cose_signature_verify   *me_x,
-                               const uint32_t                   option_flags,
-                               const struct t_cose_sign_inputs *sign_inputs,
-                               const struct t_cose_parameter   *parameter_list,
-                               const struct q_useful_buf_c      signature)
+t_cose_signature_verify1_main_cb(struct t_cose_signature_verify   *me_x,
+                                 const uint32_t                   option_flags,
+                                 const struct t_cose_sign_inputs *sign_inputs,
+                                 const struct t_cose_parameter   *parameter_list,
+                                 const struct q_useful_buf_c      signature)
 {
     const struct t_cose_signature_verify_main *me =
                           (const struct t_cose_signature_verify_main *)me_x;
@@ -89,16 +87,16 @@ Done:
           Signature validate
           Signature didn't validate
 
- This is an implementation of t_cose_signature_verify_callback
+ This is an implementation of t_cose_signature_verify_cb
  */
 static enum t_cose_err_t
-t_cose_signature_verify_main(struct t_cose_signature_verify     *me_x,
-                              const uint32_t                      option_flags,
-                              const struct t_cose_header_location loc,
-                              const struct t_cose_sign_inputs    *sign_inputs,
-                              struct t_cose_parameter_storage    *param_storage,
-                              QCBORDecodeContext                 *qcbor_decoder,
-                              struct t_cose_parameter           **decoded_signature_parameters)
+t_cose_signature_verify_main_cb(struct t_cose_signature_verify     *me_x,
+                                const uint32_t                      option_flags,
+                                const struct t_cose_header_location loc,
+                                const struct t_cose_sign_inputs    *sign_inputs,
+                                struct t_cose_parameter_storage    *param_storage,
+                                QCBORDecodeContext                 *qcbor_decoder,
+                                struct t_cose_parameter           **decoded_signature_parameters)
 {
     const struct t_cose_signature_verify_main *me =
                             (const struct t_cose_signature_verify_main *)me_x;
@@ -133,11 +131,11 @@ t_cose_signature_verify_main(struct t_cose_signature_verify     *me_x,
     /* --- Done decoding the COSE_Signature --- */
 
 
-    return_value = t_cose_signature_verify1_main(me_x,
-                                                 option_flags,
-                                                 sign_inputs,
-                                                *decoded_signature_parameters,
-                                                 signature);
+    return_value = t_cose_signature_verify1_main_cb(me_x,
+                                                    option_flags,
+                                                    sign_inputs,
+                                                   *decoded_signature_parameters,
+                                                    signature);
 Done:
     return return_value;
 }
@@ -147,6 +145,6 @@ void
 t_cose_signature_verify_main_init(struct t_cose_signature_verify_main *me)
 {
     memset(me, 0, sizeof(*me));
-    me->s.callback  = t_cose_signature_verify_main;
-    me->s.callback1 = t_cose_signature_verify1_main;
+    me->s.verify_cb  = t_cose_signature_verify_main_cb;
+    me->s.verify1_cb = t_cose_signature_verify1_main_cb;
 }

--- a/src/t_cose_signature_verify_main.c
+++ b/src/t_cose_signature_verify_main.c
@@ -18,9 +18,7 @@
 #include "t_cose_crypto.h"
 
 
-/*
- * This is an implementation of \ref t_cose_signature_verify1_cb.
- */
+/** This is an implementation of \ref t_cose_signature_verify1_cb. */
 static enum t_cose_err_t
 t_cose_signature_verify1_main_cb(struct t_cose_signature_verify   *me_x,
                                  const uint32_t                   option_flags,
@@ -89,14 +87,16 @@ Done:
 
  This is an implementation of t_cose_signature_verify_cb
  */
+
+/** This is an implementation of \ref t_cose_signature_verify_cb. */
 static enum t_cose_err_t
-t_cose_signature_verify_main_cb(struct t_cose_signature_verify     *me_x,
-                                const uint32_t                      option_flags,
+t_cose_signature_verify_main_cb(struct t_cose_signature_verify  *me_x,
+                                const uint32_t                  option_flags,
                                 const struct t_cose_header_location loc,
-                                const struct t_cose_sign_inputs    *sign_inputs,
-                                struct t_cose_parameter_storage    *param_storage,
-                                QCBORDecodeContext                 *qcbor_decoder,
-                                struct t_cose_parameter           **decoded_signature_parameters)
+                                const struct t_cose_sign_inputs *sign_inputs,
+                                struct t_cose_parameter_storage *param_storage,
+                                QCBORDecodeContext              *qcbor_decoder,
+                                struct t_cose_parameter        **decoded_params)
 {
     const struct t_cose_signature_verify_main *me =
                             (const struct t_cose_signature_verify_main *)me_x;
@@ -113,7 +113,7 @@ t_cose_signature_verify_main_cb(struct t_cose_signature_verify     *me_x,
                                          me->reader,
                                          me->reader_ctx,
                                          param_storage,
-                                         decoded_signature_parameters,
+                                         decoded_params,
                                         &protected_parameters);
     if(return_value != T_COSE_SUCCESS) {
         goto Done;
@@ -134,7 +134,7 @@ t_cose_signature_verify_main_cb(struct t_cose_signature_verify     *me_x,
     return_value = t_cose_signature_verify1_main_cb(me_x,
                                                     option_flags,
                                                     sign_inputs,
-                                                   *decoded_signature_parameters,
+                                                   *decoded_params,
                                                     signature);
 Done:
     return return_value;


### PR DESCRIPTION
Better and more consistent naming.

Separate out COSE_Sign1 from COSE_Signature/Sign better in the signer interface.