### PR TITLE
key wrap crypto for OSSL adaptor plus key wrap tests,...

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -124,7 +124,7 @@ if (BUILD_TESTS)
 
     if (CRYPTO_PROVIDER STREQUAL "MbedTLS")
         set(TEST_SRC_EXTRA test/t_cose_make_psa_test_key.c)
-        set(TEST_EXTRA_DEFS -DT_COSE_DISABLE_MAC0 -DT_COSE_DISABLE_AES_KW)
+        set(TEST_EXTRA_DEFS -DT_COSE_DISABLE_MAC0)
     elseif(CRYPTO_PROVIDER STREQUAL "OpenSSL")
         set(TEST_SRC_EXTRA test/t_cose_make_openssl_test_key.c)
         set(TEST_EXTRA_DEFS -DT_COSE_DISABLE_MAC0)

--- a/crypto_adapters/t_cose_openssl_crypto.c
+++ b/crypto_adapters/t_cose_openssl_crypto.c
@@ -18,6 +18,7 @@
 #include <openssl/rsa.h>
 #include <openssl/evp.h>
 #include <openssl/err.h>
+#include <openssl/aes.h>
 
 #include "t_cose_util.h"
 
@@ -141,6 +142,29 @@ is_size_t_to_int_cast_ok(size_t x)
      * 0xffffffffffffffff or 0xffffffff and INT_MAX is 0x7fffffff.
      */
     if(x > INT_MAX) {
+        return false;
+    } else {
+        return true;
+    }
+#else
+    /* It would be very weird for INT_MAX to be larger than SIZE_MAX,
+     * but it is allowed by the C standard and this code aims for
+     * correctness against the C standard. If this happens a size_t
+     * always fits in an int.
+     */
+    return true;
+#endif /* SIZE_MAX > INT_MAX */
+}
+
+
+static inline bool
+is_size_t_to_uint_cast_ok(size_t x)
+{
+#if SIZE_MAX > UNT_MAX
+    /* The common case on a typical 64 or 32-bit CPU where SIZE_MAX is
+     * 0xffffffffffffffff or 0xffffffff and INT_MAX is 0x7fffffff.
+     */
+    if(x > UINT_MAX) {
         return false;
     } else {
         return true;
@@ -1630,3 +1654,182 @@ Done2:
 Done3:
     return return_value;
 }
+
+
+#ifndef T_COSE_DISABLE_AES_KW
+
+static int
+bits_in_kw_key(int32_t cose_algorithm_id)
+{
+    switch(cose_algorithm_id) {
+        case T_COSE_ALGORITHM_A128KW: return 128;
+        case T_COSE_ALGORITHM_A192KW: return 192;
+        case T_COSE_ALGORITHM_A256KW: return 256;
+        default: return INT_MAX;
+    }
+}
+
+
+/* This computes the length of the output of a key wrap algorithm
+ * based on the plaintext size. It is only dependent on the
+ * plaintext size, not on the key size.
+ */
+static size_t
+key_wrap_length(size_t plaintext_size)
+{
+    if(plaintext_size % 8) {
+        return 0;
+    }
+
+    if(plaintext_size > SIZE_MAX - 8) {
+        return 0;
+    }
+
+    return plaintext_size + 8;
+}
+
+
+/* The IV for all key wraps sizes in RFC 3394 */
+static const uint8_t rfc_3394_key_wrap_iv[] = {0xa6, 0xa6, 0xa6, 0xa6,
+                                               0xa6, 0xa6, 0xa6, 0xa6};
+
+/*
+ * See documentation in t_cose_crypto.h
+ */
+enum t_cose_err_t
+t_cose_crypto_kw_wrap(int32_t                 algorithm_id,
+                      struct q_useful_buf_c   kek,
+                      struct q_useful_buf_c   plaintext,
+                      struct q_useful_buf     ciphertext_buffer,
+                      struct q_useful_buf_c  *ciphertext_result)
+{
+    int      ossl_result;
+    AES_KEY  kek_ossl;
+    size_t   wrapped_size;
+    int      key_size_in_bits;
+    int      expected_kek_bits;
+
+    /* Check the algorithm ID and get expected bits in KEK. */
+    expected_kek_bits = bits_in_kw_key(algorithm_id);
+    if(expected_kek_bits == INT_MAX) {
+        return T_COSE_ERR_UNSUPPORTED_CIPHER_ALG;
+    }
+
+    /* Safely calculate bits in the KEK and check it */
+    if(kek.len > INT_MAX / 8) {
+        /* Cast to int isn't safe */
+        return T_COSE_ERR_WRONG_TYPE_OF_KEY;
+    }
+    key_size_in_bits = (int)kek.len * 8;
+    if(key_size_in_bits != expected_kek_bits){
+        return T_COSE_ERR_WRONG_TYPE_OF_KEY;
+    }
+
+    /* Set up the kek as an OpenSSL AES_KEY */
+    ossl_result = AES_set_encrypt_key(kek.ptr, key_size_in_bits, &kek_ossl);
+    if(ossl_result != 0) {
+        /* An OpenSSL API unlike others for which 0 is success. */
+        return T_COSE_ERR_KW_FAILED;
+    }
+
+    /* Check for space in the output buffer */
+    wrapped_size = key_wrap_length(plaintext.len);
+    if(ciphertext_buffer.len <= wrapped_size) {
+        return T_COSE_ERR_TOO_SMALL;
+    }
+
+    /* Do the wrap */
+    if(!is_size_t_to_uint_cast_ok(plaintext.len)){
+        return T_COSE_ERR_KW_FAILED;
+    }
+    // TODO: be sure OpenSSL won't run off the end of
+    // any buffers in this call by reading docs, testing and thinking...
+    ossl_result = AES_wrap_key(&kek_ossl,
+                               rfc_3394_key_wrap_iv,
+                               ciphertext_buffer.ptr,
+                               plaintext.ptr,
+                               (unsigned int)plaintext.len);
+    if(ossl_result != (int)wrapped_size) {
+        return T_COSE_ERR_KW_FAILED;
+    }
+
+    ciphertext_result->len = wrapped_size;
+    ciphertext_result->ptr = ciphertext_buffer.ptr;
+
+    return T_COSE_SUCCESS;
+}
+
+
+
+/*
+ * See documentation in t_cose_crypto.h
+ */
+enum t_cose_err_t
+t_cose_crypto_kw_unwrap(int32_t                 algorithm_id,
+                        struct q_useful_buf_c   kek,
+                        struct q_useful_buf_c   ciphertext,
+                        struct q_useful_buf     plaintext_buffer,
+                        struct q_useful_buf_c  *plaintext_result)
+{
+    int     unwrapped_size;
+    AES_KEY kek_ossl;
+    size_t  expected_unwrapped_size;
+    int     kek_size_in_bits;
+    int      expected_kek_bits;
+
+    /* Check the algorithm ID and get expected bits in KEK. */
+    expected_kek_bits = bits_in_kw_key(algorithm_id);
+    if(expected_kek_bits == INT_MAX) {
+        return T_COSE_ERR_UNSUPPORTED_CIPHER_ALG;
+    }
+
+    /* Safely calculate bits in the KEK and check it */
+    if(kek.len > INT_MAX / 8) {
+        /* Cast to int isn't safe */
+        return T_COSE_ERR_WRONG_TYPE_OF_KEY;
+    }
+    kek_size_in_bits = (int)kek.len * 8;
+    if(kek_size_in_bits != expected_kek_bits){
+        return T_COSE_ERR_WRONG_TYPE_OF_KEY;
+    }
+
+    /* Set up the kek as an OpenSSL AES_KEY */
+    unwrapped_size = AES_set_decrypt_key(kek.ptr, kek_size_in_bits, &kek_ossl);
+    if(unwrapped_size != 0) {
+        /* An OpenSSL API unlike others for which 0 is success. */
+        return T_COSE_ERR_KW_FAILED;
+    }
+
+    /* Check for space in the output buffer */
+    expected_unwrapped_size = ciphertext.len - 8;
+    if(plaintext_buffer.len <= expected_unwrapped_size) {
+        return T_COSE_ERR_TOO_SMALL;
+    }
+
+    /* Do the unwrap */
+    if(!is_size_t_to_uint_cast_ok(ciphertext.len)) {
+        return T_COSE_ERR_KW_FAILED;
+    }
+    // TODO: be sure OpenSSL won't run off the end of
+    // any buffers in this call by reading docs, testing and thinking...
+    unwrapped_size = AES_unwrap_key(&kek_ossl,
+                                 rfc_3394_key_wrap_iv,
+                                 plaintext_buffer.ptr,
+                                 ciphertext.ptr,
+                                 (unsigned int)ciphertext.len);
+    if(!is_int_to_size_t_cast_ok(unwrapped_size)) {
+        return T_COSE_ERR_KW_FAILED;
+    }
+    if((size_t)unwrapped_size != expected_unwrapped_size) {
+        /* Doesn't seem to be any way to distinguish data auth failed
+         * from other errors and this seems the more likely error.
+         * TODO: go read ossl source to understand. */
+        return T_COSE_ERR_DATA_AUTH_FAILED;
+    }
+    plaintext_result->len = expected_unwrapped_size;
+    plaintext_result->ptr = plaintext_buffer.ptr;
+
+    return T_COSE_SUCCESS;
+}
+
+#endif /* !T_COSE_DISABLE_AES_KW */

--- a/crypto_adapters/t_cose_openssl_crypto.c
+++ b/crypto_adapters/t_cose_openssl_crypto.c
@@ -98,6 +98,13 @@ bool t_cose_crypto_is_algorithm_supported(int32_t cose_algorithm_id)
         T_COSE_ALGORITHM_A128GCM,
         T_COSE_ALGORITHM_A192GCM, /* For 9053 key wrap and direct, not HPKE */
         T_COSE_ALGORITHM_A256GCM,
+
+#ifndef T_COSE_DISABLE_AES_KW
+        T_COSE_ALGORITHM_A128KW,
+        T_COSE_ALGORITHM_A192KW,
+        T_COSE_ALGORITHM_A256KW,
+#endif /* T_COSE_DISABLE_AES_KW */
+
         T_COSE_ALGORITHM_NONE /* List terminator */
     };
 
@@ -156,7 +163,7 @@ is_size_t_to_int_cast_ok(size_t x)
 #endif /* SIZE_MAX > INT_MAX */
 }
 
-
+#ifndef T_COSE_DISABLE_AES_KW
 static inline bool
 is_size_t_to_uint_cast_ok(size_t x)
 {
@@ -178,6 +185,7 @@ is_size_t_to_uint_cast_ok(size_t x)
     return true;
 #endif /* SIZE_MAX > INT_MAX */
 }
+#endif /* T_COSE_DISABLE_AES_KW */
 
 
 /* See is_size_t_to_int_cast_ok() */

--- a/crypto_adapters/t_cose_openssl_crypto.c
+++ b/crypto_adapters/t_cose_openssl_crypto.c
@@ -1,7 +1,7 @@
 /*
  *  t_cose_openssl_crypto.c
  *
- * Copyright 2019-2022, Laurence Lundblade
+ * Copyright 2019-2023, Laurence Lundblade
  * Copyright (c) 2022, Arm Limited. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/crypto_adapters/t_cose_psa_crypto.c
+++ b/crypto_adapters/t_cose_psa_crypto.c
@@ -1,7 +1,7 @@
 /*
  * t_cose_psa_crypto.c
  *
- * Copyright 2019-2022, Laurence Lundblade
+ * Copyright 2019-2023, Laurence Lundblade
  * Copyright (c) 2020-2022, Arm Limited. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/crypto_adapters/t_cose_psa_crypto.c
+++ b/crypto_adapters/t_cose_psa_crypto.c
@@ -40,7 +40,6 @@
 #include <mbedtls/aes.h> // TODO: Isn't there a PSA API for AES?
 
 #ifndef T_COSE_DISABLE_AES_KW
-// TODO: isn't there a PSA API for key wrap?
 #include <mbedtls/nist_kw.h>
 #endif /* T_COSE_DISABLE_AES_KW */
 
@@ -719,61 +718,168 @@ t_cose_crypto_get_random(struct q_useful_buf    buffer,
 
 
 #ifndef T_COSE_DISABLE_AES_KW
+
+
+static unsigned int
+bits_in_kw_key(int32_t cose_algorithm_id)
+{
+    switch(cose_algorithm_id) {
+        case T_COSE_ALGORITHM_A128KW: return 128;
+        case T_COSE_ALGORITHM_A192KW: return 192;
+        case T_COSE_ALGORITHM_A256KW: return 256;
+        default: return UINT_MAX;
+    }
+}
+
+
 /*
  * See documentation in t_cose_crypto.h
  */
 enum t_cose_err_t
-t_cose_crypto_aes_kw(int32_t                 algorithm_id,
-                     struct q_useful_buf_c   kek,
-                     struct q_useful_buf_c   plaintext,
-                     struct q_useful_buf     ciphertext_buffer,
-                     struct q_useful_buf_c  *ciphertext_result)
+t_cose_crypto_kw_wrap(int32_t                 cose_algorithm_id,
+                      struct q_useful_buf_c   kek,
+                      struct q_useful_buf_c   plaintext,
+                      struct q_useful_buf     ciphertext_buffer,
+                      struct q_useful_buf_c  *ciphertext_result)
 {
-    /* Mbed TLS AES-KW Variables */
-    mbedtls_nist_kw_context ctx;
+    mbedtls_nist_kw_context kw_context;
     int                     ret;
-    size_t                  res_len;
+    size_t                  ciphertext_len;
+    unsigned int            kek_bits;
+    unsigned int            expected_kek_bits;
 
-    // TODO: this needs to check the algorithm ID
-    (void)algorithm_id;
+    /* Check the supplied kek and algorithm ID */
+    if(kek.len > UINT_MAX / 8) {
+        /* Integer math would overflow (and it would be an enormous key) */
+        return T_COSE_ERR_WRONG_TYPE_OF_KEY;
+    }
+    kek_bits = (unsigned int)(8 * kek.len);
 
-    mbedtls_nist_kw_init(&ctx);
+    expected_kek_bits = bits_in_kw_key(cose_algorithm_id);
+    if(expected_kek_bits == UINT_MAX) {
+        return T_COSE_ERR_UNSUPPORTED_CIPHER_ALG;
+    }
+
+    if(kek_bits != expected_kek_bits) {
+        /* An unsupported algorithm will return UINT_MAX bits */
+        return T_COSE_ERR_WRONG_TYPE_OF_KEY;
+    }
+
+    mbedtls_nist_kw_init(&kw_context);
 
     /* Configure KEK to be externally supplied symmetric key */
-    ret = mbedtls_nist_kw_setkey(&ctx,                 // Key wrapping context
-                                 MBEDTLS_CIPHER_ID_AES, // Block cipher
-                                 kek.ptr,           // Key Encryption Key (KEK)
-                                 (unsigned int)
-                                    kek.len * 8,    // KEK size in bits
-                                 MBEDTLS_ENCRYPT    // Operation within the context
+    ret = mbedtls_nist_kw_setkey(&kw_context,
+                                  MBEDTLS_CIPHER_ID_AES,
+                                  kek.ptr,
+                                  kek_bits,
+                                  MBEDTLS_ENCRYPT
                                 );
 
     if (ret != 0) {
-        return(T_COSE_ERR_AES_KW_FAILED);
+        return T_COSE_ERR_KW_FAILED;
     }
 
     /* Encrypt CEK with the AES key wrap algorithm defined in RFC 3394. */
-    ret = mbedtls_nist_kw_wrap(&ctx,
-                               MBEDTLS_KW_MODE_KW,
-                               plaintext.ptr,
-                               plaintext.len,
-                               ciphertext_buffer.ptr,
-                               &res_len,
-                               ciphertext_buffer.len
+    ret = mbedtls_nist_kw_wrap(&kw_context,
+                                MBEDTLS_KW_MODE_KW,
+                                plaintext.ptr,
+                                plaintext.len,
+                                ciphertext_buffer.ptr,
+                               &ciphertext_len,
+                                ciphertext_buffer.len
                               );
 
     if (ret != 0) {
-        return(T_COSE_ERR_AES_KW_FAILED);
+        return T_COSE_ERR_KW_FAILED;
     }
 
     ciphertext_result->ptr = ciphertext_buffer.ptr;
-    ciphertext_result->len = res_len;
+    ciphertext_result->len = ciphertext_len;
 
-    mbedtls_nist_kw_free(&ctx);
+    // TODO: this needs to be called in error conditions
 
-    return(T_COSE_SUCCESS);
+    mbedtls_nist_kw_free(&kw_context);
+
+    return T_COSE_SUCCESS;
 }
-#endif
+
+
+enum t_cose_err_t
+t_cose_crypto_kw_unwrap(int32_t                 cose_algorithm_id,
+                        struct q_useful_buf_c   kek,
+                        struct q_useful_buf_c   ciphertext,
+                        struct q_useful_buf     plaintext_buffer,
+                        struct q_useful_buf_c  *plaintext_result)
+{
+    mbedtls_nist_kw_context kw_context;
+    int                     ret;
+    size_t                  plaintext_len;
+    unsigned int            kek_bits;
+    unsigned int            expected_kek_bits;
+    enum t_cose_err_t       return_value;
+
+    /* Check the supplied kek and algorithm ID */
+    if(kek.len > UINT_MAX / 8) {
+        /* Integer math would overflow (and it would be an enormous key) */
+        return T_COSE_ERR_WRONG_TYPE_OF_KEY;
+    }
+    kek_bits = (unsigned int)(8 * kek.len);
+
+    expected_kek_bits = bits_in_kw_key(cose_algorithm_id);
+    if(expected_kek_bits == UINT_MAX) {
+        return T_COSE_ERR_UNSUPPORTED_CIPHER_ALG;
+    }
+
+    if(kek_bits != expected_kek_bits) {
+        /* An unsupported algorithm will return UINT_MAX bits */
+        return T_COSE_ERR_WRONG_TYPE_OF_KEY;
+    }
+
+    /* Initialize and configure KEK */
+    mbedtls_nist_kw_init(&kw_context);
+    ret = mbedtls_nist_kw_setkey(&kw_context,
+                                 MBEDTLS_CIPHER_ID_AES,
+                                 kek.ptr,
+                                 kek_bits,
+                                 MBEDTLS_DECRYPT
+                                );
+    if (ret != 0) {
+        return_value = T_COSE_ERR_KW_FAILED;
+        goto Done;
+    }
+
+    /* Encrypt CEK with the AES key wrap algorithm defined in RFC 3394. */
+    ret = mbedtls_nist_kw_unwrap(&kw_context,
+                                  MBEDTLS_KW_MODE_KW,
+                                  ciphertext.ptr,
+                                  ciphertext.len,
+                                  plaintext_buffer.ptr,
+                                 &plaintext_len,
+                                  plaintext_buffer.len
+                                );
+
+    if(ret == MBEDTLS_ERR_CIPHER_AUTH_FAILED) {
+        return_value = T_COSE_ERR_DATA_AUTH_FAILED;
+        goto Done;
+    }
+    if (ret != 0) {
+        return_value = T_COSE_ERR_KW_FAILED;
+        goto Done;
+    }
+    plaintext_result->ptr = plaintext_buffer.ptr;
+    plaintext_result->len = plaintext_len;
+
+    return_value = T_COSE_SUCCESS;
+
+Done:
+    mbedtls_nist_kw_free(&kw_context);
+
+    return return_value;
+}
+#endif /* !T_COSE_DISABLE_AES_KW */
+
+
+
 
 /*
  * See documentation in t_cose_crypto.h

--- a/crypto_adapters/t_cose_psa_crypto.c
+++ b/crypto_adapters/t_cose_psa_crypto.c
@@ -96,11 +96,11 @@ bool t_cose_crypto_is_algorithm_supported(int32_t cose_algorithm_id)
         T_COSE_ALGORITHM_A256GCM,
         #endif /* T_COSE_DISABLE_MAC0 */
 
-#ifndef NO_MBED_KW_API
+#if !defined NO_MBED_KW_API & !defined T_COSE_DISABLE_AES_KW
         T_COSE_ALGORITHM_A128KW,
         T_COSE_ALGORITHM_A192KW,
         T_COSE_ALGORITHM_A256KW,
-#endif /* !NO_MBED_KW_API */
+#endif /* !(NO_MBED_KW_API && T_COSE_DISABLE_AES_KW) */
 
         T_COSE_ALGORITHM_NONE /* List terminator */
     };

--- a/crypto_adapters/t_cose_test_crypto.c
+++ b/crypto_adapters/t_cose_test_crypto.c
@@ -530,3 +530,63 @@ t_cose_crypto_aead_decrypt(const int32_t          cose_algorithm_id,
 }
 
 #endif /* T_COSE_DISABLE_EDDSA */
+
+
+static const uint8_t rfc_3394_key_wrap_iv[] = {0xa6, 0xa6, 0xa6, 0xa6, 0xa6, 0xa6, 0xa6, 0xa6};
+
+enum t_cose_err_t
+t_cose_crypto_kw_wrap(int32_t                 cose_algorithm_id,
+                      struct q_useful_buf_c   kek,
+                      struct q_useful_buf_c   plaintext,
+                      struct q_useful_buf     ciphertext_buffer,
+                      struct q_useful_buf_c  *ciphertext_result)
+{
+    UsefulOutBuf UOB;
+
+    (void)cose_algorithm_id;
+    (void)kek;
+
+    UsefulOutBuf_Init(&UOB, ciphertext_buffer);
+    UsefulOutBuf_AppendUsefulBuf(&UOB, plaintext);
+    UsefulOutBuf_AppendUsefulBuf(&UOB, Q_USEFUL_BUF_FROM_BYTE_ARRAY_LITERAL(rfc_3394_key_wrap_iv));
+    *ciphertext_result = UsefulOutBuf_OutUBuf(&UOB);
+
+    if(q_useful_buf_c_is_null(*ciphertext_result)){
+        return T_COSE_ERR_TOO_SMALL;
+    }
+
+    return T_COSE_SUCCESS;
+}
+
+
+enum t_cose_err_t
+t_cose_crypto_kw_unwrap(int32_t                 cose_algorithm_id,
+                        struct q_useful_buf_c   kek,
+                        struct q_useful_buf_c   ciphertext,
+                        struct q_useful_buf     plaintext_buffer,
+                        struct q_useful_buf_c  *plaintext_result)
+{
+    UsefulBufC                  tag;
+    struct q_useful_buf_c       plain_text;
+    const struct q_useful_buf_c expected_tag = Q_USEFUL_BUF_FROM_BYTE_ARRAY_LITERAL(rfc_3394_key_wrap_iv);
+
+    (void)cose_algorithm_id;
+    (void)kek;
+
+    UsefulInputBuf UIB;
+    UsefulInputBuf_Init(&UIB, ciphertext);
+
+    plain_text = UsefulInputBuf_GetUsefulBuf(&UIB, ciphertext.len - expected_tag.len);
+    tag = UsefulInputBuf_GetUsefulBuf(&UIB, expected_tag.len);
+
+    if(UsefulBuf_Compare(tag, expected_tag)) {
+        return T_COSE_ERR_DATA_AUTH_FAILED;
+    }
+
+    *plaintext_result = UsefulBuf_Copy(plaintext_buffer, plain_text);
+    if(q_useful_buf_c_is_null(*plaintext_result)) {
+        return T_COSE_ERR_TOO_SMALL;
+    }
+
+    return T_COSE_SUCCESS;
+}

--- a/crypto_adapters/t_cose_test_crypto.c
+++ b/crypto_adapters/t_cose_test_crypto.c
@@ -1,7 +1,7 @@
 /*
  *  t_cose_test_crypto.c
  *
- * Copyright 2019-2020, Laurence Lundblade
+ * Copyright 2019-2023, Laurence Lundblade
  * Copyright (c) 2022, Arm Limited. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/inc/t_cose/t_cose_common.h
+++ b/inc/t_cose/t_cose_common.h
@@ -582,7 +582,7 @@ enum t_cose_err_t {
     T_COSE_ERR_KEY_EXPORT_FAILED = 62,
 
     /** Something went wrong with AES Key Wrap. */
-    T_COSE_ERR_AES_KW_FAILED = 63,
+    T_COSE_ERR_KW_FAILED = 63,
     /** The signature algorithm needs an extra buffer, but none was provided.
      * See \ref t_cose_sign1_verify_set_auxiliary_buffer for more details.
      */

--- a/src/t_cose_recipient_enc_aes_kw.c
+++ b/src/t_cose_recipient_enc_aes_kw.c
@@ -65,7 +65,7 @@ enum t_cose_err_t t_cose_create_recipient_aes_kw(
     recipient_key_result.len = recipient_key_len;
 
     /* AES key wrap encryption */
-    return_value = t_cose_crypto_aes_kw(
+    return_value = t_cose_crypto_kw_wrap(
                         0,
                         recipient_key_result,
                         plaintext,

--- a/test/run_tests.c
+++ b/test/run_tests.c
@@ -57,7 +57,9 @@ static test_entry2 s_tests2[] = {
 static test_entry s_tests[] = {
 
     TEST_ENTRY(aead_test),
+#ifndef T_COSE_DISABLE_AES_KW
     TEST_ENTRY(kw_test),
+#endif
 
 #ifndef T_COSE_DISABLE_SIGN1
     // TODO: re enable this test when it is fixed

--- a/test/run_tests.c
+++ b/test/run_tests.c
@@ -57,6 +57,7 @@ static test_entry2 s_tests2[] = {
 static test_entry s_tests[] = {
 
     TEST_ENTRY(aead_test),
+    TEST_ENTRY(kw_test),
 
 #ifndef T_COSE_DISABLE_SIGN1
     // TODO: re enable this test when it is fixed

--- a/test/t_cose_crypto_test.c
+++ b/test/t_cose_crypto_test.c
@@ -145,6 +145,8 @@ int_fast32_t aead_test(void)
 
 
 
+#ifndef T_COSE_DISABLE_AES_KW
+
 int_fast32_t kw_test(void)
 {
     /* These are test vectors from RFC 3394 */
@@ -160,6 +162,17 @@ int_fast32_t kw_test(void)
 
     struct q_useful_buf_c ciphertext;
     struct q_useful_buf_c plaintext;
+
+    if(!t_cose_is_algorithm_supported(T_COSE_ALGORITHM_A128KW)) {
+        /* This is necessary because MbedTLS 2.28 doesn't have
+         * nist KW enabled by default. The PSA crypto layer deals with
+         * this dynamically. The below tests will correctly link
+         * on 2.28, but will fail to run so this exception is needed.
+         */
+        return 0;
+    }
+
+    // TODO: test more sizes and algorithms
 
     e = t_cose_crypto_kw_wrap(T_COSE_ALGORITHM_A128KW,
                               kek,
@@ -213,3 +226,5 @@ int_fast32_t kw_test(void)
 
     return 0;
 }
+
+#endif /* !T_COSE_DISABLE_AES_KW */

--- a/test/t_cose_crypto_test.c
+++ b/test/t_cose_crypto_test.c
@@ -10,7 +10,7 @@
 
 #include "t_cose_crypto_test.h"
 
-#include "../src/t_cose_crypto.h" /* NOT a public interface so this test can't run an installed library */
+#include "../src/t_cose_crypto.h" /* NOT a public interface so this test can't run against an installed library */
 
 static const uint8_t test_key_0_128bit[] = {
     0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x010, 0x00,

--- a/test/t_cose_crypto_test.c
+++ b/test/t_cose_crypto_test.c
@@ -1,7 +1,7 @@
 /*
  *  t_cose_crypto_test.c
  *
- * Copyright 2022, Laurence Lundblade
+ * Copyright 2022-2023, Laurence Lundblade
  * Created by Laurence Lundblade on 12/28/22.
  *
  * SPDX-License-Identifier: BSD-3-Clause
@@ -88,7 +88,7 @@ int_fast32_t aead_test(void)
 #else
     /* It's not really necessary to test the test crypto, but it is
      * helpful to validate it some. But the above is disabled as it
-     * doesn't produce real AES-GCM results even though it an
+     * doesn't produce real AES-GCM results even though it can
      * fake encryption and decryption. */
 #endif
 
@@ -143,3 +143,73 @@ int_fast32_t aead_test(void)
     return 0;
 }
 
+
+
+int_fast32_t kw_test(void)
+{
+    /* These are test vectors from RFC 3394 */
+    const struct q_useful_buf_c kek = Q_USEFUL_BUF_FROM_BYTE_ARRAY_LITERAL(((const uint8_t []){0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F}));
+    
+    const struct q_useful_buf_c key_data = Q_USEFUL_BUF_FROM_BYTE_ARRAY_LITERAL(((const uint8_t []){0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF}));
+
+    const struct q_useful_buf_c expected_wrap = Q_USEFUL_BUF_FROM_BYTE_ARRAY_LITERAL(((const uint8_t []){0x1F, 0xA6, 0x8B, 0x0A, 0x81, 0x12, 0xB4, 0x47,  0xAE, 0xF3, 0x4B, 0xD8, 0xFB, 0x5A, 0x7B, 0x82,  0x9D, 0x3E, 0x86, 0x23, 0x71, 0xD2, 0xCF, 0xE5}));
+
+    enum t_cose_err_t e;
+    Q_USEFUL_BUF_MAKE_STACK_UB (ciphertext_buffer, 9 * 8); /* sized for 256-bit key with authentication tag */
+    Q_USEFUL_BUF_MAKE_STACK_UB (plaintext_buffer, 8 * 8); /* sized for 256-bit key */
+
+    struct q_useful_buf_c ciphertext;
+    struct q_useful_buf_c plaintext;
+
+    e = t_cose_crypto_kw_wrap(T_COSE_ALGORITHM_A128KW,
+                              kek,
+                              key_data,
+                              ciphertext_buffer,
+                             &ciphertext);
+    if(e != T_COSE_SUCCESS) {
+        return 1;
+    }
+
+    /* TODO: proper define to know about test crypto */
+#ifndef T_COSE_USE_B_CON_SHA256
+    if(q_useful_buf_compare(ciphertext, expected_wrap)) {
+        return 5;
+    }
+#else
+    (void)expected_wrap;
+    /* It's not really necessary to test the test crypto, but it is
+     * helpful to validate it some. But the above is disabled as it
+     * doesn't produce real key wra results even though it can
+     * fake wrap and unwrap. */
+#endif
+
+    e = t_cose_crypto_kw_unwrap(T_COSE_ALGORITHM_A128KW,
+                                kek,
+                                ciphertext,
+                                plaintext_buffer,
+                                &plaintext);
+    if(e != T_COSE_SUCCESS) {
+        return 9;
+    }
+
+    if(q_useful_buf_compare(key_data, plaintext)) {
+        return 15;
+    }
+
+
+    /* Now modify the cipher text so the integrity check will fail.  */
+    /* It's only a test case so cheating a bit here by casting away const is not too big of a crime. */
+    ((uint8_t *)(uintptr_t)ciphertext.ptr)[ciphertext.len-1] += 1;
+
+    e = t_cose_crypto_kw_unwrap(T_COSE_ALGORITHM_A128KW,
+                                kek,
+                                ciphertext,
+                                plaintext_buffer,
+                                &plaintext);
+    if(e != T_COSE_ERR_DATA_AUTH_FAILED) {
+        return 27;
+    }
+
+
+    return 0;
+}

--- a/test/t_cose_crypto_test.h
+++ b/test/t_cose_crypto_test.h
@@ -1,7 +1,7 @@
 /*
  *  t_cose_crypto_test.h
  *
- * Copyright 2022, Laurence Lundblade
+ * Copyright 2022-2023, Laurence Lundblade
  * Created by Laurence Lundblade on 12/28/22.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/test/t_cose_crypto_test.h
+++ b/test/t_cose_crypto_test.h
@@ -16,4 +16,6 @@
 
 int_fast32_t aead_test(void);
 
+int_fast32_t kw_test(void);
+
 #endif /* t_cose_crypto_test_h */


### PR DESCRIPTION
Adds key wrap to OSSL crypto adaptor.

Adds fake key wrap to test crypto adaptor.

Adds test of key wrap crypto adaptors.

Improvements to API for key wrap in crypto adaptor layer.

Improvements to PSA key wrap -- mostly error codes and defenses.

Enables key wrap for PSA crypto adaptor by default and adds compile-time and run-time facilities to handle MbedTLS 2.28 which doesn't support key wrap.