### PR TITLE
Add detached payload for mac

### DIFF
--- a/inc/t_cose/t_cose_mac_compute.h
+++ b/inc/t_cose/t_cose_mac_compute.h
@@ -194,6 +194,7 @@ are replaced with t_cose_sign1_add_body_header_parameters()
  */
 enum t_cose_err_t
 t_cose_mac_encode_parameters(struct t_cose_mac_calculate_ctx *context,
+                             bool                             payload_is_detached,
                              QCBOREncodeContext              *cbor_encode_ctx);
 
 /**
@@ -214,6 +215,7 @@ t_cose_mac_encode_parameters(struct t_cose_mac_calculate_ctx *context,
  */
 enum t_cose_err_t
 t_cose_mac_encode_tag(struct t_cose_mac_calculate_ctx *context,
+                      struct q_useful_buf_c            detached_payload,
                       QCBOREncodeContext              *cbor_encode_ctx);
 
 

--- a/src/t_cose_mac_compute.c
+++ b/src/t_cose_mac_compute.c
@@ -31,7 +31,6 @@ t_cose_mac_compute_private(struct t_cose_mac_calculate_ctx *context,
                            struct q_useful_buf              out_buf,
                            struct q_useful_buf_c           *result)
 {
-    (void)payload_is_detached;
     (void)aad;
     QCBOREncodeContext  encode_ctx;
     enum t_cose_err_t   return_value;
@@ -40,14 +39,26 @@ t_cose_mac_compute_private(struct t_cose_mac_calculate_ctx *context,
     QCBOREncode_Init(&encode_ctx, out_buf);
 
     /* -- Output the header parameters into the encoder context -- */
-    return_value = t_cose_mac_encode_parameters(context, &encode_ctx);
+    return_value = t_cose_mac_encode_parameters(context, payload_is_detached, &encode_ctx);
     if(return_value != T_COSE_SUCCESS) {
         goto Done;
     }
 
-    QCBOREncode_AddEncoded(&encode_ctx, payload);
+    if(payload_is_detached) {
+        /* detached payload:
+         * the payload should be transfered in another channel
+         */
+        QCBOREncode_AddNULL(&encode_ctx);
+    } else {
+        /* --- Get started on the payload --- */
+        QCBOREncode_AddEncoded(&encode_ctx, payload);
+    }
+    if(!payload_is_detached) {
+        // TODO: combine with above?
+        payload = NULL_Q_USEFUL_BUF_C;
+    }
 
-    return_value = t_cose_mac_encode_tag(context,&encode_ctx);
+    return_value = t_cose_mac_encode_tag(context, payload, &encode_ctx);
     if(return_value) {
         goto Done;
     }
@@ -67,6 +78,7 @@ Done:
  */
 enum t_cose_err_t
 t_cose_mac_encode_parameters(struct t_cose_mac_calculate_ctx *me,
+                             bool                             payload_is_detached,
                              QCBOREncodeContext              *cbor_encode_ctx)
 {
     size_t                  tag_len;
@@ -103,7 +115,9 @@ t_cose_mac_encode_parameters(struct t_cose_mac_calculate_ctx *me,
                                          &me->protected_parameters);
 
     /* --- Get started on the payload --- */
-    QCBOREncode_BstrWrap(cbor_encode_ctx);
+    if(!payload_is_detached) {
+        QCBOREncode_BstrWrap(cbor_encode_ctx);
+    }
 
     /*
      * Any failures in CBOR encoding will be caught in finish
@@ -119,6 +133,7 @@ t_cose_mac_encode_parameters(struct t_cose_mac_calculate_ctx *me,
  */
 enum t_cose_err_t
 t_cose_mac_encode_tag(struct t_cose_mac_calculate_ctx *me,
+                      struct q_useful_buf_c            detached_payload,
                       QCBOREncodeContext              *cbor_encode_ctx)
 {
     enum t_cose_err_t            return_value;
@@ -135,7 +150,14 @@ t_cose_mac_encode_tag(struct t_cose_mac_calculate_ctx *me,
     struct t_cose_crypto_hmac    hmac_ctx;
     struct q_useful_buf_c        maced_payload;
 
-    QCBOREncode_CloseBstrWrap2(cbor_encode_ctx, false, &maced_payload);
+    /* --- Close off the payload --- */
+    if(q_useful_buf_c_is_null(detached_payload)) {
+        /* Payload is inline, not detached */
+        QCBOREncode_CloseBstrWrap2(cbor_encode_ctx, false, &maced_payload);
+    } else {
+        maced_payload = detached_payload;
+    }
+
 
     /* Check that there are no CBOR encoding errors before proceeding
      * with hashing and tagging. This is not actually necessary as the

--- a/src/t_cose_mac_validate.c
+++ b/src/t_cose_mac_validate.c
@@ -124,7 +124,6 @@ t_cose_mac_validate_private(struct t_cose_mac_validate_ctx *context,
                             struct t_cose_parameter       **return_params)
 {
     (void)aad;
-    (void)payload_is_detached;
     QCBORDecodeContext            decode_context;
     struct q_useful_buf_c         protected_parameters;
     QCBORError                    qcbor_error;
@@ -167,7 +166,13 @@ t_cose_mac_validate_private(struct t_cose_mac_validate_ctx *context,
                           &protected_parameters);
 
     /* --- The payload --- */
-    QCBORDecode_GetByteString(&decode_context, payload);
+    if (payload_is_detached) {
+        /* detached payload: the payload should be set by caller */
+        QCBORDecode_GetNull(&decode_context);
+    }
+    else {
+        QCBORDecode_GetByteString(&decode_context, payload);
+    }
 
     /* --- The tag --- */
     QCBORDecode_GetByteString(&decode_context, &tag);

--- a/test/run_tests.c
+++ b/test/run_tests.c
@@ -85,6 +85,8 @@ static test_entry s_tests[] = {
     TEST_ENTRY(compute_validate_mac_basic_test),
     TEST_ENTRY(compute_validate_mac_sig_fail_test),
     TEST_ENTRY(compute_validate_get_size_mac_test),
+    TEST_ENTRY(compute_validate_detached_content_mac_sig_fail_test),
+    TEST_ENTRY(compute_validate_get_size_detached_content_mac_test),
 #endif /* T_COSE_DISABLE_MAC0 */
 #endif /* T_COSE_DISABLE_SIGN_VERIFY_TESTS */
 

--- a/test/t_cose_compute_validate_mac_test.c
+++ b/test/t_cose_compute_validate_mac_test.c
@@ -135,7 +135,6 @@ int_fast32_t compute_validate_mac_sig_fail_test()
     struct q_useful_buf_c        payload;
     QCBORError                   cbor_error;
     struct t_cose_mac_validate_ctx verify_ctx;
-    size_t                       tamper_offset;
 
 
     /* Make an HMAC key that will be used for both signing and

--- a/test/t_cose_compute_validate_mac_test.c
+++ b/test/t_cose_compute_validate_mac_test.c
@@ -347,4 +347,228 @@ int_fast32_t compute_validate_get_size_mac_test()
     return 0;
 }
 
+
+/*
+ * Public function, see t_cose_compute_validate_mac_test.h
+ */
+int_fast32_t compute_validate_detached_content_mac_sig_fail_test()
+{
+    struct t_cose_mac_calculate_ctx   sign_ctx;
+    QCBOREncodeContext           cbor_encode;
+    int32_t                      return_value;
+    enum t_cose_err_t            result;
+    Q_USEFUL_BUF_MAKE_STACK_UB(  signed_cose_buffer, 300);
+    struct q_useful_buf_c        signed_cose;
+    struct t_cose_key            key;
+    struct q_useful_buf_c        payload;
+    QCBORError                   cbor_error;
+    struct t_cose_mac_validate_ctx verify_ctx;
+    size_t                       tamper_offset;
+
+
+    /* ---- Set up ---- */
+    payload = Q_USEFUL_BUF_FROM_SZ_LITERAL("payload");
+
+    /* Make an HMAC key that will be used for both signing and
+     * verification.
+     */
+    result = make_hmac_key(T_COSE_ALGORITHM_HMAC256, &key);
+    if(result) {
+        return 1000 + (int32_t)result;
+    }
+
+    QCBOREncode_Init(&cbor_encode, signed_cose_buffer);
+
+    t_cose_mac_compute_init(&sign_ctx, 0, T_COSE_ALGORITHM_HMAC256);
+    t_cose_mac_set_computing_key(&sign_ctx, key, NULL_Q_USEFUL_BUF_C);
+
+    result = t_cose_mac_encode_parameters(&sign_ctx, true, &cbor_encode);
+    if(result) {
+        return_value = 2000 + (int32_t)result;
+        goto Done;
+    }
+
+    QCBOREncode_AddNULL(&cbor_encode);
+
+    result = t_cose_mac_encode_tag(&sign_ctx, payload, &cbor_encode);
+    if(result) {
+        return_value = 3000 + (int32_t)result;
+        goto Done;
+    }
+
+    cbor_error = QCBOREncode_Finish(&cbor_encode, &signed_cose);
+    if(cbor_error) {
+        return_value = 4000 + (int32_t)cbor_error;
+        goto Done;
+    }
+
+    /* Set up tampered detached payload */
+    struct q_useful_buf_c temp_const = Q_USEFUL_BUF_FROM_SZ_LITERAL("hayload");
+
+    t_cose_mac_validate_init(&verify_ctx, 0);
+
+    t_cose_mac_set_validate_key(&verify_ctx, key);
+
+    result = t_cose_mac_validate(&verify_ctx,
+                                signed_cose, /* COSE to verify */
+                                NULL_Q_USEFUL_BUF_C,
+                               &temp_const, /* detached payload */
+                                NULL);
+
+    if(result != T_COSE_ERR_SIG_VERIFY) {
+        return_value = 5000 + (int32_t)result;
+    }
+
+    return_value = 0;
+
+Done:
+    free_key(key);
+
+    return return_value;
+}
+
+
+static int detached_content_size_test(int32_t               cose_algorithm_id,
+                     struct q_useful_buf_c kid,
+                     struct t_cose_key     key)
+{
+    struct t_cose_mac_calculate_ctx sign_ctx;
+    QCBOREncodeContext         cbor_encode;
+    enum t_cose_err_t          return_value;
+    struct q_useful_buf        nil_buf;
+    size_t                     calculated_size;
+    QCBORError                 cbor_error;
+    struct q_useful_buf_c      actual_signed_cose;
+    Q_USEFUL_BUF_MAKE_STACK_UB(signed_cose_buffer, 300);
+    struct q_useful_buf_c      payload;
+
+    /* ---- Common Set up ---- */
+    payload = Q_USEFUL_BUF_FROM_SZ_LITERAL("payload");
+
+    /* ---- First calculate the size ----- */
+    nil_buf = (struct q_useful_buf) {NULL, INT32_MAX};
+    QCBOREncode_Init(&cbor_encode, nil_buf);
+
+    t_cose_mac_compute_init(&sign_ctx,  0,  cose_algorithm_id);
+    t_cose_mac_set_computing_key(&sign_ctx, key, kid);
+
+    return_value = t_cose_mac_encode_parameters(&sign_ctx, true, &cbor_encode);
+    if(return_value) {
+        return 2000 + (int32_t)return_value;
+    }
+
+    QCBOREncode_AddNULL(&cbor_encode);
+
+    return_value = t_cose_mac_encode_tag(&sign_ctx, payload, &cbor_encode);
+    if(return_value) {
+        return 3000 + (int32_t)return_value;
+    }
+
+    cbor_error = QCBOREncode_FinishGetSize(&cbor_encode, &calculated_size);
+    if(cbor_error) {
+        return 4000 + (int32_t)cbor_error;
+    }
+
+    /* ---- Now make a real COSE_Mac0 and compare the size ---- */
+    QCBOREncode_Init(&cbor_encode, signed_cose_buffer);
+
+    t_cose_mac_compute_init(&sign_ctx, 0, cose_algorithm_id);
+    t_cose_mac_set_computing_key(&sign_ctx, key, kid);
+
+    return_value = t_cose_mac_encode_parameters(&sign_ctx, true, &cbor_encode);
+    if(return_value) {
+        return 2000 + (int32_t)return_value;
+    }
+
+    QCBOREncode_AddNULL(&cbor_encode);
+
+    return_value = t_cose_mac_encode_tag(&sign_ctx, payload, &cbor_encode);
+    if(return_value) {
+        return 3000 + (int32_t)return_value;
+    }
+
+    cbor_error = QCBOREncode_Finish(&cbor_encode, &actual_signed_cose);
+    if(actual_signed_cose.len != calculated_size) {
+        return -2;
+    }
+
+    /* ---- Again with one-call API to make COSE_Mac0 ---- */\
+    t_cose_mac_compute_init(&sign_ctx, 0, cose_algorithm_id);
+    t_cose_mac_set_computing_key(&sign_ctx, key, kid);
+    return_value = t_cose_mac_compute_detached(&sign_ctx,
+                                         NULL_Q_USEFUL_BUF_C,
+                                         payload,
+                                         signed_cose_buffer,
+                                        &actual_signed_cose);
+    if(return_value) {
+        return 7000 + (int32_t)return_value;
+    }
+
+    if(actual_signed_cose.len != calculated_size) {
+        return -3;
+    }
+
+    return 0;
+}
+
+
+/*
+ * Public function, see t_cose_compute_validate_mac_test.h
+ */
+int_fast32_t compute_validate_get_size_detached_content_mac_test()
+{
+    enum t_cose_err_t return_value;
+    struct t_cose_key key;
+    int32_t           result;
+
+    if(t_cose_is_algorithm_supported(T_COSE_ALGORITHM_HMAC256)) {
+        return_value = make_hmac_key(T_COSE_ALGORITHM_HMAC256, &key);
+        if(return_value) {
+            return 10000 + (int32_t)return_value;
+        }
+
+        result = detached_content_size_test(T_COSE_ALGORITHM_HMAC256, NULL_Q_USEFUL_BUF_C, key);
+        free_key(key);
+        if(result) {
+            return 20000 + result;
+        }
+    }
+
+    if(t_cose_is_algorithm_supported(T_COSE_ALGORITHM_HMAC384)) {
+        return_value = make_hmac_key(T_COSE_ALGORITHM_HMAC384, &key);
+        if(return_value) {
+            return 30000 + (int32_t)return_value;
+        }
+
+        result = detached_content_size_test(T_COSE_ALGORITHM_HMAC384, NULL_Q_USEFUL_BUF_C, key);
+        free_key(key);
+        if(result) {
+            return 40000 + result;
+        }
+    }
+
+    if(t_cose_is_algorithm_supported(T_COSE_ALGORITHM_HMAC512)) {
+        return_value = make_hmac_key(T_COSE_ALGORITHM_HMAC512, &key);
+        if(return_value) {
+            return 50000 + (int32_t)return_value;
+        }
+
+        result = detached_content_size_test(T_COSE_ALGORITHM_HMAC512, NULL_Q_USEFUL_BUF_C, key);
+        if(result) {
+            free_key(key);
+            return 60000 + result;
+        }
+
+        result = detached_content_size_test(T_COSE_ALGORITHM_HMAC512,
+                           Q_USEFUL_BUF_FROM_SZ_LITERAL("greasy kid stuff"),
+                           key);
+        free_key(key);
+        if(result) {
+            return 70000 + result;
+        }
+    }
+
+    return 0;
+}
+
 #endif /* !T_COSE_DISABLE_MAC0 */

--- a/test/t_cose_compute_validate_mac_test.c
+++ b/test/t_cose_compute_validate_mac_test.c
@@ -151,7 +151,7 @@ int_fast32_t compute_validate_mac_sig_fail_test()
     t_cose_mac_compute_init(&sign_ctx, 0, T_COSE_ALGORITHM_HMAC256);
     t_cose_mac_set_computing_key(&sign_ctx, key, NULL_Q_USEFUL_BUF_C);
 
-    result = t_cose_mac_encode_parameters(&sign_ctx, &cbor_encode);
+    result = t_cose_mac_encode_parameters(&sign_ctx, false, &cbor_encode);
     if(result) {
         return_value = 2000 + (int32_t)result;
         goto Done;
@@ -159,7 +159,7 @@ int_fast32_t compute_validate_mac_sig_fail_test()
 
     QCBOREncode_AddSZString(&cbor_encode, "payload");
 
-    result = t_cose_mac_encode_tag(&sign_ctx, &cbor_encode);
+    result = t_cose_mac_encode_tag(&sign_ctx, NULL_Q_USEFUL_BUF_C, &cbor_encode);
     if(result) {
         return_value = 3000 + (int32_t)result;
         goto Done;
@@ -228,14 +228,14 @@ static int size_test(int32_t               cose_algorithm_id,
     t_cose_mac_compute_init(&sign_ctx,  0,  cose_algorithm_id);
     t_cose_mac_set_computing_key(&sign_ctx, key, kid);
 
-    return_value = t_cose_mac_encode_parameters(&sign_ctx, &cbor_encode);
+    return_value = t_cose_mac_encode_parameters(&sign_ctx, false, &cbor_encode);
     if(return_value) {
         return 2000 + (int32_t)return_value;
     }
 
     QCBOREncode_AddEncoded(&cbor_encode, payload);
 
-    return_value = t_cose_mac_encode_tag(&sign_ctx, &cbor_encode);
+    return_value = t_cose_mac_encode_tag(&sign_ctx, NULL_Q_USEFUL_BUF_C, &cbor_encode);
     if(return_value) {
         return 3000 + (int32_t)return_value;
     }
@@ -251,14 +251,14 @@ static int size_test(int32_t               cose_algorithm_id,
     t_cose_mac_compute_init(&sign_ctx, 0, cose_algorithm_id);
     t_cose_mac_set_computing_key(&sign_ctx, key, kid);
 
-    return_value = t_cose_mac_encode_parameters(&sign_ctx, &cbor_encode);
+    return_value = t_cose_mac_encode_parameters(&sign_ctx, false, &cbor_encode);
     if(return_value) {
         return 2000 + (int32_t)return_value;
     }
 
     QCBOREncode_AddEncoded(&cbor_encode, payload);
 
-    return_value = t_cose_mac_encode_tag(&sign_ctx, &cbor_encode);
+    return_value = t_cose_mac_encode_tag(&sign_ctx, NULL_Q_USEFUL_BUF_C, &cbor_encode);
     if(return_value) {
         return 3000 + (int32_t)return_value;
     }

--- a/test/t_cose_compute_validate_mac_test.h
+++ b/test/t_cose_compute_validate_mac_test.h
@@ -41,4 +41,16 @@ int_fast32_t compute_validate_mac_sig_fail_test(void);
  */
 int_fast32_t compute_validate_get_size_mac_test(void);
 
+
+/*
+ * Sign some data, perturb the data and see that sig validation fails.
+ */
+int_fast32_t compute_validate_detached_content_mac_sig_fail_test(void);
+
+
+/*
+ * Test the ability to calculate size of a COSE_Mac0.
+ */
+int_fast32_t compute_validate_get_size_detached_content_mac_test(void);
+
 #endif /* t_cose_compute_validate_mac_test_h */


### PR DESCRIPTION
Add "detached content" mode for COSE_Mac and COSE_Mac0.
The interfaces of `t_cose_mac_encode_parameters` and `t_cose_mac_encode_tag` are changed like `t_cose_sign_encode_start` and `t_cose_sign_encode_finish` respectively.