### PR TITLE
Change interface for detached content

### DIFF
--- a/examples/signing_examples.c
+++ b/examples/signing_examples.c
@@ -512,7 +512,7 @@ int32_t two_step_sign_example_new(void)
      * This just outputs the COSE_Sign1 header parameters and gets set
      * up for the payload to be output.
      */
-    return_value = t_cose_sign_encode_start(&sign_ctx, false, &cbor_encode);
+    return_value = t_cose_sign_encode_start(&sign_ctx, &cbor_encode);
 
     printf("Encoded COSE headers: %d (%s)\n", return_value, return_value ? "fail" : "success");
     if(return_value) {
@@ -544,6 +544,7 @@ int32_t two_step_sign_example_new(void)
      * message. For that call the payload is just passed in as a
      * buffer.
      */
+    QCBOREncode_BstrWrap(&cbor_encode);
     QCBOREncode_OpenMap(&cbor_encode);
     QCBOREncode_AddSZStringToMap(&cbor_encode, "BeingType", "Humanoid");
     QCBOREncode_AddSZStringToMap(&cbor_encode, "Greeting", "We come in peace");
@@ -552,6 +553,7 @@ int32_t two_step_sign_example_new(void)
     QCBOREncode_AddSZStringToMap(&cbor_encode, "BrainSize", "medium");
     QCBOREncode_AddBoolToMap(&cbor_encode, "DrinksWater", true);
     QCBOREncode_CloseMap(&cbor_encode);
+    QCBOREncode_CloseBstrWrap2(&cbor_encode, false, &payload);
 
     printf("Payload added\n");
 
@@ -563,7 +565,7 @@ int32_t two_step_sign_example_new(void)
      */
     return_value = t_cose_sign_encode_finish(&sign_ctx,
                                              NULL_Q_USEFUL_BUF_C,
-                                             NULL_Q_USEFUL_BUF_C,
+                                             payload,
                                              &cbor_encode);
 
     printf("Fnished signing: %d (%s)\n", return_value, return_value ? "fail" : "success");

--- a/examples/signing_examples.c
+++ b/examples/signing_examples.c
@@ -332,6 +332,7 @@ int32_t two_step_sign_example(void)
      * message. For that call the payload is just passed in as a
      * buffer.
      */
+    QCBOREncode_BstrWrap(&cbor_encode);
     QCBOREncode_OpenMap(&cbor_encode);
     QCBOREncode_AddSZStringToMap(&cbor_encode, "BeingType", "Humanoid");
     QCBOREncode_AddSZStringToMap(&cbor_encode, "Greeting", "We come in peace");
@@ -340,6 +341,7 @@ int32_t two_step_sign_example(void)
     QCBOREncode_AddSZStringToMap(&cbor_encode, "BrainSize", "medium");
     QCBOREncode_AddBoolToMap(&cbor_encode, "DrinksWater", true);
     QCBOREncode_CloseMap(&cbor_encode);
+    QCBOREncode_CloseBstrWrap2(&cbor_encode, false, &payload);
 
     printf("Payload added\n");
 
@@ -349,7 +351,7 @@ int32_t two_step_sign_example(void)
      * This call signals the end payload construction, causes the actual
      * signing to run.
      */
-    return_value = t_cose_sign1_encode_signature(&sign_ctx, &cbor_encode);
+    return_value = t_cose_sign1_encode_signature2(&sign_ctx, payload, &cbor_encode);
 
     printf("Fnished signing: %d (%s)\n", return_value, return_value ? "fail" : "success");
     if(return_value) {
@@ -754,6 +756,7 @@ int32_t two_step_sign_example_new_verify(void)
      * message. For that call the payload is just passed in as a
      * buffer.
      */
+    QCBOREncode_BstrWrap(&cbor_encode);
     QCBOREncode_OpenMap(&cbor_encode);
     QCBOREncode_AddSZStringToMap(&cbor_encode, "BeingType", "Humanoid");
     QCBOREncode_AddSZStringToMap(&cbor_encode, "Greeting", "We come in peace");
@@ -762,6 +765,7 @@ int32_t two_step_sign_example_new_verify(void)
     QCBOREncode_AddSZStringToMap(&cbor_encode, "BrainSize", "medium");
     QCBOREncode_AddBoolToMap(&cbor_encode, "DrinksWater", true);
     QCBOREncode_CloseMap(&cbor_encode);
+    QCBOREncode_CloseBstrWrap2(&cbor_encode, false, &payload);
 
     printf("Payload added\n");
 
@@ -771,7 +775,7 @@ int32_t two_step_sign_example_new_verify(void)
      * This call signals the end payload construction, causes the actual
      * signing to run.
      */
-    return_value = t_cose_sign1_encode_signature(&sign_ctx, &cbor_encode);
+    return_value = t_cose_sign1_encode_signature2(&sign_ctx, payload, &cbor_encode);
 
     printf("Fnished signing: %d (%s)\n", return_value, return_value ? "fail" : "success");
     if(return_value) {

--- a/examples/signing_examples.c
+++ b/examples/signing_examples.c
@@ -332,7 +332,6 @@ int32_t two_step_sign_example(void)
      * message. For that call the payload is just passed in as a
      * buffer.
      */
-    QCBOREncode_BstrWrap(&cbor_encode);
     QCBOREncode_OpenMap(&cbor_encode);
     QCBOREncode_AddSZStringToMap(&cbor_encode, "BeingType", "Humanoid");
     QCBOREncode_AddSZStringToMap(&cbor_encode, "Greeting", "We come in peace");
@@ -341,7 +340,6 @@ int32_t two_step_sign_example(void)
     QCBOREncode_AddSZStringToMap(&cbor_encode, "BrainSize", "medium");
     QCBOREncode_AddBoolToMap(&cbor_encode, "DrinksWater", true);
     QCBOREncode_CloseMap(&cbor_encode);
-    QCBOREncode_CloseBstrWrap2(&cbor_encode, false, &payload);
 
     printf("Payload added\n");
 
@@ -351,7 +349,7 @@ int32_t two_step_sign_example(void)
      * This call signals the end payload construction, causes the actual
      * signing to run.
      */
-    return_value = t_cose_sign1_encode_signature2(&sign_ctx, payload, &cbor_encode);
+    return_value = t_cose_sign1_encode_signature(&sign_ctx, &cbor_encode);
 
     printf("Fnished signing: %d (%s)\n", return_value, return_value ? "fail" : "success");
     if(return_value) {
@@ -756,7 +754,6 @@ int32_t two_step_sign_example_new_verify(void)
      * message. For that call the payload is just passed in as a
      * buffer.
      */
-    QCBOREncode_BstrWrap(&cbor_encode);
     QCBOREncode_OpenMap(&cbor_encode);
     QCBOREncode_AddSZStringToMap(&cbor_encode, "BeingType", "Humanoid");
     QCBOREncode_AddSZStringToMap(&cbor_encode, "Greeting", "We come in peace");
@@ -765,7 +762,6 @@ int32_t two_step_sign_example_new_verify(void)
     QCBOREncode_AddSZStringToMap(&cbor_encode, "BrainSize", "medium");
     QCBOREncode_AddBoolToMap(&cbor_encode, "DrinksWater", true);
     QCBOREncode_CloseMap(&cbor_encode);
-    QCBOREncode_CloseBstrWrap2(&cbor_encode, false, &payload);
 
     printf("Payload added\n");
 
@@ -775,7 +771,7 @@ int32_t two_step_sign_example_new_verify(void)
      * This call signals the end payload construction, causes the actual
      * signing to run.
      */
-    return_value = t_cose_sign1_encode_signature2(&sign_ctx, payload, &cbor_encode);
+    return_value = t_cose_sign1_encode_signature(&sign_ctx, &cbor_encode);
 
     printf("Fnished signing: %d (%s)\n", return_value, return_value ? "fail" : "success");
     if(return_value) {

--- a/inc/t_cose/t_cose_mac_compute.h
+++ b/inc/t_cose/t_cose_mac_compute.h
@@ -197,7 +197,6 @@ are replaced with t_cose_sign1_add_body_header_parameters()
  */
 enum t_cose_err_t
 t_cose_mac_encode_parameters(struct t_cose_mac_calculate_ctx *context,
-                             bool                             payload_is_detached,
                              QCBOREncodeContext              *cbor_encode_ctx);
 
 /**
@@ -218,7 +217,7 @@ t_cose_mac_encode_parameters(struct t_cose_mac_calculate_ctx *context,
  */
 enum t_cose_err_t
 t_cose_mac_encode_tag(struct t_cose_mac_calculate_ctx *context,
-                      struct q_useful_buf_c            detached_payload,
+                      struct q_useful_buf_c            payload,
                       QCBOREncodeContext              *cbor_encode_ctx);
 
 

--- a/inc/t_cose/t_cose_sign1_sign.h
+++ b/inc/t_cose/t_cose_sign1_sign.h
@@ -625,7 +625,6 @@ t_cose_sign1_encode_parameters_private(struct t_cose_sign1_sign_ctx *me,
                                        QCBOREncodeContext *cbor_encode_ctx)
 {
     return t_cose_sign_encode_start(&(me->me2),
-                                    payload_is_detached,
                                     cbor_encode_ctx);
 }
 

--- a/inc/t_cose/t_cose_sign1_sign.h
+++ b/inc/t_cose/t_cose_sign1_sign.h
@@ -462,8 +462,6 @@ t_cose_sign1_encode_signature_aad(struct t_cose_sign1_sign_ctx *context,
  *        \c COSE_Sign1 message.
  *
  * \param[in] context              The t_cose signing context.
- * \param[in] payload_is_detached  If the payload is to be detached, this
- *                                 is \c true.
  * \param[in] cbor_encode_ctx      Encoding context to output to.
  *
  * \return This returns one of the error codes defined by \ref t_cose_err_t.
@@ -474,7 +472,6 @@ t_cose_sign1_encode_signature_aad(struct t_cose_sign1_sign_ctx *context,
  */
 static enum t_cose_err_t
 t_cose_sign1_encode_parameters_private(struct t_cose_sign1_sign_ctx *context,
-                                       bool              payload_is_detached,
                                        QCBOREncodeContext   *cbor_encode_ctx);
 
 
@@ -483,7 +480,6 @@ t_cose_sign1_encode_parameters(struct t_cose_sign1_sign_ctx *context,
                                QCBOREncodeContext           *cbor_encode_ctx)
 {
     return t_cose_sign1_encode_parameters_private(context,
-                                                   false,
                                                    cbor_encode_ctx);
 }
 
@@ -602,6 +598,16 @@ t_cose_sign1_encode_signature_aad(struct t_cose_sign1_sign_ctx *me,
                                                     cbor_encode_ctx);
 }
 
+static inline enum t_cose_err_t
+t_cose_sign1_encode_signature2(struct t_cose_sign1_sign_ctx *me,
+                               struct q_useful_buf_c         signed_payload,
+                               QCBOREncodeContext           *cbor_encode_ctx)
+{
+    return t_cose_sign1_encode_signature_aad_private(me,
+                                                     NULL_Q_USEFUL_BUF_C,
+                                                     signed_payload,
+                                                     cbor_encode_ctx);
+}
 
 static inline enum t_cose_err_t
 t_cose_sign1_encode_signature(struct t_cose_sign1_sign_ctx *me,
@@ -621,7 +627,6 @@ t_cose_sign1_encode_signature(struct t_cose_sign1_sign_ctx *me,
  */
 static inline enum t_cose_err_t
 t_cose_sign1_encode_parameters_private(struct t_cose_sign1_sign_ctx *me,
-                                       bool                payload_is_detached,
                                        QCBOREncodeContext *cbor_encode_ctx)
 {
     return t_cose_sign_encode_start(&(me->me2),
@@ -635,12 +640,12 @@ t_cose_sign1_encode_parameters_private(struct t_cose_sign1_sign_ctx *me,
 static inline enum t_cose_err_t
 t_cose_sign1_encode_signature_aad_private(struct t_cose_sign1_sign_ctx *me,
                                           struct q_useful_buf_c aad,
-                                          struct q_useful_buf_c detached_payload,
+                                          struct q_useful_buf_c signed_payload,
                                           QCBOREncodeContext   *cbor_encode_ctx)
 {
     return t_cose_sign_encode_finish(&(me->me2),
                                      aad,
-                                     detached_payload,
+                                     signed_payload,
                                      cbor_encode_ctx);
 }
 

--- a/inc/t_cose/t_cose_sign_sign.h
+++ b/inc/t_cose/t_cose_sign_sign.h
@@ -319,7 +319,6 @@ t_cose_sign_sign_detached(struct t_cose_sign_sign_ctx *context,
  */
 enum t_cose_err_t
 t_cose_sign_encode_start(struct t_cose_sign_sign_ctx *context,
-                         bool                         payload_is_detached,
                          QCBOREncodeContext          *cbor_encode_ctx);
 
 
@@ -351,7 +350,7 @@ t_cose_sign_encode_start(struct t_cose_sign_sign_ctx *context,
 enum t_cose_err_t
 t_cose_sign_encode_finish(struct t_cose_sign_sign_ctx *context,
                           struct q_useful_buf_c        aad,
-                          struct q_useful_buf_c        detached_payload,
+                          struct q_useful_buf_c        signed_payload,
                           QCBOREncodeContext          *cbor_encode_ctx);
 
 

--- a/test/t_cose_compute_validate_mac_test.c
+++ b/test/t_cose_compute_validate_mac_test.c
@@ -201,15 +201,17 @@ int_fast32_t compute_validate_mac_sig_fail_test()
     t_cose_mac_compute_init(&sign_ctx, 0, T_COSE_ALGORITHM_HMAC256);
     t_cose_mac_set_computing_key(&sign_ctx, key, NULL_Q_USEFUL_BUF_C);
 
-    result = t_cose_mac_encode_parameters(&sign_ctx, false, &cbor_encode);
+    result = t_cose_mac_encode_parameters(&sign_ctx, &cbor_encode);
     if(result) {
         return_value = 2000 + (int32_t)result;
         goto Done;
     }
 
+    QCBOREncode_BstrWrap(&cbor_encode);
     QCBOREncode_AddSZString(&cbor_encode, "payload");
+    QCBOREncode_CloseBstrWrap2(&cbor_encode, false, &payload);
 
-    result = t_cose_mac_encode_tag(&sign_ctx, NULL_Q_USEFUL_BUF_C, &cbor_encode);
+    result = t_cose_mac_encode_tag(&sign_ctx, payload, &cbor_encode);
     if(result) {
         return_value = 3000 + (int32_t)result;
         goto Done;
@@ -278,14 +280,14 @@ static int size_test(int32_t               cose_algorithm_id,
     t_cose_mac_compute_init(&sign_ctx,  0,  cose_algorithm_id);
     t_cose_mac_set_computing_key(&sign_ctx, key, kid);
 
-    return_value = t_cose_mac_encode_parameters(&sign_ctx, false, &cbor_encode);
+    return_value = t_cose_mac_encode_parameters(&sign_ctx, &cbor_encode);
     if(return_value) {
         return 2000 + (int32_t)return_value;
     }
 
-    QCBOREncode_AddEncoded(&cbor_encode, payload);
+    QCBOREncode_AddBytes(&cbor_encode, payload);
 
-    return_value = t_cose_mac_encode_tag(&sign_ctx, NULL_Q_USEFUL_BUF_C, &cbor_encode);
+    return_value = t_cose_mac_encode_tag(&sign_ctx, payload, &cbor_encode);
     if(return_value) {
         return 3000 + (int32_t)return_value;
     }
@@ -301,14 +303,14 @@ static int size_test(int32_t               cose_algorithm_id,
     t_cose_mac_compute_init(&sign_ctx, 0, cose_algorithm_id);
     t_cose_mac_set_computing_key(&sign_ctx, key, kid);
 
-    return_value = t_cose_mac_encode_parameters(&sign_ctx, false, &cbor_encode);
+    return_value = t_cose_mac_encode_parameters(&sign_ctx, &cbor_encode);
     if(return_value) {
         return 2000 + (int32_t)return_value;
     }
 
-    QCBOREncode_AddEncoded(&cbor_encode, payload);
+    QCBOREncode_AddBytes(&cbor_encode, payload);
 
-    return_value = t_cose_mac_encode_tag(&sign_ctx, NULL_Q_USEFUL_BUF_C, &cbor_encode);
+    return_value = t_cose_mac_encode_tag(&sign_ctx, payload, &cbor_encode);
     if(return_value) {
         return 3000 + (int32_t)return_value;
     }
@@ -431,7 +433,7 @@ int_fast32_t compute_validate_detached_content_mac_sig_fail_test()
     t_cose_mac_compute_init(&sign_ctx, 0, T_COSE_ALGORITHM_HMAC256);
     t_cose_mac_set_computing_key(&sign_ctx, key, NULL_Q_USEFUL_BUF_C);
 
-    result = t_cose_mac_encode_parameters(&sign_ctx, true, &cbor_encode);
+    result = t_cose_mac_encode_parameters(&sign_ctx, &cbor_encode);
     if(result) {
         return_value = 2000 + (int32_t)result;
         goto Done;
@@ -501,7 +503,7 @@ static int detached_content_size_test(int32_t               cose_algorithm_id,
     t_cose_mac_compute_init(&sign_ctx,  0,  cose_algorithm_id);
     t_cose_mac_set_computing_key(&sign_ctx, key, kid);
 
-    return_value = t_cose_mac_encode_parameters(&sign_ctx, true, &cbor_encode);
+    return_value = t_cose_mac_encode_parameters(&sign_ctx, &cbor_encode);
     if(return_value) {
         return 2000 + (int32_t)return_value;
     }
@@ -524,7 +526,7 @@ static int detached_content_size_test(int32_t               cose_algorithm_id,
     t_cose_mac_compute_init(&sign_ctx, 0, cose_algorithm_id);
     t_cose_mac_set_computing_key(&sign_ctx, key, kid);
 
-    return_value = t_cose_mac_encode_parameters(&sign_ctx, true, &cbor_encode);
+    return_value = t_cose_mac_encode_parameters(&sign_ctx, &cbor_encode);
     if(return_value) {
         return 2000 + (int32_t)return_value;
     }

--- a/test/t_cose_sign_verify_test.c
+++ b/test/t_cose_sign_verify_test.c
@@ -465,6 +465,7 @@ int_fast32_t sign_verify_make_cwt_test()
 
 
     /* -- The payload as from RFC 8932 -- */
+    QCBOREncode_BstrWrap(&cbor_encode);
     QCBOREncode_OpenMap(&cbor_encode);
     QCBOREncode_AddSZStringToMapN(&cbor_encode, 1, "coap://as.example.com");
     QCBOREncode_AddSZStringToMapN(&cbor_encode, 2, "erikw");
@@ -476,10 +477,10 @@ int_fast32_t sign_verify_make_cwt_test()
     QCBOREncode_AddBytesToMapN(&cbor_encode, 7,
                                Q_USEFUL_BUF_FROM_BYTE_ARRAY_LITERAL(xx));
     QCBOREncode_CloseMap(&cbor_encode);
-
+    QCBOREncode_CloseBstrWrap2(&cbor_encode, false, &payload);
 
     /* -- Finish up the COSE_Sign1. This is where the signing happens -- */
-    result = t_cose_sign1_encode_signature(&sign_ctx, &cbor_encode);
+    result = t_cose_sign1_encode_signature2(&sign_ctx, payload, &cbor_encode);
     if(result) {
         return_value = 3000 + (int32_t)result;
         goto Done;
@@ -602,9 +603,9 @@ static int_fast32_t size_test(int32_t               cose_algorithm_id,
         goto Done;
     }
 
-    QCBOREncode_AddEncoded(&cbor_encode, payload);
+    QCBOREncode_AddBytes(&cbor_encode, payload);
 
-    result = t_cose_sign1_encode_signature(&sign_ctx, &cbor_encode);
+    result = t_cose_sign1_encode_signature2(&sign_ctx, payload, &cbor_encode);
     if(result) {
         return_value = 4000 + (int32_t)result;
         goto Done;
@@ -655,9 +656,9 @@ static int_fast32_t size_test(int32_t               cose_algorithm_id,
         goto Done;
     }
 
-    QCBOREncode_AddEncoded(&cbor_encode, payload);
+    QCBOREncode_AddBytes(&cbor_encode, payload);
 
-    result = t_cose_sign1_encode_signature(&sign_ctx, &cbor_encode);
+    result = t_cose_sign1_encode_signature2(&sign_ctx, payload, &cbor_encode);
     if(result) {
         return_value = 7000 + (int32_t)result;
         goto Done;

--- a/test/t_cose_sign_verify_test.c
+++ b/test/t_cose_sign_verify_test.c
@@ -465,7 +465,6 @@ int_fast32_t sign_verify_make_cwt_test()
 
 
     /* -- The payload as from RFC 8932 -- */
-    QCBOREncode_BstrWrap(&cbor_encode);
     QCBOREncode_OpenMap(&cbor_encode);
     QCBOREncode_AddSZStringToMapN(&cbor_encode, 1, "coap://as.example.com");
     QCBOREncode_AddSZStringToMapN(&cbor_encode, 2, "erikw");
@@ -477,10 +476,9 @@ int_fast32_t sign_verify_make_cwt_test()
     QCBOREncode_AddBytesToMapN(&cbor_encode, 7,
                                Q_USEFUL_BUF_FROM_BYTE_ARRAY_LITERAL(xx));
     QCBOREncode_CloseMap(&cbor_encode);
-    QCBOREncode_CloseBstrWrap2(&cbor_encode, false, &payload);
 
     /* -- Finish up the COSE_Sign1. This is where the signing happens -- */
-    result = t_cose_sign1_encode_signature2(&sign_ctx, payload, &cbor_encode);
+    result = t_cose_sign1_encode_signature(&sign_ctx, &cbor_encode);
     if(result) {
         return_value = 3000 + (int32_t)result;
         goto Done;
@@ -603,9 +601,9 @@ static int_fast32_t size_test(int32_t               cose_algorithm_id,
         goto Done;
     }
 
-    QCBOREncode_AddBytes(&cbor_encode, payload);
+    QCBOREncode_AddEncoded(&cbor_encode, payload);
 
-    result = t_cose_sign1_encode_signature2(&sign_ctx, payload, &cbor_encode);
+    result = t_cose_sign1_encode_signature(&sign_ctx, &cbor_encode);
     if(result) {
         return_value = 4000 + (int32_t)result;
         goto Done;
@@ -656,9 +654,9 @@ static int_fast32_t size_test(int32_t               cose_algorithm_id,
         goto Done;
     }
 
-    QCBOREncode_AddBytes(&cbor_encode, payload);
+    QCBOREncode_AddEncoded(&cbor_encode, payload);
 
-    result = t_cose_sign1_encode_signature2(&sign_ctx, payload, &cbor_encode);
+    result = t_cose_sign1_encode_signature(&sign_ctx, &cbor_encode);
     if(result) {
         return_value = 7000 + (int32_t)result;
         goto Done;

--- a/test/t_cose_test.c
+++ b/test/t_cose_test.c
@@ -366,13 +366,11 @@ int_fast32_t short_circuit_signing_error_conditions_test()
     t_cose_sign1_sign_init(&sign_ctx, 0, T_COSE_ALGORITHM_SHORT_CIRCUIT_256);
     result = t_cose_sign1_encode_parameters(&sign_ctx, &cbor_encode);
 
-    QCBOREncode_BstrWrap(&cbor_encode);
     QCBOREncode_AddSZString(&cbor_encode, "payload");
     /* Force a CBOR encoding error by closing a map that is not open */
     QCBOREncode_CloseMap(&cbor_encode);
-    QCBOREncode_CloseBstrWrap2(&cbor_encode, false, &payload);
 
-    result = t_cose_sign1_encode_signature2(&sign_ctx, payload, &cbor_encode);
+    result = t_cose_sign1_encode_signature(&sign_ctx, &cbor_encode);
 
     if(result != T_COSE_ERR_CBOR_FORMATTING) {
         return -3;
@@ -433,7 +431,6 @@ int_fast32_t short_circuit_make_cwt_test()
         return 1000 + (int32_t)result;
     }
 
-    QCBOREncode_BstrWrap(&cbor_encode);
     QCBOREncode_OpenMap(&cbor_encode);
     QCBOREncode_AddSZStringToMapN(&cbor_encode, 1, "coap://as.example.com");
     QCBOREncode_AddSZStringToMapN(&cbor_encode, 2, "erikw");
@@ -444,10 +441,9 @@ int_fast32_t short_circuit_make_cwt_test()
     const uint8_t xx[] = {0x0b, 0x71};
     QCBOREncode_AddBytesToMapN(&cbor_encode, 7, Q_USEFUL_BUF_FROM_BYTE_ARRAY_LITERAL(xx));
     QCBOREncode_CloseMap(&cbor_encode);
-    QCBOREncode_CloseBstrWrap2(&cbor_encode, false, &payload);
 
     /* Finish up the COSE_Sign1. This is where the signing happens */
-    result = t_cose_sign1_encode_signature2(&sign_ctx, payload, &cbor_encode);
+    result = t_cose_sign1_encode_signature(&sign_ctx, &cbor_encode);
     if(result) {
         return 2000 + (int32_t)result;
     }
@@ -574,12 +570,10 @@ int_fast32_t short_circuit_decode_only_test()
         return 1000 + (int32_t)result;
     }
 
-    QCBOREncode_BstrWrap(&cbor_encode);
     QCBOREncode_AddSZString(&cbor_encode, "payload");
-    QCBOREncode_CloseBstrWrap2(&cbor_encode, false, &payload);
 
     /* Finish up the COSE_Sign1. This is where the signing happens */
-    result = t_cose_sign1_encode_signature2(&sign_ctx, payload, &cbor_encode);
+    result = t_cose_sign1_encode_signature(&sign_ctx, &cbor_encode);
     if(result) {
         return 2000 + (int32_t)result;
     }
@@ -1654,7 +1648,6 @@ int_fast32_t tags_test()
         return 1000 + (int32_t)result;
     }
 
-    QCBOREncode_BstrWrap(&cbor_encode);
     QCBOREncode_OpenMap(&cbor_encode);
     QCBOREncode_AddSZStringToMapN(&cbor_encode, 1, "coap://as.example.com");
     QCBOREncode_AddSZStringToMapN(&cbor_encode, 2, "erikw");
@@ -1665,10 +1658,9 @@ int_fast32_t tags_test()
     const uint8_t xx[] = {0x0b, 0x71};
     QCBOREncode_AddBytesToMapN(&cbor_encode, 7, Q_USEFUL_BUF_FROM_BYTE_ARRAY_LITERAL(xx));
     QCBOREncode_CloseMap(&cbor_encode);
-    QCBOREncode_CloseBstrWrap2(&cbor_encode, false, &payload);
 
     /* Finish up the COSE_Sign1. This is where the signing happens */
-    result = t_cose_sign1_encode_signature2(&sign_ctx, payload, &cbor_encode);
+    result = t_cose_sign1_encode_signature(&sign_ctx, &cbor_encode);
     if(result) {
         return 2000 + (int32_t)result;
     }
@@ -1831,14 +1823,12 @@ int_fast32_t tags_test()
         return 1000 + (int32_t)result;
     }
 
-    QCBOREncode_BstrWrap(&cbor_encode);
     QCBOREncode_OpenMap(&cbor_encode);
     QCBOREncode_AddSZStringToMapN(&cbor_encode, 1, "coap://as.example.com");
     QCBOREncode_CloseMap(&cbor_encode);
-    QCBOREncode_CloseBstrWrap2(&cbor_encode, false, &payload);
 
     /* Finish up the COSE_Sign1. This is where the signing happens */
-    result = t_cose_sign1_encode_signature2(&sign_ctx, payload, &cbor_encode);
+    result = t_cose_sign1_encode_signature(&sign_ctx, &cbor_encode);
     if(result) {
         return 2000 + (int32_t)result;
     }
@@ -1891,7 +1881,6 @@ int_fast32_t tags_test()
         return 1000 + (int32_t)result;
     }
 
-    QCBOREncode_BstrWrap(&cbor_encode);
     QCBOREncode_OpenMap(&cbor_encode);
     QCBOREncode_AddSZStringToMapN(&cbor_encode, 1, "coap://as.example.com");
     QCBOREncode_AddSZStringToMapN(&cbor_encode, 2, "erikw");
@@ -1902,10 +1891,9 @@ int_fast32_t tags_test()
     const uint8_t xxy[] = {0x0b, 0x71};
     QCBOREncode_AddBytesToMapN(&cbor_encode, 7, Q_USEFUL_BUF_FROM_BYTE_ARRAY_LITERAL(xxy));
     QCBOREncode_CloseMap(&cbor_encode);
-    QCBOREncode_CloseBstrWrap2(&cbor_encode, false, &payload);
 
     /* Finish up the COSE_Sign1. This is where the signing happens */
-    result = t_cose_sign1_encode_signature2(&sign_ctx, payload, &cbor_encode);
+    result = t_cose_sign1_encode_signature(&sign_ctx, &cbor_encode);
     if(result) {
         return 2000 + (int32_t)result;
     }
@@ -2023,9 +2011,9 @@ int_fast32_t get_size_test()
         return 2000 + (int32_t)return_value;
     }
 
-    QCBOREncode_AddBytes(&cbor_encode, payload);
+    QCBOREncode_AddEncoded(&cbor_encode, payload);
 
-    return_value = t_cose_sign1_encode_signature2(&sign_ctx, payload, &cbor_encode);
+    return_value = t_cose_sign1_encode_signature(&sign_ctx, &cbor_encode);
     if(return_value) {
         return 3000 + (int32_t)return_value;
     }
@@ -2056,9 +2044,9 @@ int_fast32_t get_size_test()
         return 2000 + (int32_t)return_value;
     }
 
-    QCBOREncode_AddBytes(&cbor_encode, payload);
+    QCBOREncode_AddEncoded(&cbor_encode, payload);
 
-    return_value = t_cose_sign1_encode_signature2(&sign_ctx, payload, &cbor_encode);
+    return_value = t_cose_sign1_encode_signature(&sign_ctx, &cbor_encode);
     if(return_value) {
         return 3000 + (int32_t)return_value;
     }

--- a/test/t_cose_test.c
+++ b/test/t_cose_test.c
@@ -331,6 +331,7 @@ int_fast32_t short_circuit_signing_error_conditions_test()
     enum t_cose_err_t            result;
     Q_USEFUL_BUF_MAKE_STACK_UB(  signed_cose_buffer, 300);
     Q_USEFUL_BUF_MAKE_STACK_UB(  small_signed_cose_buffer, 15);
+    struct q_useful_buf_c        payload;
     struct q_useful_buf_c        signed_cose;
 
     /* -- Test bad algorithm ID 0 -- */
@@ -365,12 +366,13 @@ int_fast32_t short_circuit_signing_error_conditions_test()
     t_cose_sign1_sign_init(&sign_ctx, 0, T_COSE_ALGORITHM_SHORT_CIRCUIT_256);
     result = t_cose_sign1_encode_parameters(&sign_ctx, &cbor_encode);
 
-
+    QCBOREncode_BstrWrap(&cbor_encode);
     QCBOREncode_AddSZString(&cbor_encode, "payload");
     /* Force a CBOR encoding error by closing a map that is not open */
     QCBOREncode_CloseMap(&cbor_encode);
+    QCBOREncode_CloseBstrWrap2(&cbor_encode, false, &payload);
 
-    result = t_cose_sign1_encode_signature(&sign_ctx, &cbor_encode);
+    result = t_cose_sign1_encode_signature2(&sign_ctx, payload, &cbor_encode);
 
     if(result != T_COSE_ERR_CBOR_FORMATTING) {
         return -3;
@@ -431,6 +433,7 @@ int_fast32_t short_circuit_make_cwt_test()
         return 1000 + (int32_t)result;
     }
 
+    QCBOREncode_BstrWrap(&cbor_encode);
     QCBOREncode_OpenMap(&cbor_encode);
     QCBOREncode_AddSZStringToMapN(&cbor_encode, 1, "coap://as.example.com");
     QCBOREncode_AddSZStringToMapN(&cbor_encode, 2, "erikw");
@@ -441,9 +444,10 @@ int_fast32_t short_circuit_make_cwt_test()
     const uint8_t xx[] = {0x0b, 0x71};
     QCBOREncode_AddBytesToMapN(&cbor_encode, 7, Q_USEFUL_BUF_FROM_BYTE_ARRAY_LITERAL(xx));
     QCBOREncode_CloseMap(&cbor_encode);
+    QCBOREncode_CloseBstrWrap2(&cbor_encode, false, &payload);
 
     /* Finish up the COSE_Sign1. This is where the signing happens */
-    result = t_cose_sign1_encode_signature(&sign_ctx, &cbor_encode);
+    result = t_cose_sign1_encode_signature2(&sign_ctx, payload, &cbor_encode);
     if(result) {
         return 2000 + (int32_t)result;
     }
@@ -570,11 +574,12 @@ int_fast32_t short_circuit_decode_only_test()
         return 1000 + (int32_t)result;
     }
 
-
+    QCBOREncode_BstrWrap(&cbor_encode);
     QCBOREncode_AddSZString(&cbor_encode, "payload");
+    QCBOREncode_CloseBstrWrap2(&cbor_encode, false, &payload);
 
     /* Finish up the COSE_Sign1. This is where the signing happens */
-    result = t_cose_sign1_encode_signature(&sign_ctx, &cbor_encode);
+    result = t_cose_sign1_encode_signature2(&sign_ctx, payload, &cbor_encode);
     if(result) {
         return 2000 + (int32_t)result;
     }
@@ -1649,6 +1654,7 @@ int_fast32_t tags_test()
         return 1000 + (int32_t)result;
     }
 
+    QCBOREncode_BstrWrap(&cbor_encode);
     QCBOREncode_OpenMap(&cbor_encode);
     QCBOREncode_AddSZStringToMapN(&cbor_encode, 1, "coap://as.example.com");
     QCBOREncode_AddSZStringToMapN(&cbor_encode, 2, "erikw");
@@ -1659,9 +1665,10 @@ int_fast32_t tags_test()
     const uint8_t xx[] = {0x0b, 0x71};
     QCBOREncode_AddBytesToMapN(&cbor_encode, 7, Q_USEFUL_BUF_FROM_BYTE_ARRAY_LITERAL(xx));
     QCBOREncode_CloseMap(&cbor_encode);
+    QCBOREncode_CloseBstrWrap2(&cbor_encode, false, &payload);
 
     /* Finish up the COSE_Sign1. This is where the signing happens */
-    result = t_cose_sign1_encode_signature(&sign_ctx, &cbor_encode);
+    result = t_cose_sign1_encode_signature2(&sign_ctx, payload, &cbor_encode);
     if(result) {
         return 2000 + (int32_t)result;
     }
@@ -1824,12 +1831,14 @@ int_fast32_t tags_test()
         return 1000 + (int32_t)result;
     }
 
+    QCBOREncode_BstrWrap(&cbor_encode);
     QCBOREncode_OpenMap(&cbor_encode);
     QCBOREncode_AddSZStringToMapN(&cbor_encode, 1, "coap://as.example.com");
     QCBOREncode_CloseMap(&cbor_encode);
+    QCBOREncode_CloseBstrWrap2(&cbor_encode, false, &payload);
 
     /* Finish up the COSE_Sign1. This is where the signing happens */
-    result = t_cose_sign1_encode_signature(&sign_ctx, &cbor_encode);
+    result = t_cose_sign1_encode_signature2(&sign_ctx, payload, &cbor_encode);
     if(result) {
         return 2000 + (int32_t)result;
     }
@@ -1882,6 +1891,7 @@ int_fast32_t tags_test()
         return 1000 + (int32_t)result;
     }
 
+    QCBOREncode_BstrWrap(&cbor_encode);
     QCBOREncode_OpenMap(&cbor_encode);
     QCBOREncode_AddSZStringToMapN(&cbor_encode, 1, "coap://as.example.com");
     QCBOREncode_AddSZStringToMapN(&cbor_encode, 2, "erikw");
@@ -1892,9 +1902,10 @@ int_fast32_t tags_test()
     const uint8_t xxy[] = {0x0b, 0x71};
     QCBOREncode_AddBytesToMapN(&cbor_encode, 7, Q_USEFUL_BUF_FROM_BYTE_ARRAY_LITERAL(xxy));
     QCBOREncode_CloseMap(&cbor_encode);
+    QCBOREncode_CloseBstrWrap2(&cbor_encode, false, &payload);
 
     /* Finish up the COSE_Sign1. This is where the signing happens */
-    result = t_cose_sign1_encode_signature(&sign_ctx, &cbor_encode);
+    result = t_cose_sign1_encode_signature2(&sign_ctx, payload, &cbor_encode);
     if(result) {
         return 2000 + (int32_t)result;
     }
@@ -2012,9 +2023,9 @@ int_fast32_t get_size_test()
         return 2000 + (int32_t)return_value;
     }
 
-    QCBOREncode_AddEncoded(&cbor_encode, payload);
+    QCBOREncode_AddBytes(&cbor_encode, payload);
 
-    return_value = t_cose_sign1_encode_signature(&sign_ctx, &cbor_encode);
+    return_value = t_cose_sign1_encode_signature2(&sign_ctx, payload, &cbor_encode);
     if(return_value) {
         return 3000 + (int32_t)return_value;
     }
@@ -2045,9 +2056,9 @@ int_fast32_t get_size_test()
         return 2000 + (int32_t)return_value;
     }
 
-    QCBOREncode_AddEncoded(&cbor_encode, payload);
+    QCBOREncode_AddBytes(&cbor_encode, payload);
 
-    return_value = t_cose_sign1_encode_signature(&sign_ctx, &cbor_encode);
+    return_value = t_cose_sign1_encode_signature2(&sign_ctx, payload, &cbor_encode);
     if(return_value) {
         return 3000 + (int32_t)return_value;
     }


### PR DESCRIPTION
Relate to #122 , changing interfaces and roles of 
- `t_cose_sign1_encode_parameters`
- `t_cose_sign1_encode_signature`
- `t_cose_sign_encode_start`
- `t_cose_sign_encode_finish`
- `t_cose_mac_encode_parameters`
- `t_cose_mac_encode_tag`

4 conditional branches are removed in total.
Two-step signing (computing mac) need to call `QCBOREncode_BstrWrap` and `QCBOREncode_CloseBstrWrap2` respectively, but the performance and code size would be improved.