### PR TITLE
Better AEAD crypto adaptor; HPKE uses AEAD adaptor.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -114,6 +114,7 @@ if (BUILD_TESTS)
         test/run_tests.c
         test/t_cose_make_test_messages.c
         test/t_cose_test.c
+        test/t_cose_crypto_test.c
         test/t_cose_param_test.c
     )
 

--- a/Makefile.ossl
+++ b/Makefile.ossl
@@ -68,6 +68,7 @@ TEST_OBJ=test/t_cose_test.o \
     test/t_cose_make_test_messages.o \
     test/t_cose_compute_validate_mac_test.o \
     test/t_cose_param_test.o \
+    test/t_cose_crypto_test.o \
     $(CRYPTO_TEST_OBJ)
 
 

--- a/Makefile.ossl
+++ b/Makefile.ossl
@@ -49,7 +49,14 @@ CRYPTO_TEST_OBJ=test/t_cose_make_openssl_test_key.o
 
 
 # ---- compiler configuration -----
-# Optimize for size
+# This makefile uses a minimum of compiler flags so that it will
+# work out-of-the-box with a wide variety of compilers.  For example,
+# some compilers error out on some of the warnings flags gcc supports.
+# The $(CMD_LINE) variable allows passing in extra flags. This is
+# used on the stringent build script that is in
+# https://github.com/laurencelundblade/tdv.  This script is used
+# before pushes to master (though not yet through an automated build
+# process). See "warn:" below.
 C_OPTS=-Os -fPIC
 
 
@@ -82,12 +89,15 @@ SRC_OBJ=src/t_cose_util.o \
         src/t_cose_mac_compute.o \
         src/t_cose_mac_validate.o
 
-.PHONY: all install install_headers install_so uninstall clean
+.PHONY: all install install_headers install_so uninstall clean warn
 
 all: libt_cose.a t_cose_test t_cose_basic_example_ossl
 
 libt_cose.a: $(SRC_OBJ) $(CRYPTO_OBJ)
 	ar -r $@ $^
+
+warn:
+	make -f Makefile.ossl CMD_LINE="-Wall -Wextra -Wpedantic -Wshadow -Wconversion -Wcast-qual"
 
 # The shared library is not made by default because of platform
 # variability For example MacOS and Linux behave differently and some

--- a/Makefile.psa
+++ b/Makefile.psa
@@ -51,7 +51,14 @@ CRYPTO_TEST_OBJ=test/t_cose_make_psa_test_key.o
 
 
 # ---- compiler configuration -----
-# Optimize for size
+# This makefile uses a minimum of compiler flags so that it will
+# work out-of-the-box with a wide variety of compilers.  For example,
+# some compilers error out on some of the warnings flags gcc supports.
+# The $(CMD_LINE) variable allows passing in extra flags. This is
+# used on the stringent build script that is in
+# https://github.com/laurencelundblade/tdv.  This script is used
+# before pushes to master (though not yet through an automated build
+# process). See "warn:" below.
 C_OPTS=-Os -fPIC
 
 
@@ -99,12 +106,18 @@ SRC_OBJ=src/t_cose_util.o \
         src/t_cose_recipient_enc_hpke.o \
         src/hpke.o
 
-.PHONY: all install install_headers install_so uninstall clean
+.PHONY: all install install_headers install_so uninstall clean warn
 
 all: libt_cose.a t_cose_test t_cose_basic_example_psa t_cose_encryption_example_psa
 
 libt_cose.a: $(SRC_OBJ) $(CRYPTO_OBJ)
 	ar -r $@ $^
+
+# run "make warn" as a handy way to compile with the warning flags
+# used in the QCBOR release process. See CFLAGS above.
+warn:
+	make -f Makefile.psa CMD_LINE="-Wall -Wextra -Wpedantic -Wshadow -Wconversion -Wcast-qual"
+
 
 # The shared library is not made by default because of platform
 # variability For example MacOS and Linux behave differently and some

--- a/Makefile.psa
+++ b/Makefile.psa
@@ -74,6 +74,7 @@ TEST_OBJ=test/t_cose_test.o \
     test/t_cose_sign_verify_test.o \
     test/t_cose_compute_validate_mac_test.o \
     test/t_cose_make_test_messages.o \
+    test/t_cose_crypto_test.o \
     test/t_cose_param_test.o \
     $(CRYPTO_TEST_OBJ)
 

--- a/Makefile.test
+++ b/Makefile.test
@@ -46,7 +46,7 @@ C_OPTS=-Os -fPIC
 
 # ---- T_COSE Config and test options ----
 TEST_CONFIG_OPTS=-DT_COSE_ENABLE_HASH_FAIL_TEST -DT_COSE_DISABLE_SIGN_VERIFY_TESTS
-TEST_OBJ=test/t_cose_test.o test/run_tests.o test/t_cose_make_test_messages.o test/t_cose_make_test_test_key.o test/t_cose_param_test.o $(CRYPTO_TEST_OBJ)
+TEST_OBJ=test/t_cose_test.o test/run_tests.o test/t_cose_crypto_test.o test/t_cose_make_test_messages.o test/t_cose_make_test_test_key.o test/t_cose_param_test.o $(CRYPTO_TEST_OBJ)
 
 
 # ---- the main body that is invariant ----

--- a/Makefile.test
+++ b/Makefile.test
@@ -33,7 +33,14 @@ CRYPTO_TEST_OBJ=
 
 
 # ---- compiler configuration -----
-# Optimize for size
+# This makefile uses a minimum of compiler flags so that it will
+# work out-of-the-box with a wide variety of compilers.  For example,
+# some compilers error out on some of the warnings flags gcc supports.
+# The $(CMD_LINE) variable allows passing in extra flags. This is
+# used on the stringent build script that is in
+# https://github.com/laurencelundblade/tdv.  This script is used
+# before pushes to master (though not yet through an automated build
+# process). See "warn:" below.
 C_OPTS=-Os -fPIC
 
 
@@ -61,13 +68,18 @@ SRC_OBJ=src/t_cose_sign1_verify.o \
 	src/t_cose_mac_validate.o \
         src/hpke.o
 
-.PHONY: all clean
+.PHONY: all clean warn
 
 all: libt_cose.a t_cose_test
 
 
 libt_cose.a: $(SRC_OBJ) $(CRYPTO_OBJ)
 	ar -r $@ $^
+
+# run "make warn" as a handy way to compile with the warning flags
+# used in the QCBOR release process. See CFLAGS above.
+warn:
+	make -f Makefile.test CMD_LINE="-Wall -Wextra -Wpedantic -Wshadow -Wconversion -Wcast-qual"
 
 libt_cose.so: $(SRC_OBJ) $(CRYPTO_OBJ)
 	cc $^ $(CFLAGS) -dead_strip -o $@ -shared $(QCBOR_LIB) $(CRYPTO_LIB)

--- a/crypto_adapters/t_cose_openssl_crypto.c
+++ b/crypto_adapters/t_cose_openssl_crypto.c
@@ -1124,7 +1124,7 @@ t_cose_crypto_make_symmetric_key_handle(int32_t               cose_algorithm_id,
                                         struct q_useful_buf_c symmetric_key,
                                         struct t_cose_key    *key_handle)
 {
-    (void)cose_algorithm_id;
+    (void)cose_algorithm_id; // TODO: maybe check the algorithm is symmetric
     key_handle->crypto_lib   = T_COSE_CRYPTO_LIB_OPENSSL;
     key_handle->k.key_buffer = symmetric_key;
 

--- a/crypto_adapters/t_cose_psa_crypto.c
+++ b/crypto_adapters/t_cose_psa_crypto.c
@@ -878,7 +878,7 @@ t_cose_crypto_make_symmetric_key_handle(int32_t               cose_algorithm_id,
                             &psa_key_handle);
 
     if (status != PSA_SUCCESS) {
-        return T_COSE_ERR_KEY_IMPORT_FAILED; // TODO: do better with this error?
+        return T_COSE_ERR_KEY_IMPORT_FAILED;
     }
 
     key_handle->k.key_handle = psa_key_handle;

--- a/crypto_adapters/t_cose_psa_crypto.c
+++ b/crypto_adapters/t_cose_psa_crypto.c
@@ -139,7 +139,8 @@ static psa_algorithm_t cose_alg_id_to_psa_alg_id(int32_t cose_alg_id)
  *
  * \return The \ref t_cose_err_t.
  */
-enum t_cose_err_t psa_status_to_t_cose_error_signing(psa_status_t err)
+static enum t_cose_err_t
+psa_status_to_t_cose_error_signing(psa_status_t err)
 {
     /* Intentionally keeping to fewer mapped errors to save object code */
     return err == PSA_SUCCESS                   ? T_COSE_SUCCESS :
@@ -148,51 +149,6 @@ enum t_cose_err_t psa_status_to_t_cose_error_signing(psa_status_t err)
            err == PSA_ERROR_INSUFFICIENT_MEMORY ? T_COSE_ERR_INSUFFICIENT_MEMORY :
            err == PSA_ERROR_CORRUPTION_DETECTED ? T_COSE_ERR_TAMPERING_DETECTED :
                                                   T_COSE_ERR_SIG_FAIL;
-}
-
-enum t_cose_err_t moopmoop(psa_status_t err)
-{
-    /* Intentionally keeping to fewer mapped errors to save object code */
-    return err == PSA_SUCCESS                   ? T_COSE_SUCCESS :
-           err == PSA_ERROR_INVALID_SIGNATURE   ? T_COSE_ERR_SIG_VERIFY :
-           //err == PSA_ERROR_NOT_SUPPORTED       ? T_COSE_ERR_UNSUPPORTED_SIGNING_ALG:
-           err == PSA_ERROR_INSUFFICIENT_MEMORY ? T_COSE_ERR_INSUFFICIENT_MEMORY :
-           err == PSA_ERROR_INSUFFICIENT_MEMORY+1 ? T_COSE_ERR_INSUFFICIENT_MEMORY+1 :
-           err == PSA_ERROR_INSUFFICIENT_MEMORY+2 ? T_COSE_ERR_INSUFFICIENT_MEMORY+2 :
-           err == PSA_ERROR_CORRUPTION_DETECTED ? T_COSE_ERR_TAMPERING_DETECTED :
-                                                  T_COSE_ERR_SIG_FAIL;
-}
-
-int32_t meepmeep(const int32_t xx[][2], int32_t y)
-{
-    int i;
-    for(i = 0; xx[i][0] != INT32_MAX; i++) {
-        if(xx[i][0] == y) {
-            return xx[1][i];
-        }
-    }
-    return INT32_MAX;
-}
-
-enum t_cose_err_t mapmap(psa_status_t err)
-{
-    static const int32_t map[][2] = {
-      //  { PSA_SUCCESS                    , T_COSE_SUCCESS},
-       // { PSA_ERROR_INVALID_SIGNATURE    , T_COSE_ERR_SIG_VERIFY},
-       // { PSA_ERROR_INVALID_SIGNATURE    , T_COSE_ERR_SIG_VERIFY},
-        { PSA_ERROR_INVALID_SIGNATURE    , T_COSE_ERR_SIG_VERIFY},
-        { PSA_ERROR_INVALID_SIGNATURE    , T_COSE_ERR_SIG_VERIFY},
-        { INT32_MAX                      , INT32_MAX},
-
-
-    };
-
-    return (enum t_cose_err_t )meepmeep(map, (int32_t)err);
- /*          err == PSA_ERROR_NOT_SUPPORTED       ? T_COSE_ERR_UNSUPPORTED_SIGNING_ALG:
-           err == PSA_ERROR_INSUFFICIENT_MEMORY ? T_COSE_ERR_INSUFFICIENT_MEMORY :
-           err == PSA_ERROR_CORRUPTION_DETECTED ? T_COSE_ERR_TAMPERING_DETECTED :
-                                                  T_COSE_ERR_SIG_FAIL; */
-
 }
 
 

--- a/crypto_adapters/t_cose_psa_crypto.c
+++ b/crypto_adapters/t_cose_psa_crypto.c
@@ -152,7 +152,6 @@ psa_status_to_t_cose_error_signing(psa_status_t err)
 }
 
 
-
 /*
  * See documentation in t_cose_crypto.h
  */
@@ -825,7 +824,8 @@ t_cose_crypto_make_symmetric_key_handle(int32_t               cose_algorithm_id,
     size_t                 key_bitlen;
     psa_key_type_t         psa_keytype;
 
-    /* TODO: remove this and put it somewhere common. */
+    /* TODO: remove this and put it somewhere common. (It's OK to call twice,
+     * so having it here doesn't cause a problem in the short term */
     psa_crypto_init();
 
 
@@ -847,8 +847,6 @@ t_cose_crypto_make_symmetric_key_handle(int32_t               cose_algorithm_id,
             psa_keytype = PSA_KEY_TYPE_AES;
             key_bitlen = 256;
             break;
-
-            // TODO: support cha-cha?
 
         default:
             return T_COSE_ERR_UNSUPPORTED_CIPHER_ALG;
@@ -884,7 +882,7 @@ t_cose_crypto_make_symmetric_key_handle(int32_t               cose_algorithm_id,
     }
 
     key_handle->k.key_handle = psa_key_handle;
-    key_handle->crypto_lib = T_COSE_CRYPTO_LIB_PSA;
+    key_handle->crypto_lib   = T_COSE_CRYPTO_LIB_PSA;
 
     return T_COSE_SUCCESS;
 }
@@ -1036,21 +1034,3 @@ t_cose_crypto_aead_decrypt(const int32_t          cose_algorithm_id,
 
     return T_COSE_SUCCESS;
 }
-
-
-
-
-#ifdef XXX
-    static const int32_t map[][2] = {
-        { T_COSE_ALGORITHM_A128GCM    , PSA_ALG_GCM},
-        { T_COSE_ALGORITHM_A192GCM    , PSA_ALG_GCM},
-        { T_COSE_ALGORITHM_A256GCM    , PSA_ALG_GCM},
-        { INT32_MAX                      , INT32_MAX}
-    };
-
-    psa_algorithm_id = (psa_algorithm_t)meepmeep(map, cose_algorithm_id);
-    if(psa_algorithm_id == INT32_MAX) {
-        return T_COSE_ERR_UNSUPPORTED_CIPHER_ALG;
-    }
-#endif
-

--- a/crypto_adapters/t_cose_test_crypto.c
+++ b/crypto_adapters/t_cose_test_crypto.c
@@ -379,6 +379,8 @@ t_cose_crypto_make_symmetric_key_handle(int32_t               cose_algorithm_id,
                                         struct q_useful_buf_c symmetric_key,
                                         struct t_cose_key    *key_handle)
 {
+    (void)cose_algorithm_id;
+
     key_handle->k.key_buffer = symmetric_key;
     key_handle->crypto_lib   = T_COSE_CRYPTO_LIB_TEST;
 
@@ -434,6 +436,11 @@ t_cose_crypto_aead_encrypt(const int32_t          cose_algorithm_id,
 {
     struct q_useful_buf_c tag = Q_USEFUL_BUF_FROM_SZ_LITERAL(FAKE_TAG);
 
+    (void)nonce;
+    (void)aad;
+    (void)cose_algorithm_id;
+
+
     if(ciphertext_buffer.ptr == NULL) {
         /* Called in length calculation mode. Return length & exit. */
         ciphertext->len = aead_byte_count(cose_algorithm_id,
@@ -475,6 +482,11 @@ t_cose_crypto_aead_decrypt(const int32_t          cose_algorithm_id,
 {
     struct q_useful_buf_c expected_tag = Q_USEFUL_BUF_FROM_SZ_LITERAL(FAKE_TAG);
     struct q_useful_buf_c received_tag;
+    struct q_useful_buf_c received_plaintext;
+
+    (void)nonce;
+    (void)aad;
+    (void)cose_algorithm_id;
 
     if(key.crypto_lib != T_COSE_CRYPTO_LIB_TEST) {
         return T_COSE_ERR_INCORRECT_KEY_FOR_LIB;
@@ -482,12 +494,14 @@ t_cose_crypto_aead_decrypt(const int32_t          cose_algorithm_id,
 
     UsefulInputBuf UIB;
     UsefulInputBuf_Init(&UIB, ciphertext);
-    *plaintext = UsefulInputBuf_GetUsefulBuf(&UIB, ciphertext.len - expected_tag.len); // TODO: is subtraction safe?
+    received_plaintext = UsefulInputBuf_GetUsefulBuf(&UIB, ciphertext.len - expected_tag.len); // TODO: is subtraction safe?
     received_tag = UsefulInputBuf_GetUsefulBuf(&UIB, expected_tag.len);
 
     if(q_useful_buf_compare(expected_tag, received_tag)) {
         return 99; // TODO: error
     }
+
+    *plaintext = q_useful_buf_copy(plaintext_buffer, received_plaintext);
 
     if(q_useful_buf_c_is_null(*plaintext)) {
         return 99; // TODO: error

--- a/crypto_adapters/t_cose_test_crypto.c
+++ b/crypto_adapters/t_cose_test_crypto.c
@@ -368,4 +368,132 @@ t_cose_crypto_get_random(struct q_useful_buf    buffer,
     return T_COSE_SUCCESS;
 }
 
+
+
+
+/*
+ * See documentation in t_cose_crypto.h
+ */
+enum t_cose_err_t
+t_cose_crypto_make_symmetric_key_handle(int32_t               cose_algorithm_id,
+                                        struct q_useful_buf_c symmetric_key,
+                                        struct t_cose_key    *key_handle)
+{
+    key_handle->k.key_buffer = symmetric_key;
+    key_handle->crypto_lib   = T_COSE_CRYPTO_LIB_TEST;
+
+    return T_COSE_SUCCESS;
+}
+
+
+/* Compute size of ciphertext, given size of plaintext. Returns
+ * SIZE_MAX if the algorithm is unknown. Also returns the tag
+ * length. */
+static size_t
+aead_byte_count(const int32_t cose_algorithm_id,
+                size_t        plain_text_len)
+{
+    /* So far this just works for GCM AEAD algorithms, but can be
+     * augmented for others.
+     *
+     * For GCM as used by COSE and HPKE, the authentication tag is
+     * appended to the end of the cipher text and is always 16 bytes.
+     * Since GCM is a variant of counter mode, the ciphertext length
+     * is the same as the plaintext length. (This is not true of other
+     * ciphers).
+     * https://crypto.stackexchange.com/questions/26783/ciphertext-and-tag-size-and-iv-transmission-with-aes-in-gcm-mode
+     */
+
+    /* The same tag length for all COSE and HPKE AEAD algorithms supported.*/
+    const size_t common_gcm_tag_length = 16;
+
+    switch(cose_algorithm_id) {
+        case T_COSE_ALGORITHM_A128GCM:
+            return plain_text_len + common_gcm_tag_length;
+        case T_COSE_ALGORITHM_A192GCM:
+            return plain_text_len + common_gcm_tag_length;
+        case T_COSE_ALGORITHM_A256GCM:
+            return plain_text_len + common_gcm_tag_length;
+        default: return SIZE_MAX;;
+    }
+}
+
+#define FAKE_TAG "tagtagtagtagtagt"
+
+/*
+ * See documentation in t_cose_crypto.h
+ */
+enum t_cose_err_t
+t_cose_crypto_aead_encrypt(const int32_t          cose_algorithm_id,
+                           struct t_cose_key      key,
+                           struct q_useful_buf_c  nonce,
+                           struct q_useful_buf_c  aad,
+                           struct q_useful_buf_c  plaintext,
+                           struct q_useful_buf    ciphertext_buffer,
+                           struct q_useful_buf_c *ciphertext)
+{
+    struct q_useful_buf_c tag = Q_USEFUL_BUF_FROM_SZ_LITERAL(FAKE_TAG);
+
+    if(ciphertext_buffer.ptr == NULL) {
+        /* Called in length calculation mode. Return length & exit. */
+        ciphertext->len = aead_byte_count(cose_algorithm_id,
+                                          plaintext.len);;
+        return T_COSE_SUCCESS;
+    }
+
+    if(key.crypto_lib != T_COSE_CRYPTO_LIB_TEST) {
+        return T_COSE_ERR_INCORRECT_KEY_FOR_LIB;
+    }
+
+    /* Use useful output to copy the plaintext as pretend encryption
+     * and add "tagtag.." as a pretend tag.*/
+    UsefulOutBuf UOB;
+    UsefulOutBuf_Init(&UOB, ciphertext_buffer);
+    UsefulOutBuf_AppendUsefulBuf(&UOB, plaintext);
+    UsefulOutBuf_AppendUsefulBuf(&UOB, tag);
+    *ciphertext = UsefulOutBuf_OutUBuf(&UOB);
+
+    if(q_useful_buf_c_is_null(*ciphertext)) {
+        return 99;
+    }
+
+    return T_COSE_SUCCESS;
+}
+
+
+/*
+ * See documentation in t_cose_crypto.h
+ */
+enum t_cose_err_t
+t_cose_crypto_aead_decrypt(const int32_t          cose_algorithm_id,
+                           struct t_cose_key      key,
+                           struct q_useful_buf_c  nonce,
+                           struct q_useful_buf_c  aad,
+                           struct q_useful_buf_c  ciphertext,
+                           struct q_useful_buf    plaintext_buffer,
+                           struct q_useful_buf_c *plaintext)
+{
+    struct q_useful_buf_c expected_tag = Q_USEFUL_BUF_FROM_SZ_LITERAL(FAKE_TAG);
+    struct q_useful_buf_c received_tag;
+
+    if(key.crypto_lib != T_COSE_CRYPTO_LIB_TEST) {
+        return T_COSE_ERR_INCORRECT_KEY_FOR_LIB;
+    }
+
+    UsefulInputBuf UIB;
+    UsefulInputBuf_Init(&UIB, ciphertext);
+    *plaintext = UsefulInputBuf_GetUsefulBuf(&UIB, ciphertext.len - expected_tag.len); // TODO: is subtraction safe?
+    received_tag = UsefulInputBuf_GetUsefulBuf(&UIB, expected_tag.len);
+
+    if(q_useful_buf_compare(expected_tag, received_tag)) {
+        return 99; // TODO: error
+    }
+
+    if(q_useful_buf_c_is_null(*plaintext)) {
+        return 99; // TODO: error
+    }
+
+    return T_COSE_SUCCESS;
+}
+
 #endif /* T_COSE_DISABLE_EDDSA */

--- a/crypto_adapters/t_cose_test_crypto.c
+++ b/crypto_adapters/t_cose_test_crypto.c
@@ -461,7 +461,7 @@ t_cose_crypto_aead_encrypt(const int32_t          cose_algorithm_id,
     *ciphertext = UsefulOutBuf_OutUBuf(&UOB);
 
     if(q_useful_buf_c_is_null(*ciphertext)) {
-        return 99;
+        return T_COSE_ERR_TOO_SMALL;
     }
 
     return T_COSE_SUCCESS;
@@ -494,17 +494,20 @@ t_cose_crypto_aead_decrypt(const int32_t          cose_algorithm_id,
 
     UsefulInputBuf UIB;
     UsefulInputBuf_Init(&UIB, ciphertext);
-    received_plaintext = UsefulInputBuf_GetUsefulBuf(&UIB, ciphertext.len - expected_tag.len); // TODO: is subtraction safe?
+    if(ciphertext.len < expected_tag.len) {
+        return T_COSE_ERR_DECRYPT_FAIL;
+    }
+    received_plaintext = UsefulInputBuf_GetUsefulBuf(&UIB, ciphertext.len - expected_tag.len);
     received_tag = UsefulInputBuf_GetUsefulBuf(&UIB, expected_tag.len);
 
     if(q_useful_buf_compare(expected_tag, received_tag)) {
-        return 99; // TODO: error
+        return T_COSE_ERR_DATA_AUTH_FAILED;
     }
 
     *plaintext = q_useful_buf_copy(plaintext_buffer, received_plaintext);
 
     if(q_useful_buf_c_is_null(*plaintext)) {
-        return 99; // TODO: error
+        return T_COSE_ERR_TOO_SMALL;
     }
 
     return T_COSE_SUCCESS;

--- a/examples/t_cose_encryption_example_psa.c
+++ b/examples/t_cose_encryption_example_psa.c
@@ -328,7 +328,7 @@ int main(void)
     }
 
     printf("\nPlaintext: ");
-    printf("%s\n", plain_text_ubc.ptr); // TODO: probably shouldn't assume a NULL-terminated string here
+    printf("%s\n", (const char *)plain_text_ubc.ptr); // TODO: probably shouldn't assume a NULL-terminated string here
 
     memset(buffer, 0, sizeof(buffer));
     memset(encrypted_firmware, 0, encrypted_firmware_len);
@@ -377,7 +377,7 @@ int main(void)
     free_psa_key(t_cose_skR_key);
 
     printf("\nPlaintext: ");
-    printf("%s\n", plain_text_ubc.ptr); // TODO: probably shouldn't assume a NULL-terminated string here
+    printf("%s\n", (const char *)plain_text_ubc.ptr); // TODO: probably shouldn't assume a NULL-terminated string here
 
     memset(buffer, 0, sizeof(buffer));
     memset(encrypted_firmware, 0, encrypted_firmware_len);
@@ -434,7 +434,7 @@ int main(void)
     }
 
     printf("\nPlaintext: ");
-    printf("%s\n", plain_text_ubc.ptr); // TODO: probably shouldn't assume a NULL-terminated string here
+    printf("%s\n", (const char *)plain_text_ubc.ptr); // TODO: probably shouldn't assume a NULL-terminated string here
 
     memset(buffer, 0, sizeof(buffer));
     memset(encrypted_firmware, 0, encrypted_firmware_len);

--- a/examples/t_cose_encryption_example_psa.c
+++ b/examples/t_cose_encryption_example_psa.c
@@ -298,7 +298,7 @@ int main(void)
         return(EXIT_FAILURE);
     }
 
-    //free_psa_key(t_cose_pkR_key);
+    free_psa_key(t_cose_pkR_key);
 
     printf("COSE: ");
     print_bytestr(buffer, result_len);

--- a/examples/t_cose_encryption_example_psa.c
+++ b/examples/t_cose_encryption_example_psa.c
@@ -298,7 +298,7 @@ int main(void)
         return(EXIT_FAILURE);
     }
 
-    free_psa_key(t_cose_pkR_key);
+    //free_psa_key(t_cose_pkR_key);
 
     printf("COSE: ");
     print_bytestr(buffer, result_len);

--- a/examples/t_cose_encryption_example_psa.c
+++ b/examples/t_cose_encryption_example_psa.c
@@ -99,7 +99,7 @@ int test_cose_encrypt(uint32_t options,
 {
     struct t_cose_encrypt_enc_ctx enc_ctx;
     enum t_cose_err_t result;
-    struct q_useful_buf encrypted_firmware_final = {0,0};
+    struct q_useful_buf_c encrypted_firmware_final;
 
     struct q_useful_buf_c encrypt_cose;
 
@@ -189,7 +189,8 @@ int main(void)
     enum t_cose_err_t ret;
 
     uint8_t plaintext[400];
-    size_t plaintext_output_len;
+
+    struct q_useful_buf_c plain_text_ubc;
 
     /* Key id for PSK */
     struct q_useful_buf_c kid1 = {psk_kid, psk_kid_len};
@@ -319,7 +320,7 @@ int main(void)
                              buffer, result_len, //sizeof(buffer),
                              encrypted_firmware, encrypted_firmware_result_len,
                              plaintext, sizeof(plaintext),
-                             &plaintext_output_len);
+                             &plain_text_ubc);
 
     if (ret != T_COSE_SUCCESS) {
         printf("\nDecryption failed!\n");
@@ -327,11 +328,11 @@ int main(void)
     }
 
     printf("\nPlaintext: ");
-    printf("%s\n", plaintext);
+    printf("%s\n", plain_text_ubc.ptr); // TODO: probably shouldn't assume a NULL-terminated string here
 
     memset(buffer, 0, sizeof(buffer));
     memset(encrypted_firmware, 0, encrypted_firmware_len);
-    memset(plaintext, 0, plaintext_output_len);
+    memset(plaintext, 0, sizeof(plaintext));
 
 
 
@@ -366,7 +367,7 @@ int main(void)
                              buffer, result_len,
                              NULL, 0,
                              plaintext, sizeof(plaintext),
-                             &plaintext_output_len);
+                             &plain_text_ubc);
 
     if (ret != T_COSE_SUCCESS) {
         printf("\nDecryption failed!\n");
@@ -376,11 +377,11 @@ int main(void)
     free_psa_key(t_cose_skR_key);
 
     printf("\nPlaintext: ");
-    printf("%s\n", plaintext);
+    printf("%s\n", plain_text_ubc.ptr); // TODO: probably shouldn't assume a NULL-terminated string here
 
     memset(buffer, 0, sizeof(buffer));
     memset(encrypted_firmware, 0, encrypted_firmware_len);
-    memset(plaintext, 0, plaintext_output_len);
+    memset(plaintext, 0, sizeof(plaintext));
 #endif
     /* -------------------------------------------------------------------------*/
 
@@ -425,7 +426,7 @@ int main(void)
                              buffer, sizeof(buffer),
                              encrypted_firmware, encrypted_firmware_result_len,
                              plaintext, sizeof(plaintext),
-                             &plaintext_output_len);
+                             &plain_text_ubc);
 
     if (ret != T_COSE_SUCCESS) {
         printf("\nDecryption failed!\n");
@@ -433,11 +434,11 @@ int main(void)
     }
 
     printf("\nPlaintext: ");
-    printf("%s\n", plaintext);
+    printf("%s\n", plain_text_ubc.ptr); // TODO: probably shouldn't assume a NULL-terminated string here
 
     memset(buffer, 0, sizeof(buffer));
     memset(encrypted_firmware, 0, encrypted_firmware_len);
-    memset(plaintext, 0, plaintext_output_len);
+    memset(plaintext, 0, sizeof(plaintext));
 #endif /* T_COSE_DISABLE_HPKE */
 
 #ifndef T_COSE_DISABLE_AES_KW
@@ -470,7 +471,7 @@ int main(void)
     memset(buffer, 0, sizeof(buffer));
     memset(encrypted_firmware, 0, encrypted_firmware_len);
 #ifndef T_COSE_DISABLE_HPKE
-    memset(plaintext, 0, plaintext_output_len);
+    memset(plaintext, 0, sizeof(plaintext));
 #endif /* T_COSE_DISABLE_HPKE */
 
 #endif /* T_COSE_DISABLE_AES_KW */

--- a/inc/t_cose/t_cose_common.h
+++ b/inc/t_cose/t_cose_common.h
@@ -263,6 +263,12 @@ struct t_cose_key {
         void *key_ptr;
         /** For libraries that use an integer handle to the key */
         uint64_t key_handle;
+        /** For pointer and length of actual key bytes. Length is a uint16_t to keep the
+         * size of this struct down because it occurs on the stack. */
+        struct {
+            uint16_t       len;
+            const uint8_t *ptr;
+        } key_buffer;
     } k;
 };
 

--- a/inc/t_cose/t_cose_common.h
+++ b/inc/t_cose/t_cose_common.h
@@ -265,10 +265,7 @@ struct t_cose_key {
         uint64_t key_handle;
         /** For pointer and length of actual key bytes. Length is a uint16_t to keep the
          * size of this struct down because it occurs on the stack. */
-        struct {
-            uint16_t       len;
-            const uint8_t *ptr;
-        } key_buffer;
+        struct q_useful_buf_c key_buffer;
     } k;
 };
 

--- a/inc/t_cose/t_cose_common.h
+++ b/inc/t_cose/t_cose_common.h
@@ -384,10 +384,11 @@ enum t_cose_err_t {
      * when verifying a \c COSE_Sign1. */
     T_COSE_ERR_NO_KID = 12,
 
-    /** Signature verification failed. For example, the cryptographic
-     * operations completed successfully but hash wasn't as
-     * expected. */
+    /** Signature verification or data authentication failed. For
+     * example, the cryptographic operations completed successfully
+     * but hash wasn't as expected. */
     T_COSE_ERR_SIG_VERIFY = 13,
+    T_COSE_ERR_DATA_AUTH_FAILED = 13,
 
     /** Verification of a short-circuit signature failed. */
     T_COSE_ERR_BAD_SHORT_CIRCUIT_KID = 14,

--- a/inc/t_cose/t_cose_encrypt_dec.h
+++ b/inc/t_cose/t_cose_encrypt_dec.h
@@ -152,10 +152,9 @@ t_cose_encrypt_dec_set_private_key(struct t_cose_encrypt_dec_ctx *context,
  * \param[in] cose_len                  The COSE payload length.
  * \param[in] detached_ciphertext       The detached ciphertext.
  * \param[in] detached_ciphertext_len   The detached ciphertext length.
- * \param[out] plaintext                A buffer for plaintext.
+ * \param[out] plaintext_ptr                A buffer for plaintext.
  * \param[in] plaintext_len             The length of the plaintext buffer.
- * \param[out] plaintext_output_len     The true plaintext length after
- *                                      decryption.
+ * \param[out] plaintext     Place to return pointer and length of the plaintext.
  *
  * \return This returns one of the error codes defined by \ref t_cose_err_t.
  *
@@ -167,8 +166,8 @@ enum t_cose_err_t
 t_cose_encrypt_dec(struct t_cose_encrypt_dec_ctx *context,
                    uint8_t *cose, size_t cose_len,
                    uint8_t *detached_ciphertext, size_t detached_ciphertext_len,
-                   uint8_t *plaintext, size_t plaintext_len,
-                   size_t *plaintext_output_len
+                   uint8_t *plaintext_ptr, size_t plaintext_len,
+                   struct q_useful_buf_c *plaintext
                   );
 
 /* ------------------------------------------------------------------------
@@ -189,7 +188,7 @@ t_cose_encrypt_dec_set_private_key(struct t_cose_encrypt_dec_ctx *context,
                                    struct t_cose_key              recipient_key,
                                    struct q_useful_buf_c          kid)
 {
-    memcpy(&context->recipient_key, &recipient_key, sizeof(struct t_cose_key));
+    context->recipient_key = recipient_key;
     memcpy(&context->kid, &kid, sizeof(struct q_useful_buf_c));
 }
 

--- a/inc/t_cose/t_cose_encrypt_enc.h
+++ b/inc/t_cose/t_cose_encrypt_enc.h
@@ -213,7 +213,7 @@ enum t_cose_err_t
 t_cose_encrypt_enc(struct t_cose_encrypt_enc_ctx *context,
                    struct q_useful_buf_c          payload,
                    struct q_useful_buf            encrypted_payload,
-                   struct q_useful_buf           *encrypted_payload_final,
+                   struct q_useful_buf_c         *encrypted_payload_final,
                    struct q_useful_buf            out_buf,
                    struct q_useful_buf_c         *result);
 

--- a/inc/t_cose/t_cose_standard_constants.h
+++ b/inc/t_cose/t_cose_standard_constants.h
@@ -305,6 +305,10 @@
  * \def COSE_ALGORITHM_A192GCM
  *
  * \brief AES-GCM mode w/ 192-bit key, 128-bit tag
+ *
+ * Note that while RFC 9180 (HPKE) doesn't define
+ * support of this, RFC 9053 (COSE) for direct
+ * and key wrap encryption.
  */
 #define T_COSE_ALGORITHM_A192GCM 2
 

--- a/src/hpke.c
+++ b/src/hpke.c
@@ -1444,5 +1444,12 @@ int mbedtls_hpke_encrypt( unsigned int mode, hpke_suite_t suite,
                          cipherlen, cipher ); // ciphertext
 }
 
+#else
+
+void hpke_placeholder(void) {}
+
+
 #endif /* T_COSE_DISABLE_HPKE */
+
+
 

--- a/src/hpke.c
+++ b/src/hpke.c
@@ -34,6 +34,8 @@
 #include "hpke.h"
 #include "mbedtls/hkdf.h"
 
+#include "t_cose_crypto.h" /* The crypto adaptor layer */
+
 #include "mbedtls/platform_util.h"
 #include "mbedtls/error.h"
 
@@ -195,6 +197,29 @@ struct mbedtls_ssl_hpke_labels_struct const mbedtls_ssl_hpke_labels =
                      MBEDTLS_SSL_TLS1_3_KEY_SCHEDULE_MAX_CONTEXT_LEN )
 
 #undef MBEDTLS_SSL_HPKE_LABEL
+
+
+
+static int32_t
+hpke_aead_id_2_cose(const hpke_suite_t suite)
+{
+    // TODO: this can probably be a look up table (smaller code size and inlined)
+    switch(suite.aead_id) {
+        case HPKE_AEAD_ID_AES_GCM_256:
+            return T_COSE_ALGORITHM_A256GCM;
+
+        case HPKE_AEAD_ID_AES_GCM_128:
+            return T_COSE_ALGORITHM_A128GCM;
+/*
+        case PSA_ALG_CHACHA20_POLY1305:
+            return T_COSE_ALG_CHA_CHA; */
+
+        default:
+            return T_COSE_ALGORITHM_NONE;
+    }
+}
+
+
 
 int mbedtls_hpke_extract(
         const hpke_suite_t suite,
@@ -611,81 +636,7 @@ static int hpke_aead_dec(
     return( 0 );
 }
 
-static int hpke_aead_enc(
-            hpke_suite_t suite,
-            unsigned char *key, size_t keylen,
-            unsigned char *iv, size_t ivlen,
-            unsigned char *aad, size_t aadlen,
-            const unsigned char *plain, size_t plainlen,
-            unsigned char *cipher, size_t *cipherlen )
-{
-    psa_key_attributes_t attr_ciphertext = PSA_KEY_ATTRIBUTES_INIT;
-    psa_status_t status;
-    psa_algorithm_t mode;
-    size_t key_length;
-    psa_key_handle_t key_handle = 0;
-    psa_key_type_t key_type;
 
-    /* Initialize the PSA */
-    status = psa_crypto_init( );
-
-    if( status != PSA_SUCCESS )
-    {
-        return( status );
-    }
-
-    if ( ( suite.aead_id == HPKE_AEAD_ID_AES_GCM_256 ) ||
-         ( suite.aead_id == HPKE_AEAD_ID_AES_GCM_128 ) )
-    {
-        mode = PSA_ALG_GCM;
-        key_type = PSA_KEY_TYPE_AES;
-    }
-    else if (suite.aead_id == HPKE_AEAD_ID_CHACHA_POLY1305 )
-    {
-        mode = PSA_ALG_CHACHA20_POLY1305; 
-        key_type = PSA_KEY_TYPE_CHACHA20; 
-    }
-    else return( MBEDTLS_ERR_HPKE_BAD_INPUT_DATA );
-
-    // key length are in bits
-    key_length = hpke_aead_tab[suite.aead_id].Nk * 8;
-
-    if( key_length != keylen * 8 )
-    {
-        return( MBEDTLS_ERR_HPKE_INTERNAL_ERROR );
-    }
-
-    psa_set_key_usage_flags( &attr_ciphertext, PSA_KEY_USAGE_ENCRYPT );
-    psa_set_key_algorithm( &attr_ciphertext, mode );
-    psa_set_key_type( &attr_ciphertext, key_type );
-    psa_set_key_bits( &attr_ciphertext, key_length );
-
-    status = psa_import_key( &attr_ciphertext, key, key_length / 8, &key_handle );
-
-    if ( status != PSA_SUCCESS )
-    {
-        return( status );
-    }
-
-    status = psa_aead_encrypt( key_handle,       // key
-                               mode,             // algorithm
-                               iv,               // iv
-                               ivlen,            // iv length
-                               aad,              // additional data
-                               aadlen,           // additional data length
-                               plain, plainlen,  // plaintext
-                               cipher,           // ciphertext
-                               *cipherlen,       // ciphertext length
-                               cipherlen );      // length of output
-
-    if ( status != PSA_SUCCESS )
-    {
-        return( status );
-    }
-
-    psa_destroy_key( key_handle );
-    return( 0 );
-}
 
 /*!
  * \brief run the KEM with two keys as per draft-05
@@ -1225,6 +1176,7 @@ static int hpke_enc_int( unsigned int mode, hpke_suite_t suite,
     size_t key_len;
     psa_key_type_t type;
     int ret;
+    enum t_cose_err_t err;
 
     // Input check: mode
     switch( mode )
@@ -1427,22 +1379,46 @@ static int hpke_enc_int( unsigned int mode, hpke_suite_t suite,
         goto error;
     }
 
-    /* step 5. call the AEAD */
-    ret = hpke_aead_enc( suite,
-                         key, keylen,
-                         nonce, noncelen,
-                         aad, aadlen,
-                         clear, clearlen,
-                         cipher, cipherlen );
+    int32_t               cose_aead_algorithm_id;
+    struct q_useful_buf_c ci;
+    struct t_cose_key     cek_handle;
 
-    if( ret != 0 )
+    /* Map the HPKE algorithm ID to a COSE algorithm ID */
+    cose_aead_algorithm_id = hpke_aead_id_2_cose(suite);
+
+    /* Turn the bytes of the CEK into a key handle for the crypto library. */
+    err = t_cose_crypto_make_symmetric_key_handle(cose_aead_algorithm_id,
+                                            (struct q_useful_buf_c) {key, keylen},
+                                            &cek_handle);
+    if( err != 0 )
     {
+        ret = (int)err; // TODO: make this function return enum t_cose_err_t
+        goto error;
+    }
+
+
+    // TODO: move this call out of hpke and into main t_cose_encrypt_enc so it is shared for all key distribution types
+    /* Call crypto layer to actually encrypt the payload */
+    err = t_cose_crypto_aead_encrypt(cose_aead_algorithm_id,
+                                     cek_handle,
+                                     (struct q_useful_buf_c) {nonce, noncelen},
+                                     (struct q_useful_buf_c) {aad, aadlen},
+                                     (struct q_useful_buf_c) {clear, clearlen},
+                                     (struct q_useful_buf) {cipher, *cipherlen},
+                                     &ci);
+
+    *cipherlen = ci.len; // TODO: when fully converted to useful, this will go away
+
+    if( err != 0 )
+    {
+        ret = (int)err; // TODO: make this function return enum t_cose_err_t
         goto error;
     }
 
 error:
     return( ret );
 }
+
 
 int mbedtls_hpke_encrypt( unsigned int mode, hpke_suite_t suite,
                           char *pskid, size_t psklen, uint8_t *psk,

--- a/src/t_cose_crypto.h
+++ b/src/t_cose_crypto.h
@@ -1057,21 +1057,39 @@ t_cose_crypto_hpke_decrypt(int32_t                            cose_algorithm_id,
 
 
 /**
- * \brief Returns the t_cose_key given an algorithm.and a symmetric key
+ * \brief Returns the t_cose_key given an algorithm and a symmetric key.
  *
  * \param[in] cose_algorithm_id  COSE algorithm id
  * \param[in] symmetric_key                Symmetric key
  * \param[out] key               Key in t_cose_key structure.
  *
  * \retval T_COSE_SUCCESS
- *         The key was successfully imported and is returned in the
- *         t_cose_key format.
- * \retval T_COSE_ERR_UNKNOWN_KEY
- *         The provided symmetric key could not be imported.
+ *         The key was successfully imported and is returned as a
+ *         struct t_cose_key.
  * \retval T_COSE_ERR_UNSUPPORTED_CIPHER_ALG
  *         An unsupported COSE algorithm was provided.
- * \retval T_COSE_ERR_UNSUPPORTED_KEY_USAGE_FLAGS
- *         The provided key usage flags are unsupported.
+ * \retval T_COSE_ERR_KEY_IMPORT_FAILED
+ *         The provided symmetric key could not be imported.
+ *
+ * This is part of the crypto adaptor layer because there is an easy
+ * universal representation of a symmetric key -- a byte
+ * string (this is not true for public key algorithms, so
+ * there isn't similar for them (yet)).
+ *
+ * Some crypto libraries support key usage policy. For example, a key
+ * marked only to be used for decryption can't be used for
+ * encryption. The t_cose crypto adaptor layer doesn't support this
+ * for symmetric keys in the interest of code size, because it isn't
+ * universal and because it is not a critical security feature.  That
+ * is why this API has no usage flags and implementations of this for
+ * libraries that do have usage policy should allow all usage
+ * policies.
+ *
+ * Note however that many key handles used in t_cose just pass through
+ * to to the crypto library in a struct t_cose_key. For these the key
+ * usage will be enforced. For example, a signing key passed into to
+ * t_cose_sign will pass through to the library's sign API which will
+ * enforce the usage with t_cose non the wiser.
  */
 enum t_cose_err_t
 t_cose_crypto_make_symmetric_key_handle(int32_t               cose_algorithm_id,

--- a/src/t_cose_crypto.h
+++ b/src/t_cose_crypto.h
@@ -1055,13 +1055,12 @@ t_cose_crypto_hpke_decrypt(int32_t                            cose_algorithm_id,
                            struct q_useful_buf                plaintext,
                            size_t                            *plaintext_len);
 
+
 /**
  * \brief Returns the t_cose_key given an algorithm.and a symmetric key
  *
  * \param[in] cose_algorithm_id  COSE algorithm id
- * \param[in] cek                Symmetric key
- * \param[in] cek_len            Symmetric key length
- * \param[in] flags              Key usage flags
+ * \param[in] symmetric_key                Symmetric key
  * \param[out] key               Key in t_cose_key structure.
  *
  * \retval T_COSE_SUCCESS
@@ -1075,11 +1074,9 @@ t_cose_crypto_hpke_decrypt(int32_t                            cose_algorithm_id,
  *         The provided key usage flags are unsupported.
  */
 enum t_cose_err_t
-t_cose_crypto_get_cose_key(int32_t              cose_algorithm_id,
-                           uint8_t             *cek,
-                           size_t               cek_len,
-                           uint8_t              flags,
-                           struct t_cose_key   *key);
+t_cose_crypto_make_symmetric_key_handle(int32_t               cose_algorithm_id,
+                                        struct q_useful_buf_c symmetric_key,
+                                        struct t_cose_key     *key);
 
 
 /**
@@ -1096,10 +1093,14 @@ t_cose_crypto_get_cose_key(int32_t              cose_algorithm_id,
  * \param[in] add_data               Additional data used for decryption.
  * \param[in] ciphertext             The ciphertext to decrypt.
  * \param[in] plaintext_buffer       Buffer where the plaintext will be put.
- * \param[out] plaintext_output_len  The size of the plaintext.
+ * \param[out] plaintext  Place to return the plaintext
  *
  * The key provided must be a symmetric key of the correct type for
  * \c cose_algorithm_id.
+ *
+ * A key handle is used even though it could be a buffer with a key in
+ * order to allow use of keys internal to the crypto library, crypto HW and
+ * such. See t_cose_crypto_make_symmetric_key_handle().
  *
  * \retval T_COSE_SUCCESS
  *         The decryption operation was successful.
@@ -1109,13 +1110,13 @@ t_cose_crypto_get_cose_key(int32_t              cose_algorithm_id,
  *         The decryption operation failed.
  */
 enum t_cose_err_t
-t_cose_crypto_decrypt(int32_t                cose_algorithm_id,
-                      struct t_cose_key      key,
-                      struct q_useful_buf_c  nonce,
-                      struct q_useful_buf_c  add_data,
-                      struct q_useful_buf_c  ciphertext,
-                      struct q_useful_buf    plaintext_buffer,
-                      size_t                *plaintext_output_len);
+t_cose_crypto_aead_decrypt(int32_t                cose_algorithm_id,
+                           struct t_cose_key      key,
+                           struct q_useful_buf_c  nonce,
+                           struct q_useful_buf_c  add_data,
+                           struct q_useful_buf_c  ciphertext,
+                           struct q_useful_buf    plaintext_buffer,
+                           struct q_useful_buf_c *plaintext);
 
 /**
  * \brief Encrypt plaintext using an AEAD cipher. Part of the
@@ -1131,10 +1132,14 @@ t_cose_crypto_decrypt(int32_t                cose_algorithm_id,
  * \param[in] add_data               Additional data used for encryption.
  * \param[in] plaintext              The plaintext to encrypt.
  * \param[in] ciphertext_buffer      Buffer where the ciphertext will be put.
- * \param[out] ciphertext_output_len The size of the ciphertext.
+ * \param[out] ciphertext  Place to put pointer and length to ciphertext.
  *
  * The key provided must be a symmetric key of the correct type for
  * \c cose_algorithm_id.
+ *
+ * A key handle is used even though it could be a buffer with a key in
+ * order to allow use of keys internal to the crypto library, crypto HW and
+ * such. See t_cose_crypto_make_symmetric_key_handle().
  *
  * \retval T_COSE_SUCCESS
  *         The decryption operation was successful.
@@ -1146,13 +1151,13 @@ t_cose_crypto_decrypt(int32_t                cose_algorithm_id,
  *         The encryption operation failed.
  */
 enum t_cose_err_t
-t_cose_crypto_encrypt(int32_t                cose_algorithm_id,
-                      struct q_useful_buf_c  key,
-                      struct q_useful_buf_c  nonce,
-                      struct q_useful_buf_c  add_data,
-                      struct q_useful_buf_c  plaintext,
-                      struct q_useful_buf    ciphertext_buffer,
-                      size_t                *ciphertext_output_len);
+t_cose_crypto_aead_encrypt(int32_t                cose_algorithm_id,
+                           struct t_cose_key      key,
+                           struct q_useful_buf_c  nonce,
+                           struct q_useful_buf_c  add_data,
+                           struct q_useful_buf_c  plaintext,
+                           struct q_useful_buf    ciphertext_buffer,
+                           struct q_useful_buf_c *ciphertext);
 
 
 #ifdef __cplusplus

--- a/src/t_cose_crypto.h
+++ b/src/t_cose_crypto.h
@@ -1099,18 +1099,27 @@ t_cose_crypto_make_symmetric_key_handle(int32_t               cose_algorithm_id,
  * \c cose_algorithm_id.
  *
  * A key handle is used even though it could be a buffer with a key in
- * order to allow use of keys internal to the crypto library, crypto HW and
- * such. See t_cose_crypto_make_symmetric_key_handle().
+ * order to allow use of keys internal to the crypto library, crypto
+ * HW and such. See t_cose_crypto_make_symmetric_key_handle().
  *
  * This does not need to support a size calculation mode as is
  * required of t_cose_crypto_aead_encrypt().
+ *
+ * One of the following errors should be returned. Other errors should
+ * not be returned.
  *
  * \retval T_COSE_SUCCESS
  *         The decryption operation was successful.
  * \retval T_COSE_ERR_UNSUPPORTED_CIPHER_ALG
  *         An unsupported cipher algorithm was provided.
+ * \retval T_COSE_ERR_TOO_SMALL
+ *         The \c plaintext_buffer is too small.
+ * \retval T_COSE_ERR_WRONG_TYPE_OF_KEY
+ *         The key is not right for the algorithm or is not allowed for decryption.
+ * \retval T_COSE_ERR_DATA_AUTH_FAILED
+ *         The data integrity check failed.
  * \retval T_COSE_ERR_DECRYPT_FAIL
- *         The decryption operation failed.
+ *         Decryption failed for a reason other than above.
  */
 enum t_cose_err_t
 t_cose_crypto_aead_decrypt(int32_t                cose_algorithm_id,
@@ -1141,21 +1150,26 @@ t_cose_crypto_aead_decrypt(int32_t                cose_algorithm_id,
  * \c cose_algorithm_id.
  *
  * A key handle is used even though it could be a buffer with a key in
- * order to allow use of keys internal to the crypto library, crypto HW and
- * such. See t_cose_crypto_make_symmetric_key_handle().
+ * order to allow use of keys internal to the crypto library, crypto
+ * HW and such. See t_cose_crypto_make_symmetric_key_handle().
  *
- * This must support a size calculation mode which is indicated
- * by ciphertext_buffer.ptr == NULL and which fills the size
- * in ciphertext->len.
+ * This must support a size calculation mode which is indicated by
+ * ciphertext_buffer.ptr == NULL and which fills the size in
+ * ciphertext->len.
+ *
+ * One of the following errors should be returned. Other errors should
+ * not be returned.
  *
  * \retval T_COSE_SUCCESS
  *         The decryption operation was successful.
  * \retval T_COSE_ERR_UNSUPPORTED_CIPHER_ALG
  *         An unsupported cipher algorithm was provided.
- * \retval T_COSE_ERR_KEY_IMPORT_FAILED
- *         The provided key could not be imported.
+ * \retval T_COSE_ERR_TOO_SMALL
+ *         \c ciphertext_buffer is too small.
+ * \retval T_COSE_ERR_WRONG_TYPE_OF_KEY
+ *         The key is not right for the algorithm or is not allowed for encryption.
  * \retval T_COSE_ERR_ENCRYPT_FAIL
- *         The encryption operation failed.
+ *         Encryption failed for a reason other than above.
  */
 enum t_cose_err_t
 t_cose_crypto_aead_encrypt(int32_t                cose_algorithm_id,

--- a/src/t_cose_crypto.h
+++ b/src/t_cose_crypto.h
@@ -1102,6 +1102,9 @@ t_cose_crypto_make_symmetric_key_handle(int32_t               cose_algorithm_id,
  * order to allow use of keys internal to the crypto library, crypto HW and
  * such. See t_cose_crypto_make_symmetric_key_handle().
  *
+ * This does not need to support a size calculation mode as is
+ * required of t_cose_crypto_aead_encrypt().
+ *
  * \retval T_COSE_SUCCESS
  *         The decryption operation was successful.
  * \retval T_COSE_ERR_UNSUPPORTED_CIPHER_ALG
@@ -1140,6 +1143,10 @@ t_cose_crypto_aead_decrypt(int32_t                cose_algorithm_id,
  * A key handle is used even though it could be a buffer with a key in
  * order to allow use of keys internal to the crypto library, crypto HW and
  * such. See t_cose_crypto_make_symmetric_key_handle().
+ *
+ * This must support a size calculation mode which is indicated
+ * by ciphertext_buffer.ptr == NULL and which fills the size
+ * in ciphertext->len.
  *
  * \retval T_COSE_SUCCESS
  *         The decryption operation was successful.

--- a/src/t_cose_encrypt_dec.c
+++ b/src/t_cose_encrypt_dec.c
@@ -23,7 +23,7 @@ t_cose_encrypt_dec(struct t_cose_encrypt_dec_ctx* me,
                    size_t detached_ciphertext_len,
                    uint8_t *plaintext,
                    size_t plaintext_len,
-                   size_t *plaintext_output_len)
+                   struct q_useful_buf_c *plain_text)
 {
 #if !defined(T_COSE_DISABLE_HPKE) && !defined(T_COSE_DISABLE_AES_KW)
 
@@ -429,37 +429,27 @@ t_cose_encrypt_dec(struct t_cose_encrypt_dec_ctx* me,
     }
 
     if (me->key_distribution == T_COSE_KEY_DISTRIBUTION_HPKE) {
+        enum t_cose_err_t err;
 
-        cose_result = t_cose_crypto_get_cose_key((int32_t) algorithm_id,
-                                                 cek,
-                                                 cek_len,
-                                                 T_COSE_KEY_USAGE_FLAG_DECRYPT,
-                                                 &cek_key);
-
-        if (cose_result != T_COSE_SUCCESS) {
-            return(cose_result);
+        err = t_cose_crypto_make_symmetric_key_handle((int32_t)algorithm_id,
+                                                      (struct q_useful_buf_c) {cek, cek_len},
+                                                      &cek_key);
+        if(err) {
+            return 11; // TODO: correct error code
         }
-        cose_result = t_cose_crypto_decrypt((int32_t) algorithm_id,
-                                            cek_key,
-                                            nonce_cbor,
-                                            add_data_buf,
-                                            cipher_text,
-            (struct q_useful_buf) {.ptr = plaintext, .len = plaintext_len},
-                                            plaintext_output_len);
-
-        // TODO: put this in crypto layer
-        // TODO: find the other key memory leaks (pretty sure there are some...)
-        psa_close_key((psa_key_handle_t)cek_key.k.key_handle);
 
     } else {
-        cose_result = t_cose_crypto_decrypt((int32_t) algorithm_id,
-                                            me->recipient_key,
-                                            nonce_cbor,
-                                            add_data_buf,
-                                            cipher_text,
-            (struct q_useful_buf) {.ptr = plaintext, .len = plaintext_len},
-                                            plaintext_output_len);
+        cek_key = me->recipient_key;
     }
+
+    cose_result = t_cose_crypto_aead_decrypt((int32_t) algorithm_id,
+                                             cek_key,
+                                             nonce_cbor,
+                                             add_data_buf,
+                                             cipher_text,
+                                             (struct q_useful_buf) {.ptr = plaintext, .len = plaintext_len},
+                                             plain_text);
+
 
     if (cose_result != T_COSE_SUCCESS) {
         return(cose_result);
@@ -474,7 +464,7 @@ t_cose_encrypt_dec(struct t_cose_encrypt_dec_ctx* me,
     (void)detached_ciphertext_len;
     (void)plaintext;
     (void)plaintext_len;
-    (void)plaintext_output_len;
+    (void)plain_text;
 
     return T_COSE_ERR_FAIL;
 #endif /* T_COSE_DISABLE_HPKE */

--- a/src/t_cose_encrypt_dec.c
+++ b/src/t_cose_encrypt_dec.c
@@ -147,6 +147,8 @@ t_cose_encrypt_dec(struct t_cose_encrypt_dec_ctx* me,
         detached_mode = true;
     }
 
+    (void)detached_mode; // TODO: use this variable or get rid of it
+
     /* Two key distribution mechanisms are supported, namely
      *  - Direct key distribution (where no recipient info is included)
      *  - HPKE-based key distribution (which requires recipient info)

--- a/src/t_cose_recipient_dec_hpke.c
+++ b/src/t_cose_recipient_dec_hpke.c
@@ -59,6 +59,8 @@ t_cose_crypto_hpke_decrypt(int32_t                cose_algorithm_id,
         return(T_COSE_ERR_UNSUPPORTED_KEY_EXCHANGE_ALG);
     }
 
+    (void)key_bitlen; // TODO: use this or get rid of it.
+
     /* Execute HPKE */
     *plaintext_len = plaintext.len;
 

--- a/src/t_cose_sign1_verify.c
+++ b/src/t_cose_sign1_verify.c
@@ -34,9 +34,11 @@ t_cose_sign1_verify_init(struct t_cose_sign1_verify_ctx *me,
     t_cose_sign_add_verifier(&(me->me2),
                        t_cose_signature_verify_from_main(&(me->main_verifier)));
 
+#ifndef T_COSE_DISABLE_EDDSA
     t_cose_signature_verify_eddsa_init(&(me->eddsa_verifier), option_flags);
     t_cose_sign_add_verifier(&(me->me2),
                     t_cose_signature_verify_from_eddsa(&(me->eddsa_verifier)));
+#endif /* !T_COSE_DISABLE_EDDSA */
 }
 
 

--- a/src/t_cose_signature_sign_eddsa.c
+++ b/src/t_cose_signature_sign_eddsa.c
@@ -17,6 +17,8 @@
 #include "t_cose/t_cose_parameters.h"
 #include "t_cose_util.h"
 
+#ifndef T_COSE_DISABLE_EDDSA
+
 
 /** This is an implementation of \ref t_cose_signature_sign_headers_cb */
 static void
@@ -138,3 +140,9 @@ t_cose_signature_sign_eddsa_init(struct t_cose_signature_sign_eddsa *me)
     me->s.sign1_cb   = t_cose_signature_sign1_eddsa_cb;
     me->s.headers_cb = t_cose_signature_sign_headers_eddsa_cb;
 }
+
+#else /* !T_COSE_DISABLE_EDDSA */
+
+void t_cose_signature_verify_eddsa_placeholder(void) {}
+
+#endif /* !T_COSE_DISABLE_EDDSA */

--- a/src/t_cose_signature_verify_eddsa.c
+++ b/src/t_cose_signature_verify_eddsa.c
@@ -17,6 +17,7 @@
 #include "qcbor/qcbor_spiffy_decode.h"
 #include "t_cose_crypto.h"
 
+#ifndef T_COSE_DISABLE_EDDSA
 
 /** This is an implementation of \ref t_cose_signature_verify1_cb. */
 static enum t_cose_err_t
@@ -168,3 +169,9 @@ t_cose_signature_verify_eddsa_init(struct t_cose_signature_verify_eddsa *me,
      */
     me->auxiliary_buffer.len = SIZE_MAX;
 }
+
+#else
+
+void t_cose_signature_verify_eddsa_placeholder(void) {}
+
+#endif

--- a/t_cose.xcodeproj/project.pbxproj
+++ b/t_cose.xcodeproj/project.pbxproj
@@ -165,6 +165,9 @@
 		E7F1736E29592A4D00E5ADF3 /* t_cose_recipient_dec_aes_kw.c in Sources */ = {isa = PBXBuildFile; fileRef = E77108082917EDA900D8ADF4 /* t_cose_recipient_dec_aes_kw.c */; };
 		E7F1736F29592BD000E5ADF3 /* hpke.c in Sources */ = {isa = PBXBuildFile; fileRef = E7F17342294967CD00E5ADF3 /* hpke.c */; };
 		E7F1737029592BD200E5ADF3 /* hpke.c in Sources */ = {isa = PBXBuildFile; fileRef = E7F17342294967CD00E5ADF3 /* hpke.c */; };
+		E7F17373295D1EC700E5ADF3 /* t_cose_crypto_test.c in Sources */ = {isa = PBXBuildFile; fileRef = E7F17372295D1EC700E5ADF3 /* t_cose_crypto_test.c */; };
+		E7F17374295D1EC800E5ADF3 /* t_cose_crypto_test.c in Sources */ = {isa = PBXBuildFile; fileRef = E7F17372295D1EC700E5ADF3 /* t_cose_crypto_test.c */; };
+		E7F17375295D1EC800E5ADF3 /* t_cose_crypto_test.c in Sources */ = {isa = PBXBuildFile; fileRef = E7F17372295D1EC700E5ADF3 /* t_cose_crypto_test.c */; };
 		E7F70AC62270DFAE007CE07F /* t_cose_test.c in Sources */ = {isa = PBXBuildFile; fileRef = E7F70AC52270DFAE007CE07F /* t_cose_test.c */; };
 		E7FECC472887430700420F6F /* t_cose_sign_sign.c in Sources */ = {isa = PBXBuildFile; fileRef = E7FECC452887430600420F6F /* t_cose_sign_sign.c */; };
 		E7FECC49288754E200420F6F /* t_cose_sign_sign.c in Sources */ = {isa = PBXBuildFile; fileRef = E7FECC452887430600420F6F /* t_cose_sign_sign.c */; };
@@ -353,6 +356,8 @@
 		E7F17341294967CC00E5ADF3 /* hpke.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = hpke.h; sourceTree = "<group>"; };
 		E7F17342294967CD00E5ADF3 /* hpke.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = hpke.c; sourceTree = "<group>"; };
 		E7F173692959292700E5ADF3 /* t_cose_encryption_example_psa */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = t_cose_encryption_example_psa; sourceTree = BUILT_PRODUCTS_DIR; };
+		E7F17371295D1EC700E5ADF3 /* t_cose_crypto_test.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = t_cose_crypto_test.h; sourceTree = "<group>"; };
+		E7F17372295D1EC700E5ADF3 /* t_cose_crypto_test.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = t_cose_crypto_test.c; sourceTree = "<group>"; };
 		E7F70AC42270DFAE007CE07F /* t_cose_test.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = t_cose_test.h; sourceTree = "<group>"; };
 		E7F70AC52270DFAE007CE07F /* t_cose_test.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = t_cose_test.c; sourceTree = "<group>"; };
 		E7FECC452887430600420F6F /* t_cose_sign_sign.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = t_cose_sign_sign.c; sourceTree = "<group>"; };
@@ -634,6 +639,8 @@
 				E721CB9123628B5F00C7FD56 /* t_cose_make_psa_test_key.c */,
 				E7AF703428DADF5E00F07637 /* t_cose_param_test.h */,
 				E7AF703528DADF5E00F07637 /* t_cose_param_test.c */,
+				E7F17371295D1EC700E5ADF3 /* t_cose_crypto_test.h */,
+				E7F17372295D1EC700E5ADF3 /* t_cose_crypto_test.c */,
 			);
 			path = test;
 			sourceTree = "<group>";
@@ -808,6 +815,7 @@
 				E762D6D728CC0BBD00A22792 /* t_cose_mac_validate.c in Sources */,
 				E7F17327293B09E500E5ADF3 /* t_cose_signature_sign_main.c in Sources */,
 				E77108202917EDA900D8ADF4 /* t_cose_recipient_dec_hpke.c in Sources */,
+				E7F17373295D1EC700E5ADF3 /* t_cose_crypto_test.c in Sources */,
 				E7F17328293B09E500E5ADF3 /* t_cose_signature_verify_main.c in Sources */,
 				E730E60C23612DAB00175CE0 /* run_tests.c in Sources */,
 				E730E62123612E3900175CE0 /* t_cose_test_crypto.c in Sources */,
@@ -895,6 +903,7 @@
 				E771082E2917EDA900D8ADF4 /* t_cose_recipient_enc_hpke.c in Sources */,
 				E7F1730429275F4800E5ADF3 /* t_cose_signature_sign_eddsa.c in Sources */,
 				E73CDAB223A7316700D262E0 /* t_cose_util.c in Sources */,
+				E7F17375295D1EC800E5ADF3 /* t_cose_crypto_test.c in Sources */,
 				E7FECC61288B346300420F6F /* t_cose_sign_verify.c in Sources */,
 				E73CDAB623A7316700D262E0 /* t_cose_parameters.c in Sources */,
 				E73CDAB823A7316700D262E0 /* t_cose_sign_verify_test.c in Sources */,
@@ -977,6 +986,7 @@
 				E7E36E93226CB9460040613B /* t_cose_sign1_sign.c in Sources */,
 				E771080F2917EDA900D8ADF4 /* t_cose_recipient_dec_aes_kw.c in Sources */,
 				E7F17329293B0EE200E5ADF3 /* t_cose_signature_sign_main.c in Sources */,
+				E7F17374295D1EC800E5ADF3 /* t_cose_crypto_test.c in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/t_cose.xcodeproj/project.pbxproj
+++ b/t_cose.xcodeproj/project.pbxproj
@@ -81,7 +81,6 @@
 		E771082F2917EDA900D8ADF4 /* t_cose_recipient_enc_hpke.c in Sources */ = {isa = PBXBuildFile; fileRef = E771080D2917EDA900D8ADF4 /* t_cose_recipient_enc_hpke.c */; };
 		E77108302917EDA900D8ADF4 /* t_cose_recipient_enc_hpke.c in Sources */ = {isa = PBXBuildFile; fileRef = E771080D2917EDA900D8ADF4 /* t_cose_recipient_enc_hpke.c */; };
 		E77108312917EDA900D8ADF4 /* t_cose_recipient_enc_hpke.c in Sources */ = {isa = PBXBuildFile; fileRef = E771080D2917EDA900D8ADF4 /* t_cose_recipient_enc_hpke.c */; };
-		E771083A2918578800D8ADF4 /* t_cose_encryption_example_psa.c in Sources */ = {isa = PBXBuildFile; fileRef = E77108332918577500D8ADF4 /* t_cose_encryption_example_psa.c */; };
 		E772026F23CAEC84006E966E /* t_cose_sign1_verify.c in Sources */ = {isa = PBXBuildFile; fileRef = E7E36E8A226CB9460040613B /* t_cose_sign1_verify.c */; };
 		E772027123CAEC84006E966E /* t_cose_test.c in Sources */ = {isa = PBXBuildFile; fileRef = E7F70AC52270DFAE007CE07F /* t_cose_test.c */; };
 		E772027323CAEC84006E966E /* t_cose_psa_crypto.c in Sources */ = {isa = PBXBuildFile; fileRef = E73CDAD223AD4E6D00D262E0 /* t_cose_psa_crypto.c */; };
@@ -140,6 +139,32 @@
 		E7F17343294967CD00E5ADF3 /* hpke.c in Sources */ = {isa = PBXBuildFile; fileRef = E7F17342294967CD00E5ADF3 /* hpke.c */; };
 		E7F17344294AF07200E5ADF3 /* hpke.c in Sources */ = {isa = PBXBuildFile; fileRef = E7F17342294967CD00E5ADF3 /* hpke.c */; };
 		E7F17345294AF18500E5ADF3 /* hpke.c in Sources */ = {isa = PBXBuildFile; fileRef = E7F17342294967CD00E5ADF3 /* hpke.c */; };
+		E7F173512959292700E5ADF3 /* t_cose_sign_sign.c in Sources */ = {isa = PBXBuildFile; fileRef = E7FECC452887430600420F6F /* t_cose_sign_sign.c */; };
+		E7F173522959292700E5ADF3 /* t_cose_encryption_example_psa.c in Sources */ = {isa = PBXBuildFile; fileRef = E77108332918577500D8ADF4 /* t_cose_encryption_example_psa.c */; };
+		E7F173532959292700E5ADF3 /* t_cose_encrypt_dec.c in Sources */ = {isa = PBXBuildFile; fileRef = E771080A2917EDA900D8ADF4 /* t_cose_encrypt_dec.c */; };
+		E7F173542959292700E5ADF3 /* t_cose_sign1_verify.c in Sources */ = {isa = PBXBuildFile; fileRef = E7E36E8A226CB9460040613B /* t_cose_sign1_verify.c */; };
+		E7F173552959292700E5ADF3 /* t_cose_psa_crypto.c in Sources */ = {isa = PBXBuildFile; fileRef = E73CDAD223AD4E6D00D262E0 /* t_cose_psa_crypto.c */; };
+		E7F173562959292700E5ADF3 /* t_cose_util.c in Sources */ = {isa = PBXBuildFile; fileRef = E7E36E89226CB9460040613B /* t_cose_util.c */; };
+		E7F173572959292700E5ADF3 /* t_cose_parameters.c in Sources */ = {isa = PBXBuildFile; fileRef = 0F9105792321878F00008572 /* t_cose_parameters.c */; };
+		E7F173582959292700E5ADF3 /* t_cose_recipient_dec_hpke.c in Sources */ = {isa = PBXBuildFile; fileRef = E771080B2917EDA900D8ADF4 /* t_cose_recipient_dec_hpke.c */; };
+		E7F173592959292700E5ADF3 /* t_cose_encrypt_enc.c in Sources */ = {isa = PBXBuildFile; fileRef = E77108092917EDA900D8ADF4 /* t_cose_encrypt_enc.c */; };
+		E7F1735A2959292700E5ADF3 /* t_cose_sign_verify.c in Sources */ = {isa = PBXBuildFile; fileRef = E7FECC5E288B266500420F6F /* t_cose_sign_verify.c */; };
+		E7F1735B2959292700E5ADF3 /* t_cose_signature_sign_eddsa.c in Sources */ = {isa = PBXBuildFile; fileRef = E7F173012923E09100E5ADF3 /* t_cose_signature_sign_eddsa.c */; };
+		E7F1735C2959292700E5ADF3 /* t_cose_recipient_enc_hpke.c in Sources */ = {isa = PBXBuildFile; fileRef = E771080D2917EDA900D8ADF4 /* t_cose_recipient_enc_hpke.c */; };
+		E7F1735D2959292700E5ADF3 /* sha256.c in Sources */ = {isa = PBXBuildFile; fileRef = E730E60723612D2B00175CE0 /* sha256.c */; };
+		E7F1735E2959292700E5ADF3 /* t_cose_signature_verify_main.c in Sources */ = {isa = PBXBuildFile; fileRef = E7F17326293B09E400E5ADF3 /* t_cose_signature_verify_main.c */; };
+		E7F1735F2959292700E5ADF3 /* t_cose_signature_verify_eddsa.c in Sources */ = {isa = PBXBuildFile; fileRef = E7F173072928557A00E5ADF3 /* t_cose_signature_verify_eddsa.c */; };
+		E7F173602959292700E5ADF3 /* t_cose_sign1_sign.c in Sources */ = {isa = PBXBuildFile; fileRef = E7E36E8E226CB9460040613B /* t_cose_sign1_sign.c */; };
+		E7F173612959292700E5ADF3 /* t_cose_signature_sign_main.c in Sources */ = {isa = PBXBuildFile; fileRef = E7F17325293B09E400E5ADF3 /* t_cose_signature_sign_main.c */; };
+		E7F173632959292700E5ADF3 /* libmbedcrypto.a in Frameworks */ = {isa = PBXBuildFile; fileRef = E751F9F027E1F90F00EBA5FA /* libmbedcrypto.a */; };
+		E7F173642959292700E5ADF3 /* libqcbor.a in Frameworks */ = {isa = PBXBuildFile; fileRef = E7C960A527F7569500FB537C /* libqcbor.a */; };
+		E7F1736A2959296B00E5ADF3 /* t_cose_basic_example_psa.c in Sources */ = {isa = PBXBuildFile; fileRef = E73BF6D223AFFA6500DF5C36 /* t_cose_basic_example_psa.c */; };
+		E7F1736B29592A2C00E5ADF3 /* t_cose_recipient_dec_aes_kw.c in Sources */ = {isa = PBXBuildFile; fileRef = E77108082917EDA900D8ADF4 /* t_cose_recipient_dec_aes_kw.c */; };
+		E7F1736C29592A4500E5ADF3 /* t_cose_recipient_enc_aes_kw.c in Sources */ = {isa = PBXBuildFile; fileRef = E771080C2917EDA900D8ADF4 /* t_cose_recipient_enc_aes_kw.c */; };
+		E7F1736D29592A4600E5ADF3 /* t_cose_recipient_enc_aes_kw.c in Sources */ = {isa = PBXBuildFile; fileRef = E771080C2917EDA900D8ADF4 /* t_cose_recipient_enc_aes_kw.c */; };
+		E7F1736E29592A4D00E5ADF3 /* t_cose_recipient_dec_aes_kw.c in Sources */ = {isa = PBXBuildFile; fileRef = E77108082917EDA900D8ADF4 /* t_cose_recipient_dec_aes_kw.c */; };
+		E7F1736F29592BD000E5ADF3 /* hpke.c in Sources */ = {isa = PBXBuildFile; fileRef = E7F17342294967CD00E5ADF3 /* hpke.c */; };
+		E7F1737029592BD200E5ADF3 /* hpke.c in Sources */ = {isa = PBXBuildFile; fileRef = E7F17342294967CD00E5ADF3 /* hpke.c */; };
 		E7F70AC62270DFAE007CE07F /* t_cose_test.c in Sources */ = {isa = PBXBuildFile; fileRef = E7F70AC52270DFAE007CE07F /* t_cose_test.c */; };
 		E7FECC472887430700420F6F /* t_cose_sign_sign.c in Sources */ = {isa = PBXBuildFile; fileRef = E7FECC452887430600420F6F /* t_cose_sign_sign.c */; };
 		E7FECC49288754E200420F6F /* t_cose_sign_sign.c in Sources */ = {isa = PBXBuildFile; fileRef = E7FECC452887430600420F6F /* t_cose_sign_sign.c */; };
@@ -203,6 +228,15 @@
 			runOnlyForDeploymentPostprocessing = 1;
 		};
 		E7E36E76226CB8400040613B /* CopyFiles */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = /usr/share/man/man1/;
+			dstSubfolderSpec = 0;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 1;
+		};
+		E7F173652959292700E5ADF3 /* CopyFiles */ = {
 			isa = PBXCopyFilesBuildPhase;
 			buildActionMask = 2147483647;
 			dstPath = /usr/share/man/man1/;
@@ -318,6 +352,7 @@
 		E7F1733F2948016800E5ADF3 /* t_cose_encryption_example_psa.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = t_cose_encryption_example_psa.h; sourceTree = "<group>"; };
 		E7F17341294967CC00E5ADF3 /* hpke.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = hpke.h; sourceTree = "<group>"; };
 		E7F17342294967CD00E5ADF3 /* hpke.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = hpke.c; sourceTree = "<group>"; };
+		E7F173692959292700E5ADF3 /* t_cose_encryption_example_psa */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = t_cose_encryption_example_psa; sourceTree = BUILT_PRODUCTS_DIR; };
 		E7F70AC42270DFAE007CE07F /* t_cose_test.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = t_cose_test.h; sourceTree = "<group>"; };
 		E7F70AC52270DFAE007CE07F /* t_cose_test.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = t_cose_test.c; sourceTree = "<group>"; };
 		E7FECC452887430600420F6F /* t_cose_sign_sign.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = t_cose_sign_sign.c; sourceTree = "<group>"; };
@@ -376,6 +411,15 @@
 			files = (
 				E74FFBBA263BAB38003B66FF /* libcrypto.a in Frameworks */,
 				E7C960A727F7569F00FB537C /* libqcbor.a in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		E7F173622959292700E5ADF3 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				E7F173632959292700E5ADF3 /* libmbedcrypto.a in Frameworks */,
+				E7F173642959292700E5ADF3 /* libqcbor.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -453,6 +497,7 @@
 				E7F70AC32270DF90007CE07F /* test */,
 				E730E605235E0B1800175CE0 /* QCBOR Interface */,
 				E751F9DD27E1F81000EBA5FA /* PSA Interface */,
+				E7F1734B2959290E00E5ADF3 /* t_cose_encryption_example_psa */,
 				E7F70AB22270D989007CE07F /* Frameworks */,
 				E7E36E79226CB8400040613B /* Products */,
 			);
@@ -467,6 +512,7 @@
 				E73BF6EE23AFFB4100DF5C36 /* t_cose_basic_example_psa */,
 				E73BF71C23B07ACF00DF5C36 /* t_cose_basic_example_openssl */,
 				E772028523CAEC84006E966E /* t_cose_psa_noss */,
+				E7F173692959292700E5ADF3 /* t_cose_encryption_example_psa */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -541,6 +587,13 @@
 				E7F1733B294358D100E5ADF3 /* t_cose_test_crypto.h */,
 			);
 			path = crypto_adapters;
+			sourceTree = "<group>";
+		};
+		E7F1734B2959290E00E5ADF3 /* t_cose_encryption_example_psa */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = t_cose_encryption_example_psa;
 			sourceTree = "<group>";
 		};
 		E7F70AAC2270D650007CE07F /* b_con_hash */ = {
@@ -690,6 +743,23 @@
 			productReference = E7E36E78226CB8400040613B /* t_cose_openssl */;
 			productType = "com.apple.product-type.tool";
 		};
+		E7F1734F2959292700E5ADF3 /* t_cose_encryption_example_psa */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = E7F173662959292700E5ADF3 /* Build configuration list for PBXNativeTarget "t_cose_encryption_example_psa" */;
+			buildPhases = (
+				E7F173502959292700E5ADF3 /* Sources */,
+				E7F173622959292700E5ADF3 /* Frameworks */,
+				E7F173652959292700E5ADF3 /* CopyFiles */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = t_cose_encryption_example_psa;
+			productName = t_cose;
+			productReference = E7F173692959292700E5ADF3 /* t_cose_encryption_example_psa */;
+			productType = "com.apple.product-type.tool";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -723,6 +793,7 @@
 				E73BF6D523AFFB4100DF5C36 /* t_cose_basic_example_psa */,
 				E73BF70523B07ACF00DF5C36 /* t_cose_basic_example_openssl */,
 				E772026D23CAEC84006E966E /* t_cose_psa_noss */,
+				E7F1734F2959292700E5ADF3 /* t_cose_encryption_example_psa */,
 			);
 		};
 /* End PBXProject section */
@@ -764,8 +835,8 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				E7F1736A2959296B00E5ADF3 /* t_cose_basic_example_psa.c in Sources */,
 				E7FECC4B288754E300420F6F /* t_cose_sign_sign.c in Sources */,
-				E771083A2918578800D8ADF4 /* t_cose_encryption_example_psa.c in Sources */,
 				E771081D2917EDA900D8ADF4 /* t_cose_encrypt_dec.c in Sources */,
 				E73BF6D723AFFB4100DF5C36 /* t_cose_sign1_verify.c in Sources */,
 				E73BF6DB23AFFB4100DF5C36 /* t_cose_psa_crypto.c in Sources */,
@@ -775,11 +846,14 @@
 				E77108172917EDA900D8ADF4 /* t_cose_encrypt_enc.c in Sources */,
 				E7FECC62288B346300420F6F /* t_cose_sign_verify.c in Sources */,
 				E7F17336293B110500E5ADF3 /* t_cose_signature_sign_eddsa.c in Sources */,
+				E7F1736D29592A4600E5ADF3 /* t_cose_recipient_enc_aes_kw.c in Sources */,
 				E771082F2917EDA900D8ADF4 /* t_cose_recipient_enc_hpke.c in Sources */,
 				E73BF6E323AFFB4100DF5C36 /* sha256.c in Sources */,
 				E7F17330293B10EB00E5ADF3 /* t_cose_signature_verify_main.c in Sources */,
+				E7F1737029592BD200E5ADF3 /* hpke.c in Sources */,
 				E7F17333293B110000E5ADF3 /* t_cose_signature_verify_eddsa.c in Sources */,
 				E73BF6E723AFFB4100DF5C36 /* t_cose_sign1_sign.c in Sources */,
+				E7F1736E29592A4D00E5ADF3 /* t_cose_recipient_dec_aes_kw.c in Sources */,
 				E7F1732D293B10E300E5ADF3 /* t_cose_signature_sign_main.c in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -903,6 +977,33 @@
 				E7E36E93226CB9460040613B /* t_cose_sign1_sign.c in Sources */,
 				E771080F2917EDA900D8ADF4 /* t_cose_recipient_dec_aes_kw.c in Sources */,
 				E7F17329293B0EE200E5ADF3 /* t_cose_signature_sign_main.c in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		E7F173502959292700E5ADF3 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				E7F173512959292700E5ADF3 /* t_cose_sign_sign.c in Sources */,
+				E7F173522959292700E5ADF3 /* t_cose_encryption_example_psa.c in Sources */,
+				E7F173532959292700E5ADF3 /* t_cose_encrypt_dec.c in Sources */,
+				E7F173542959292700E5ADF3 /* t_cose_sign1_verify.c in Sources */,
+				E7F173552959292700E5ADF3 /* t_cose_psa_crypto.c in Sources */,
+				E7F173562959292700E5ADF3 /* t_cose_util.c in Sources */,
+				E7F1736C29592A4500E5ADF3 /* t_cose_recipient_enc_aes_kw.c in Sources */,
+				E7F173572959292700E5ADF3 /* t_cose_parameters.c in Sources */,
+				E7F173582959292700E5ADF3 /* t_cose_recipient_dec_hpke.c in Sources */,
+				E7F173592959292700E5ADF3 /* t_cose_encrypt_enc.c in Sources */,
+				E7F1735A2959292700E5ADF3 /* t_cose_sign_verify.c in Sources */,
+				E7F1735B2959292700E5ADF3 /* t_cose_signature_sign_eddsa.c in Sources */,
+				E7F1736B29592A2C00E5ADF3 /* t_cose_recipient_dec_aes_kw.c in Sources */,
+				E7F1735C2959292700E5ADF3 /* t_cose_recipient_enc_hpke.c in Sources */,
+				E7F1735D2959292700E5ADF3 /* sha256.c in Sources */,
+				E7F1736F29592BD000E5ADF3 /* hpke.c in Sources */,
+				E7F1735E2959292700E5ADF3 /* t_cose_signature_verify_main.c in Sources */,
+				E7F1735F2959292700E5ADF3 /* t_cose_signature_verify_eddsa.c in Sources */,
+				E7F173602959292700E5ADF3 /* t_cose_sign1_sign.c in Sources */,
+				E7F173612959292700E5ADF3 /* t_cose_signature_sign_main.c in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1226,6 +1327,33 @@
 			};
 			name = Release;
 		};
+		E7F173672959292700E5ADF3 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				"GCC_PREPROCESSOR_DEFINITIONS[arch=*]" = T_COSE_USE_PSA_CRYPTO;
+				HEADER_SEARCH_PATHS = (
+					inc,
+					/usr/local/include,
+				);
+				"LIBRARY_SEARCH_PATHS[arch=*]" = /usr/local/lib;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Debug;
+		};
+		E7F173682959292700E5ADF3 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				HEADER_SEARCH_PATHS = (
+					inc,
+					/usr/local/include,
+				);
+				"LIBRARY_SEARCH_PATHS[arch=*]" = "../../mbed-crypto/library/";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -1288,6 +1416,15 @@
 			buildConfigurations = (
 				E7E36E80226CB8400040613B /* Debug */,
 				E7E36E81226CB8400040613B /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		E7F173662959292700E5ADF3 /* Build configuration list for PBXNativeTarget "t_cose_encryption_example_psa" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				E7F173672959292700E5ADF3 /* Debug */,
+				E7F173682959292700E5ADF3 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/test/run_tests.c
+++ b/test/run_tests.c
@@ -20,6 +20,7 @@
 #include "t_cose_sign_verify_test.h"
 #include "t_cose_compute_validate_mac_test.h"
 #include "t_cose_param_test.h"
+#include "t_cose_crypto_test.h"
 
 
 /*
@@ -54,6 +55,8 @@ static test_entry2 s_tests2[] = {
 
 
 static test_entry s_tests[] = {
+
+    TEST_ENTRY(aead_test),
 
 #ifndef T_COSE_DISABLE_SIGN1
     // TODO: re enable this test when it is fixed

--- a/test/run_tests.c
+++ b/test/run_tests.c
@@ -332,7 +332,7 @@ void PrintSizesTCose(OutputStringCB pfOutput, void *pOutCtx)
     PrintSize("sizeof(struct t_cose_sign1_ctx)",
               (uint32_t)sizeof(struct t_cose_sign1_sign_ctx),
               pfOutput, pOutCtx);
-    PrintSize("sizeof(struct t_cose_signing_key)",
+    PrintSize("sizeof(struct t_cose_key)",
               (uint32_t)sizeof(struct t_cose_key),
               pfOutput, pOutCtx);
     PrintSize("sizeof(struct t_cose_crypto_hash)",

--- a/test/t_cose_crypto_test.c
+++ b/test/t_cose_crypto_test.c
@@ -1,0 +1,72 @@
+//
+//  t_cose_crypto_test.c
+//  t_cose
+//
+//  Created by Laurence Lundblade on 12/28/22.
+//  Copyright © 2022 Laurence Lundblade. All rights reserved.
+//
+
+#include "t_cose_crypto_test.h"
+
+#include "../src/t_cose_crypto.h" /* NOT a public interface so this test can't run an installed library */
+
+static const uint8_t xkey[] = {
+    0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01,
+    0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01};
+
+static const uint8_t nonce[] = {
+0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01,
+0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01};
+
+static const uint8_t aad[] = {
+0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01,
+0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01};
+
+int_fast32_t aead_test(void)
+{
+    enum t_cose_err_t err;
+    int32_t cose_algorithm_id;
+    struct t_cose_key  key;
+    struct q_useful_buf_c ciphertext;
+    MakeUsefulBufOnStack(ciphertext_buffer, 300);
+    MakeUsefulBufOnStack(plaintext_buffer, 300);
+    struct q_useful_buf_c plaintext;
+
+
+    cose_algorithm_id = T_COSE_ALGORITHM_A128GCM;
+
+    err = t_cose_crypto_make_symmetric_key_handle(T_COSE_ALGORITHM_A128GCM,
+                                                  UsefulBuf_FROM_BYTE_ARRAY_LITERAL(xkey),
+                                                 &key);
+    if(err) {
+        return (int_fast32_t)err;
+    }
+
+    err = t_cose_crypto_aead_encrypt(cose_algorithm_id,
+                                     key,
+                                     Q_USEFUL_BUF_FROM_BYTE_ARRAY_LITERAL(nonce),
+                                     Q_USEFUL_BUF_FROM_BYTE_ARRAY_LITERAL(aad),
+                                     Q_USEFUL_BUF_FROM_SZ_LITERAL("plain text"),
+                                     ciphertext_buffer,
+                                     &ciphertext);
+
+    err = t_cose_crypto_aead_decrypt(cose_algorithm_id,
+                                     key,
+                                     Q_USEFUL_BUF_FROM_BYTE_ARRAY_LITERAL(nonce),
+                                     Q_USEFUL_BUF_FROM_BYTE_ARRAY_LITERAL(aad),
+                                     ciphertext,
+                                     plaintext_buffer,
+                                     &plaintext);
+
+    if(err) {
+        return (int_fast32_t)err;
+    }
+
+    if(q_useful_buf_compare(Q_USEFUL_BUF_FROM_SZ_LITERAL("plain text"), plaintext)) {
+        return -99;
+    }
+
+    
+    return 0;
+}
+

--- a/test/t_cose_crypto_test.c
+++ b/test/t_cose_crypto_test.c
@@ -34,10 +34,13 @@ static const uint8_t test_ciphertext[] = {
 };
 #endif
 
+
+/* TODO: proper define to know about test crypto */
+#ifndef T_COSE_USE_B_CON_SHA256
 /* This is what is output by both OpenSSL and MbedTLS (but different than what is in the GCM standard). */
 static const uint8_t expected_empty_tag[] = {
     0xC9, 0x4A, 0xA9, 0xF3, 0x22, 0x75, 0x73, 0x8C, 0xD5, 0xCC, 0x75, 0x01, 0xA4, 0x80, 0xBC, 0xF5};
-
+#endif
 
 int_fast32_t aead_test(void)
 {

--- a/test/t_cose_crypto_test.c
+++ b/test/t_cose_crypto_test.c
@@ -12,17 +12,30 @@
 
 #include "../src/t_cose_crypto.h" /* NOT a public interface so this test can't run an installed library */
 
-static const uint8_t xkey[] = {
-    0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01,
-    0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01};
+static const uint8_t test_key_0_128bit[] = {
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x010, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x010, 0x00};
 
-static const uint8_t nonce[] = {
-    0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01,
-    0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01};
+/* Nonce / IV is typically 12 bytes for most usage */
+static const uint8_t iv_0[] = {
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x010, 0x00,
+    0x00, 0x00, 0x00, 0x00};
 
 static const uint8_t aad[] = {
     0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01,
     0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01};
+
+
+
+static const uint8_t test_ciphertext[] = {
+    0x72, 0x66, 0x23, 0x9A, 0x61, 0xCD, 0xB6, 0x6C, 0x3E, 0xB0, 0x8B, 0x58,
+    0x72, 0x0D, 0x53, 0x4A, 0x0E, 0x4A, 0xEF, 0xC3, 0x55, 0xAC, 0x90, 0x4C,
+    0x58, 0x1F
+};
+
+static const uint8_t expected_empty_tag[] = {
+    0xC9, 0x4A, 0xA9, 0xF3, 0x22, 0x75, 0x73, 0x8C, 0xD5, 0xCC, 0x75, 0x01, 0xA4, 0x80, 0xBC, 0xF5};
+
 
 int_fast32_t aead_test(void)
 {
@@ -33,29 +46,51 @@ int_fast32_t aead_test(void)
     MakeUsefulBufOnStack(  ciphertext_buffer, 300);
     MakeUsefulBufOnStack(  plaintext_buffer, 300);
     struct q_useful_buf_c  plaintext;
+    const struct q_useful_buf_c empty = {"", 0};
 
 
     cose_algorithm_id = T_COSE_ALGORITHM_A128GCM;
 
     err = t_cose_crypto_make_symmetric_key_handle(T_COSE_ALGORITHM_A128GCM,
-                                                  UsefulBuf_FROM_BYTE_ARRAY_LITERAL(xkey),
+                                                  UsefulBuf_FROM_BYTE_ARRAY_LITERAL(test_key_0_128bit),
                                                  &key);
     if(err) {
         return (int_fast32_t)err;
     }
 
+    /* First the simplest case, no payload, no aad, just the tag */
     err = t_cose_crypto_aead_encrypt(cose_algorithm_id,
                                      key,
-                                     Q_USEFUL_BUF_FROM_BYTE_ARRAY_LITERAL(nonce),
-                                     Q_USEFUL_BUF_FROM_BYTE_ARRAY_LITERAL(aad),
-                                     Q_USEFUL_BUF_FROM_SZ_LITERAL("plain text"),
+                                     Q_USEFUL_BUF_FROM_BYTE_ARRAY_LITERAL(iv_0),
+                                     NULL_Q_USEFUL_BUF_C,
+                                     empty,
                                      ciphertext_buffer,
                                      &ciphertext);
+    if(err) {
+        return (int_fast32_t)err;
+    }
+
+    /* TODO: proper define to know about test crypto */
+#ifndef T_COSE_USE_B_CON_SHA256
+    /* Compare to the expected output.
+     * PSA and OpenSSL are creating the same value here, but it doesn't
+     * line up with the GCM test vectors from the GSM standard.
+     * I don't know why. It seems like it should.
+     */
+    if(q_useful_buf_compare(Q_USEFUL_BUF_FROM_BYTE_ARRAY_LITERAL(expected_empty_tag), ciphertext)) {
+        return -99;
+    }
+#else
+    /* It's not really necessary to test the test crypto, but it is
+     * helpful to validate it some. But the above is disabled as it
+     * doesn't produce real AES-GCM results even though it an
+     * fake encryption and decryption. */
+#endif
 
     err = t_cose_crypto_aead_decrypt(cose_algorithm_id,
                                      key,
-                                     Q_USEFUL_BUF_FROM_BYTE_ARRAY_LITERAL(nonce),
-                                     Q_USEFUL_BUF_FROM_BYTE_ARRAY_LITERAL(aad),
+                                     Q_USEFUL_BUF_FROM_BYTE_ARRAY_LITERAL(iv_0),
+                                     NULL_Q_USEFUL_BUF_C,
                                      ciphertext,
                                      plaintext_buffer,
                                      &plaintext);
@@ -64,9 +99,39 @@ int_fast32_t aead_test(void)
         return (int_fast32_t)err;
     }
 
+    if(plaintext.len != 0) {
+        return -99;
+    }
+
+
+
+    /* Test with text and aad */
+    err = t_cose_crypto_aead_encrypt(cose_algorithm_id,
+                                     key,
+                                     Q_USEFUL_BUF_FROM_BYTE_ARRAY_LITERAL(iv_0),
+                                     Q_USEFUL_BUF_FROM_BYTE_ARRAY_LITERAL(aad),
+                                     Q_USEFUL_BUF_FROM_SZ_LITERAL("plain text"),
+                                     ciphertext_buffer,
+                                     &ciphertext);
+    if(err) {
+        return (int_fast32_t)err;
+    }
+
+    err = t_cose_crypto_aead_decrypt(cose_algorithm_id,
+                                     key,
+                                     Q_USEFUL_BUF_FROM_BYTE_ARRAY_LITERAL(iv_0),
+                                     Q_USEFUL_BUF_FROM_BYTE_ARRAY_LITERAL(aad),
+                                     ciphertext,
+                                     plaintext_buffer,
+                                     &plaintext);
+    if(err) {
+        return (int_fast32_t)err;
+    }
+
     if(q_useful_buf_compare(Q_USEFUL_BUF_FROM_SZ_LITERAL("plain text"), plaintext)) {
         return -99;
     }
+
     
     return 0;
 }

--- a/test/t_cose_crypto_test.c
+++ b/test/t_cose_crypto_test.c
@@ -1,10 +1,12 @@
-//
-//  t_cose_crypto_test.c
-//  t_cose
-//
-//  Created by Laurence Lundblade on 12/28/22.
-//  Copyright © 2022 Laurence Lundblade. All rights reserved.
-//
+/*
+ *  t_cose_crypto_test.c
+ *
+ * Copyright 2022, Laurence Lundblade
+ * Created by Laurence Lundblade on 12/28/22.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ */
 
 #include "t_cose_crypto_test.h"
 
@@ -15,22 +17,22 @@ static const uint8_t xkey[] = {
     0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01};
 
 static const uint8_t nonce[] = {
-0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01,
-0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01};
+    0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01,
+    0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01};
 
 static const uint8_t aad[] = {
-0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01,
-0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01};
+    0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01,
+    0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01};
 
 int_fast32_t aead_test(void)
 {
-    enum t_cose_err_t err;
-    int32_t cose_algorithm_id;
-    struct t_cose_key  key;
-    struct q_useful_buf_c ciphertext;
-    MakeUsefulBufOnStack(ciphertext_buffer, 300);
-    MakeUsefulBufOnStack(plaintext_buffer, 300);
-    struct q_useful_buf_c plaintext;
+    enum t_cose_err_t      err;
+    int32_t                cose_algorithm_id;
+    struct t_cose_key      key;
+    struct q_useful_buf_c  ciphertext;
+    MakeUsefulBufOnStack(  ciphertext_buffer, 300);
+    MakeUsefulBufOnStack(  plaintext_buffer, 300);
+    struct q_useful_buf_c  plaintext;
 
 
     cose_algorithm_id = T_COSE_ALGORITHM_A128GCM;
@@ -65,7 +67,6 @@ int_fast32_t aead_test(void)
     if(q_useful_buf_compare(Q_USEFUL_BUF_FROM_SZ_LITERAL("plain text"), plaintext)) {
         return -99;
     }
-
     
     return 0;
 }

--- a/test/t_cose_crypto_test.h
+++ b/test/t_cose_crypto_test.h
@@ -1,0 +1,17 @@
+//
+//  t_cose_crypto_test.h
+//  t_cose
+//
+//  Created by Laurence Lundblade on 12/28/22.
+//  Copyright © 2022 Laurence Lundblade. All rights reserved.
+//
+
+#ifndef t_cose_crypto_test_h
+#define t_cose_crypto_test_h
+
+#include <stdint.h>
+
+
+int_fast32_t aead_test(void);
+
+#endif /* t_cose_crypto_test_h */

--- a/test/t_cose_crypto_test.h
+++ b/test/t_cose_crypto_test.h
@@ -1,10 +1,12 @@
-//
-//  t_cose_crypto_test.h
-//  t_cose
-//
-//  Created by Laurence Lundblade on 12/28/22.
-//  Copyright © 2022 Laurence Lundblade. All rights reserved.
-//
+/*
+ *  t_cose_crypto_test.h
+ *
+ * Copyright 2022, Laurence Lundblade
+ * Created by Laurence Lundblade on 12/28/22.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ */
 
 #ifndef t_cose_crypto_test_h
 #define t_cose_crypto_test_h


### PR DESCRIPTION
The crypto adaptor layer for AEAD is improved.

Some small changes in the encrypt and decrypt t_cose public APIs were made to bring it more in line with t_cose conventions.

HPKE is now calling AEAD through the crypto adaptor layer rather than directly calling PSA APIs. (Still lots of work to move the rest of HPKE to crypto adaptors). 

There is an OpenSSL implementation of the AEAD crypto adaptor layer. This was done to validate the design of the AEAD crypto adaptor layer.

Started a new set of tests for the crypto adaptor layer. This was motivated because the AEAD layer for OpenSSL is very complex and will be difficult to test through the public t_cose APIs that indirectly call AEAD. One of the difficulties with OpenSSL AEAD is that it allocated memory. Another is that it uses int rather that size_t for lengths. Another is that the APIs aren't well documented. Another is that they don't check lengths.

These new set of tests can be used to test other parts of the crypto adaptor layer. These tests ARE independent of the crypto library which is very good. They are not against public APIs though so the can't be against public t_cose APIs, such as against an installed binary library.

Also fixes some unrelated warnings from running tdv/b.sh.
