### PR TITLE
Code refactoring that makes encrypt recipients an object

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -99,7 +99,7 @@ if (BUILD_EXAMPLES)
         add_executable(t_cose_basic_example_psa examples/t_cose_basic_example_psa.c)
         target_link_libraries(t_cose_basic_example_psa PRIVATE t_cose ${CRYPTO_LIBRARY})
     elseif (CRYPTO_PROVIDER STREQUAL "OpenSSL")
-        add_executable(t_cose_basic_example_ossl examples/t_cose_basic_example_ossl.c)
+        add_executable(t_cose_basic_example_ossl examples/t_cose_basic_example_ossl.c examples/encryption_examples_ossl.c)
         target_link_libraries(t_cose_basic_example_ossl PRIVATE t_cose ${CRYPTO_LIBRARY})
     endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,6 +74,12 @@ set(T_COSE_SRC_COMMON
     src/t_cose_mac_validate.c
     src/t_cose_signature_verify_main.c
     src/t_cose_signature_verify_eddsa.c
+    src/t_cose_encrypt_enc.c
+    src/t_cose_encrypt_dec.c
+    src/t_cose_recipient_dec_aes_kw.c
+    src/t_cose_recipient_enc_aes_kw.c
+    src/t_cose_recipient_dec_hpke.c
+    src/t_cose_recipient_enc_hpke.c
     src/hpke.c
 )
 

--- a/Makefile.ossl
+++ b/Makefile.ossl
@@ -49,7 +49,14 @@ CRYPTO_TEST_OBJ=test/t_cose_make_openssl_test_key.o
 
 
 # ---- compiler configuration -----
-# Optimize for size
+# This makefile uses a minimum of compiler flags so that it will
+# work out-of-the-box with a wide variety of compilers.  For example,
+# some compilers error out on some of the warnings flags gcc supports.
+# The $(CMD_LINE) variable allows passing in extra flags. This is
+# used on the stringent build script that is in
+# https://github.com/laurencelundblade/tdv.  This script is used
+# before pushes to master (though not yet through an automated build
+# process). See "warn:" below.
 C_OPTS=-Os -fPIC
 
 
@@ -82,12 +89,15 @@ SRC_OBJ=src/t_cose_util.o \
         src/t_cose_mac_compute.o \
         src/t_cose_mac_validate.o
 
-.PHONY: all install install_headers install_so uninstall clean
+.PHONY: all install install_headers install_so uninstall clean warn
 
 all: libt_cose.a t_cose_test t_cose_basic_example_ossl
 
 libt_cose.a: $(SRC_OBJ) $(CRYPTO_OBJ)
 	ar -r $@ $^
+
+warn:
+	make -f Makefile.ossl CMD_LINE="-Wall -Wextra -Wpedantic -Wshadow -Wconversion -Wcast-qual"
 
 # The shared library is not made by default because of platform
 # variability For example MacOS and Linux behave differently and some

--- a/Makefile.ossl
+++ b/Makefile.ossl
@@ -88,7 +88,14 @@ SRC_OBJ=src/t_cose_util.o \
         src/t_cose_signature_verify_main.o \
         src/t_cose_signature_verify_eddsa.o \
         src/t_cose_mac_compute.o \
-        src/t_cose_mac_validate.o
+        src/t_cose_mac_validate.o \
+	src/t_cose_encrypt_enc.o \
+	src/t_cose_encrypt_dec.o \
+	src/t_cose_recipient_dec_aes_kw.o \
+	src/t_cose_recipient_enc_aes_kw.o \
+	src/t_cose_recipient_dec_hpke.o \
+	src/t_cose_recipient_enc_hpke.o \
+	src/hpke.o
 
 .PHONY: all install install_headers install_so uninstall clean warn
 

--- a/Makefile.ossl
+++ b/Makefile.ossl
@@ -110,7 +110,7 @@ t_cose_test: main.o $(TEST_OBJ) libt_cose.a
 	cc -o $@ $^ $(QCBOR_LIB) $(CRYPTO_LIB)
 
 
-t_cose_basic_example_ossl: examples/t_cose_basic_example_ossl.o libt_cose.a
+t_cose_basic_example_ossl: examples/t_cose_basic_example_ossl.o examples/encryption_examples_ossl.o libt_cose.a
 	cc -o $@ $^ $(QCBOR_LIB) $(CRYPTO_LIB)
 
 

--- a/Makefile.ossl
+++ b/Makefile.ossl
@@ -89,13 +89,13 @@ SRC_OBJ=src/t_cose_util.o \
         src/t_cose_signature_verify_eddsa.o \
         src/t_cose_mac_compute.o \
         src/t_cose_mac_validate.o \
-	src/t_cose_encrypt_enc.o \
-	src/t_cose_encrypt_dec.o \
-	src/t_cose_recipient_dec_aes_kw.o \
-	src/t_cose_recipient_enc_aes_kw.o \
-	src/t_cose_recipient_dec_hpke.o \
-	src/t_cose_recipient_enc_hpke.o \
-	src/hpke.o
+        src/t_cose_encrypt_enc.o \
+        src/t_cose_encrypt_dec.o \
+        src/t_cose_recipient_dec_aes_kw.o \
+        src/t_cose_recipient_enc_aes_kw.o \
+        src/t_cose_recipient_dec_hpke.o \
+        src/t_cose_recipient_enc_hpke.o \
+        src/hpke.o
 
 .PHONY: all install install_headers install_so uninstall clean warn
 

--- a/Makefile.psa
+++ b/Makefile.psa
@@ -51,7 +51,14 @@ CRYPTO_TEST_OBJ=test/t_cose_make_psa_test_key.o
 
 
 # ---- compiler configuration -----
-# Optimize for size
+# This makefile uses a minimum of compiler flags so that it will
+# work out-of-the-box with a wide variety of compilers.  For example,
+# some compilers error out on some of the warnings flags gcc supports.
+# The $(CMD_LINE) variable allows passing in extra flags. This is
+# used on the stringent build script that is in
+# https://github.com/laurencelundblade/tdv.  This script is used
+# before pushes to master (though not yet through an automated build
+# process). See "warn:" below.
 C_OPTS=-Os -fPIC
 
 
@@ -99,12 +106,18 @@ SRC_OBJ=src/t_cose_util.o \
         src/t_cose_recipient_enc_hpke.o \
         src/hpke.o
 
-.PHONY: all install install_headers install_so uninstall clean
+.PHONY: all install install_headers install_so uninstall clean warn
 
 all: libt_cose.a t_cose_test t_cose_basic_example_psa t_cose_encryption_example_psa
 
 libt_cose.a: $(SRC_OBJ) $(CRYPTO_OBJ)
 	ar -r $@ $^
+
+# run "make warn" as a handy way to compile with the warning flags
+# used in the QCBOR release process. See CFLAGS above.
+warn:
+	make -f Makefile.psa CMD_LINE="-Wall -Wextra -Wpedantic -Wshadow -Wconversion -Wcast-qual"
+
 
 # The shared library is not made by default because of platform
 # variability For example MacOS and Linux behave differently and some

--- a/Makefile.test
+++ b/Makefile.test
@@ -33,7 +33,14 @@ CRYPTO_TEST_OBJ=
 
 
 # ---- compiler configuration -----
-# Optimize for size
+# This makefile uses a minimum of compiler flags so that it will
+# work out-of-the-box with a wide variety of compilers.  For example,
+# some compilers error out on some of the warnings flags gcc supports.
+# The $(CMD_LINE) variable allows passing in extra flags. This is
+# used on the stringent build script that is in
+# https://github.com/laurencelundblade/tdv.  This script is used
+# before pushes to master (though not yet through an automated build
+# process). See "warn:" below.
 C_OPTS=-Os -fPIC
 
 
@@ -61,13 +68,18 @@ SRC_OBJ=src/t_cose_sign1_verify.o \
 	src/t_cose_mac_validate.o \
         src/hpke.o
 
-.PHONY: all clean
+.PHONY: all clean warn
 
 all: libt_cose.a t_cose_test
 
 
 libt_cose.a: $(SRC_OBJ) $(CRYPTO_OBJ)
 	ar -r $@ $^
+
+# run "make warn" as a handy way to compile with the warning flags
+# used in the QCBOR release process. See CFLAGS above.
+warn:
+	make -f Makefile.test CMD_LINE="-Wall -Wextra -Wpedantic -Wshadow -Wconversion -Wcast-qual"
 
 libt_cose.so: $(SRC_OBJ) $(CRYPTO_OBJ)
 	cc $^ $(CFLAGS) -dead_strip -o $@ -shared $(QCBOR_LIB) $(CRYPTO_LIB)

--- a/crypto_adapters/t_cose_openssl_crypto.c
+++ b/crypto_adapters/t_cose_openssl_crypto.c
@@ -1159,6 +1159,29 @@ Done:
 #endif /* T_COSE_DISABLE_EDDSA */
 
 
+/*
+ * See documentation in t_cose_crypto.h
+ */
+enum t_cose_err_t
+t_cose_crypto_get_random(struct q_useful_buf    buffer,
+                         size_t                 number,
+                         struct q_useful_buf_c *random)
+{
+    if (number > buffer.len) {
+        return(T_COSE_ERR_TOO_SMALL);
+    }
+
+    // TODO: make this actually get random bytes!
+
+    /* In test mode this just fills a buffer with 'x' */
+    memset(buffer.ptr, 'x', number);
+
+    random->ptr = buffer.ptr;
+    random->len = number;
+
+    return T_COSE_SUCCESS;
+}
+
 
 /*
  * See documentation in t_cose_crypto.h
@@ -1174,6 +1197,33 @@ t_cose_crypto_make_symmetric_key_handle(int32_t               cose_algorithm_id,
 
     return T_COSE_SUCCESS;
 }
+
+
+
+/*
+ * See documentation in t_cose_crypto.h
+ */
+enum t_cose_err_t
+t_cose_crypto_export_key(struct t_cose_key      key,
+                         struct q_useful_buf    key_buffer,
+                         size_t                *key_len)
+{
+    struct q_useful_buf_c copied_key;
+
+    if(key.crypto_lib  != T_COSE_CRYPTO_LIB_OPENSSL) {
+        return 1; // TODO: error code
+    }
+
+    copied_key = q_useful_buf_copy(key_buffer, key.k.key_buffer);
+    if(q_useful_buf_c_is_null(copied_key)) {
+        return 1;
+    }
+
+    *key_len = copied_key.len;
+
+    return T_COSE_SUCCESS;
+}
+
 
 
 /* Compute size of ciphertext, given size of plaintext. Returns

--- a/crypto_adapters/t_cose_openssl_crypto.c
+++ b/crypto_adapters/t_cose_openssl_crypto.c
@@ -1247,12 +1247,12 @@ t_cose_crypto_export_symmetric_key(struct t_cose_key      key,
                                    struct q_useful_buf_c *exported_key)
 {
     if(key.crypto_lib  != T_COSE_CRYPTO_LIB_OPENSSL) {
-        return 1; // TODO: error code
+        return T_COSE_ERR_INCORRECT_KEY_FOR_LIB;
     }
 
     *exported_key = q_useful_buf_copy(key_buffer, key.k.key_buffer);
     if(q_useful_buf_c_is_null(*exported_key)) {
-        return 1;
+        return T_COSE_ERR_TOO_SMALL;
     }
 
     return T_COSE_SUCCESS;

--- a/crypto_adapters/t_cose_test_crypto.c
+++ b/crypto_adapters/t_cose_test_crypto.c
@@ -536,7 +536,7 @@ static const uint8_t rfc_3394_key_wrap_iv[] = {0xa6, 0xa6, 0xa6, 0xa6, 0xa6, 0xa
 
 enum t_cose_err_t
 t_cose_crypto_kw_wrap(int32_t                 cose_algorithm_id,
-                      struct q_useful_buf_c   kek,
+                      struct t_cose_key   kek,
                       struct q_useful_buf_c   plaintext,
                       struct q_useful_buf     ciphertext_buffer,
                       struct q_useful_buf_c  *ciphertext_result)
@@ -561,7 +561,7 @@ t_cose_crypto_kw_wrap(int32_t                 cose_algorithm_id,
 
 enum t_cose_err_t
 t_cose_crypto_kw_unwrap(int32_t                 cose_algorithm_id,
-                        struct q_useful_buf_c   kek,
+                        struct t_cose_key   kek,
                         struct q_useful_buf_c   ciphertext,
                         struct q_useful_buf     plaintext_buffer,
                         struct q_useful_buf_c  *plaintext_result)

--- a/examples/encryption_examples_ossl.c
+++ b/examples/encryption_examples_ossl.c
@@ -9,6 +9,7 @@
  */
 
 #include "encryption_examples_ossl.h"
+#include <stdio.h>
 
 
 #include "t_cose/t_cose_encrypt_enc.h"

--- a/examples/encryption_examples_ossl.c
+++ b/examples/encryption_examples_ossl.c
@@ -1,10 +1,12 @@
-//
-//  encryption_examples_ossl.c
-//  t_cose_basic_example_openssl
-//
-//  Created by Laurence Lundblade on 1/20/23.
-//  Copyright © 2023 Laurence Lundblade. All rights reserved.
-//
+/*
+ *  encryption_examples_ossl.c
+ *
+ * Copyright 2023, Laurence Lundblade
+ * Created by Laurence Lundblade on 1/20/23.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ */
 
 #include "encryption_examples_ossl.h"
 
@@ -38,7 +40,7 @@ make_ossl_symmetric_key_handle(int32_t               cose_algorithm_id,
 void
 direct_detached_example()
 {
-    struct t_cose_encrypt_enc_ctx  enc_context;
+    struct t_cose_encrypt_enc  enc_context;
     enum t_cose_err_t              err;
     struct t_cose_key              cek;
     struct q_useful_buf_c          encrypted_cose_message;
@@ -129,7 +131,7 @@ direct_detached_example()
 void key_wrap_example()
 {
     struct t_cose_recipient_enc_keywrap kw_recipient;
-    struct t_cose_encrypt_enc_ctx       enc_context;
+    struct t_cose_encrypt_enc       enc_context;
     enum t_cose_err_t                   err;
     struct t_cose_key                   kek;
     struct q_useful_buf_c               encrypted_cose_message;

--- a/examples/encryption_examples_ossl.c
+++ b/examples/encryption_examples_ossl.c
@@ -111,8 +111,8 @@ direct_detached_example()
     t_cose_encrypt_dec_set_private_key(&dec_ctx, cek, NULL_Q_USEFUL_BUF_C);
 
     err = t_cose_encrypt_dec(&dec_ctx,
-                             encrypted_cose_message.ptr, encrypted_cose_message.len,
-                             encrypted_payload.ptr, encrypted_payload.len,
+                             (uint8_t *)(uintptr_t)encrypted_cose_message.ptr, encrypted_cose_message.len,
+                             (uint8_t *)(uintptr_t)encrypted_payload.ptr, encrypted_payload.len,
                              decrypted_payload_buf.ptr, decrypted_payload_buf.len,
                              &decrypted_cose_message);
 
@@ -125,7 +125,7 @@ direct_detached_example()
     print_bytestr(decrypted_cose_message.ptr, decrypted_cose_message.len);
 }
 
-#include "t_cose_recipient_enc_aes_kw.h"
+#include "t_cose/t_cose_recipient_enc_aes_kw.h"
 void key_wrap_example()
 {
     struct t_cose_recipient_enc_keywrap kw_recipient;

--- a/examples/encryption_examples_ossl.c
+++ b/examples/encryption_examples_ossl.c
@@ -1,0 +1,213 @@
+//
+//  encryption_examples_ossl.c
+//  t_cose_basic_example_openssl
+//
+//  Created by Laurence Lundblade on 1/20/23.
+//  Copyright © 2023 Laurence Lundblade. All rights reserved.
+//
+
+#include "encryption_examples_ossl.h"
+
+
+#include "t_cose/t_cose_encrypt_enc.h"
+#include "t_cose/t_cose_encrypt_dec.h"
+
+// TODO: switch to a common general purpose version of this.
+static void print_bytestr(const uint8_t *bytes, size_t len)
+{
+    for(unsigned int idx = 0; idx<len; idx++)
+    {
+        printf("%02X",bytes[idx]);
+    }
+}
+
+
+static enum t_cose_err_t
+make_ossl_symmetric_key_handle(int32_t               cose_algorithm_id,
+                               struct q_useful_buf_c symmetric_key,
+                               struct t_cose_key    *key_handle)
+{
+    (void)cose_algorithm_id; // TODO: maybe check the algorithm is symmetric
+    key_handle->crypto_lib   = T_COSE_CRYPTO_LIB_OPENSSL;
+    key_handle->k.key_buffer = symmetric_key;
+
+    return T_COSE_SUCCESS;
+}
+
+
+void
+direct_detached_example()
+{
+    struct t_cose_encrypt_enc_ctx  enc_context;
+    enum t_cose_err_t              err;
+    struct t_cose_key              cek;
+    struct q_useful_buf_c          encrypted_cose_message;
+    struct q_useful_buf_c          decrypted_cose_message;
+    struct q_useful_buf_c          encrypted_payload;
+    Q_USEFUL_BUF_MAKE_STACK_UB(    cose_message_buf, 1024);
+    Q_USEFUL_BUF_MAKE_STACK_UB(    encrypted_payload_buf, 1024);
+    Q_USEFUL_BUF_MAKE_STACK_UB(    decrypted_payload_buf, 1024);
+    struct t_cose_encrypt_dec_ctx  dec_ctx;
+
+    printf("\n-- 3a. Create COSE_Encrypt0 with detached payload (direct encryption) --\n\n");
+    /* This is the simplest form of COSE encryption, a COSE_Encrypt0.
+     * It has only headers and the ciphertext.
+     *
+     * Further in this example, the ciphertext is detached, so the
+     * COSE_Encrypt0 only consists of the protected and unprotected
+     * headers and a CBOR NULL where the ciphertext usually
+     * occurs. The ciphertext is output separatly and conveyed
+     * separately.
+     *
+     */
+    t_cose_encrypt_enc_init(&enc_context,
+                            T_COSE_OPT_COSE_ENCRYPT0 | T_COSE_OPT_COSE_ENCRYPT_DETACHED,
+                            T_COSE_ALGORITHM_A128GCM);
+
+    /* In direct encryption, we simply make a t_cose_key for the
+     * content encryption key, the CEK, and give it to t_cose.  It's
+     * the only key there is and it is simply a key to be used with
+     * AES, a string of bytes. (It is still t_cose_key, not a byte string
+     * so it can be a PSA key handle so it can be used with with
+     * an encryption implementation that doesn't allow the key to
+     * leave a protected domain, an HSM for example).
+     *
+     * There is no COSE_Recipient so t_cose_encrypt_add_recipient() is
+     * not called.
+     *
+     * Direct encryption is always a COSE_Encrypt0 and a COSE_Encrypt0
+     * is always direct encryption.
+     *
+     * The encryption key is conveyed separately.
+     *
+     * No kid is provided in line with the examples of Encrypt0
+     * in RFC 9052. RFC 9052 text describing Encrypt0 also implies that
+     * no kid should be needed, but it doesn't seem to prohibit
+     * the kid header and t_cose will allow it to be present.
+     */
+    make_ossl_symmetric_key_handle(T_COSE_ALGORITHM_A128GCM,
+                                   Q_USEFUL_BUF_FROM_SZ_LITERAL("aaaaaaaaaaaaaaaa"),
+                                  &cek);
+    t_cose_encrypt_set_key(&enc_context, cek, NULL_Q_USEFUL_BUF_C);
+
+    err = t_cose_encrypt_enc(&enc_context,
+                              Q_USEFUL_BUF_FROM_SZ_LITERAL("This is a real plaintext."),
+                              encrypted_payload_buf,
+                             &encrypted_payload,
+                              cose_message_buf,
+                             &encrypted_cose_message);
+
+
+    printf("COSE: ");
+    print_bytestr(encrypted_cose_message.ptr, encrypted_cose_message.len);
+    printf("\n\nCiphertext: ");
+    print_bytestr(encrypted_payload.ptr, encrypted_payload.len);
+    printf("\n");
+
+    printf("\n-- 3b. Process COSE_Encrypt0 with detached payload (direct encryption) --\n\n");
+
+    t_cose_encrypt_dec_init(&dec_ctx, 0, T_COSE_KEY_DISTRIBUTION_DIRECT);
+
+    t_cose_encrypt_dec_set_private_key(&dec_ctx, cek, NULL_Q_USEFUL_BUF_C);
+
+    err = t_cose_encrypt_dec(&dec_ctx,
+                             encrypted_cose_message.ptr, encrypted_cose_message.len,
+                             encrypted_payload.ptr, encrypted_payload.len,
+                             decrypted_payload_buf.ptr, decrypted_payload_buf.len,
+                             &decrypted_cose_message);
+
+    if (err != T_COSE_SUCCESS) {
+        printf("\nDecryption failed!\n");
+        return;
+    }
+
+    printf("\nPlaintext: ");
+    print_bytestr(decrypted_cose_message.ptr, decrypted_cose_message.len);
+}
+
+#include "t_cose_recipient_enc_aes_kw.h"
+void key_wrap_example()
+{
+    struct t_cose_recipient_enc_keywrap kw_recipient;
+    struct t_cose_encrypt_enc_ctx       enc_context;
+    enum t_cose_err_t                   err;
+    struct t_cose_key                   kek;
+    struct q_useful_buf_c               encrypted_cose_message;
+    struct q_useful_buf_c               encrypted_payload;
+    Q_USEFUL_BUF_MAKE_STACK_UB(         cose_message_buf, 1024);
+    Q_USEFUL_BUF_MAKE_STACK_UB(         encrypted_payload_buf, 1024);
+
+
+    printf("\n-- 4a. Create COSE_Encrypt with detached payload using AES-KW --\n\n");
+
+
+    /* ---- Make key handle for wrapping key -----
+     *
+     * The wrapping key, the KEK, is just the bytes "aaaa....".  The
+     * API requires input keys be struct t_cose_key so there's a
+     * little work to do.
+     */
+    // TODO: should th algorithm ID be T_COSE_ALGORITHM_A128KW?
+    make_ossl_symmetric_key_handle(T_COSE_ALGORITHM_A128GCM,
+                                  Q_USEFUL_BUF_FROM_SZ_LITERAL("aaaaaaaaaaaaaaaa"),
+                                  &kek);
+
+    /* ---- Set up keywrap recipient object ----
+     *
+     * The initializes an object of type struct
+     * t_cose_recipient_enc_keywrap, the object/context for making a
+     * COSE_Recipient for key wrap.
+     *
+     * We have to tell it the key wrap algorithm and give it the key
+     * and kid.
+     *
+     * This object gets handed to the main encryption API which will
+     * excersize it through a callback to create the COSE_Recipient.
+     */
+    t_cose_recipient_enc_keywrap_init(&kw_recipient, T_COSE_ALGORITHM_A128KW);
+    t_cose_recipient_enc_keywrap_set_key(&kw_recipient,
+                                          kek,
+                                          Q_USEFUL_BUF_FROM_SZ_LITERAL("Kid A"));
+
+    /* ----- Set up to make COSE_Encrypt ----
+     *
+     * Initialize. Have to say what algorithm is used to encrypt the
+     * main content, the payload.
+     *
+     * Also tell the encryptor about the object to make the key wrap
+     * COSE_Recipient by just giving it the pointer to it. It will get
+     * called back in the next step.
+     */
+    t_cose_encrypt_enc_init(&enc_context, 0, T_COSE_ALGORITHM_A128GCM);
+    t_cose_encrypt_add_recipient(&enc_context, (struct t_cose_recipient_enc *)&kw_recipient);
+
+
+    /* ---- Actually Encrypt ----
+     *
+     * All the crypto gets called here including the encryption of the
+     * payload and the key wrap.
+     *
+     * There are two buffers given, one for just the encrypted
+     * payload and one for the COSE message. TODO: detached vs not and sizing.
+     */
+    err = t_cose_encrypt_enc(&enc_context,
+                              Q_USEFUL_BUF_FROM_SZ_LITERAL("This is a real plaintext."),
+                              encrypted_payload_buf,
+                             &encrypted_payload,
+                              cose_message_buf,
+                             &encrypted_cose_message);
+
+
+    if (err != 0) {
+        printf("\nEncryption failed!\n");
+        return;
+    }
+
+    printf("COSE: ");
+    print_bytestr(encrypted_cose_message.ptr, encrypted_cose_message.len);
+    printf("\n\nCiphertext: ");
+    print_bytestr(encrypted_payload.ptr, encrypted_payload.len);
+    printf("\n");
+
+    return;
+}

--- a/examples/encryption_examples_ossl.h
+++ b/examples/encryption_examples_ossl.h
@@ -1,0 +1,16 @@
+//
+//  encryption_examples_ossl.h
+//  t_cose_basic_example_openssl
+//
+//  Created by Laurence Lundblade on 1/20/23.
+//  Copyright © 2023 Laurence Lundblade. All rights reserved.
+//
+
+#ifndef encryption_examples_ossl_h
+#define encryption_examples_ossl_h
+
+void direct_detached_example(void);
+
+void key_wrap_example(void);
+
+#endif /* encryption_examples_ossl_h */

--- a/examples/encryption_examples_ossl.h
+++ b/examples/encryption_examples_ossl.h
@@ -1,10 +1,13 @@
-//
-//  encryption_examples_ossl.h
-//  t_cose_basic_example_openssl
-//
-//  Created by Laurence Lundblade on 1/20/23.
-//  Copyright © 2023 Laurence Lundblade. All rights reserved.
-//
+/*
+ *  encryption_examples_ossl.h
+ *
+ * Copyright 2023, Laurence Lundblade
+ * Created by Laurence Lundblade on 1/20/23.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ */
+
 
 #ifndef encryption_examples_ossl_h
 #define encryption_examples_ossl_h

--- a/examples/t_cose_basic_example_ossl.c
+++ b/examples/t_cose_basic_example_ossl.c
@@ -28,6 +28,8 @@
 #include "t_cose/t_cose_sign1_verify.h"
 #include "t_cose/q_useful_buf.h"
 
+#include "encryption_examples_ossl.h"
+
 #include <stdio.h>
 
 #include "openssl/ecdsa.h"
@@ -731,4 +733,8 @@ int main(int argc, const char * argv[])
     one_step_sign_example();
     two_step_sign_example();
     aux_buffer_example();
+
+    direct_detached_example();
+
+    key_wrap_example();
 }

--- a/examples/t_cose_encryption_example_psa.c
+++ b/examples/t_cose_encryption_example_psa.c
@@ -244,7 +244,7 @@ int test_cose_encrypt(uint32_t options,
 
 
 #include "t_cose/t_cose_recipient_enc_aes_kw.h"
-static int key_wrap_example()
+static int key_wrap_example(void)
 {
     struct t_cose_recipient_enc_keywrap kw_recipient;
     struct t_cose_encrypt_enc       enc_context;
@@ -334,7 +334,7 @@ static int key_wrap_example()
 
 
 static void
-direct_detached_example()
+direct_detached_example(void)
 {
     struct t_cose_encrypt_enc  enc_context;
     enum t_cose_err_t              err;
@@ -448,7 +448,8 @@ int main(void)
     struct q_useful_buf_c plain_text_ubc;
 
     /* Key id for PSK */
-    struct q_useful_buf_c kid1 = {psk_kid, psk_kid_len};
+    // TODO: sort out which kid for PSK
+    //struct q_useful_buf_c kid1 = {psk_kid, psk_kid_len};
     /* Key id for public key */
     /* Key id for PSK 2 */
 

--- a/examples/t_cose_encryption_example_psa.c
+++ b/examples/t_cose_encryption_example_psa.c
@@ -2,6 +2,7 @@
  *  t_cose_encryption_example_psa.c
  *
  * Copyright (c) 2022, Arm Limited. All rights reserved.
+ * Copyright 2023, Laurence Lundblade
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *
@@ -169,7 +170,7 @@ int test_cose_encrypt(uint32_t options,
                       struct q_useful_buf_c kid
                      )
 {
-    struct t_cose_encrypt_enc_ctx enc_ctx;
+    struct t_cose_encrypt_enc enc_ctx;
     enum t_cose_err_t result;
     struct q_useful_buf_c encrypted_firmware_final;
     struct t_cose_recipient_enc_hpke recipient;
@@ -246,7 +247,7 @@ int test_cose_encrypt(uint32_t options,
 static int key_wrap_example()
 {
     struct t_cose_recipient_enc_keywrap kw_recipient;
-    struct t_cose_encrypt_enc_ctx       enc_context;
+    struct t_cose_encrypt_enc       enc_context;
     enum t_cose_err_t                   err;
     struct t_cose_key                   kek;
     struct q_useful_buf_c               encrypted_cose_message;
@@ -335,7 +336,7 @@ static int key_wrap_example()
 static void
 direct_detached_example()
 {
-    struct t_cose_encrypt_enc_ctx  enc_context;
+    struct t_cose_encrypt_enc  enc_context;
     enum t_cose_err_t              err;
     struct t_cose_key              cek;
     struct q_useful_buf_c          encrypted_cose_message;

--- a/examples/t_cose_encryption_example_psa.c
+++ b/examples/t_cose_encryption_example_psa.c
@@ -242,7 +242,7 @@ int test_cose_encrypt(uint32_t options,
 }
 
 
-#include "t_cose_recipient_enc_aes_kw.h"
+#include "t_cose/t_cose_recipient_enc_aes_kw.h"
 static int key_wrap_example()
 {
     struct t_cose_recipient_enc_keywrap kw_recipient;
@@ -407,9 +407,10 @@ direct_detached_example()
 
     t_cose_encrypt_dec_set_private_key(&dec_ctx, cek, NULL_Q_USEFUL_BUF_C);
 
+    // TODO: fix this cast to non-const
     err = t_cose_encrypt_dec(&dec_ctx,
-                             encrypted_cose_message.ptr, encrypted_cose_message.len,
-                             encrypted_payload.ptr, encrypted_payload.len,
+                             (uint8_t *)(uintptr_t)encrypted_cose_message.ptr, encrypted_cose_message.len,
+                             (uint8_t *)(uintptr_t)encrypted_payload.ptr, encrypted_payload.len,
                              decrypted_payload_buf.ptr, decrypted_payload_buf.len,
                              &decrypted_cose_message);
 

--- a/inc/t_cose/t_cose_common.h
+++ b/inc/t_cose/t_cose_common.h
@@ -592,6 +592,10 @@ enum t_cose_err_t {
     T_COSE_ERR_AUXILIARY_BUFFER_SIZE = 65,
 
     T_COSE_ERR_NO_VERIFIERS = 66,
+
+    /* Trying to protect a parameter when not possible, for example,
+     * in an AES Keywrap COSE_Recipient. */
+    T_CODE_ERR_PROTECTED_PARAM_NOT_ALLOWED = 67,
 };
 
 

--- a/inc/t_cose/t_cose_encrypt_enc.h
+++ b/inc/t_cose/t_cose_encrypt_enc.h
@@ -16,7 +16,6 @@
 #include <stdbool.h>
 #include <stdlib.h>
 #include "t_cose_parameters.h"
-#include "t_cose_crypto.h"
 #include "t_cose/t_cose_recipient_enc.h"
 
 #ifdef __cplusplus

--- a/inc/t_cose/t_cose_encrypt_enc.h
+++ b/inc/t_cose/t_cose_encrypt_enc.h
@@ -154,7 +154,7 @@ extern "C" {
  * The caller should allocate it and pass it to the functions here. This
  * is around 76 bytes, so it fits easily on the stack.
  */
-struct t_cose_encrypt_enc_ctx {
+struct t_cose_encrypt_enc {
     /* Private data structure */
     struct q_useful_buf_c               protected_parameters;
     int32_t                             payload_cose_algorithm_id;
@@ -195,9 +195,9 @@ struct t_cose_encrypt_enc_ctx {
  * algorithm).
  */
 void
-t_cose_encypt_enc_init(struct t_cose_encrypt_enc_ctx* context,
-                       uint32_t                       option_flags,
-                       int32_t                        payload_cose_algorithm_id);
+t_cose_encypt_enc_init(struct t_cose_encrypt_enc *context,
+                       uint32_t                   option_flags,
+                       int32_t                    payload_cose_algorithm_id);
 
 
 /**
@@ -214,8 +214,8 @@ t_cose_encypt_enc_init(struct t_cose_encrypt_enc_ctx* context,
  * this is not called.
  */
 void
-t_cose_encrypt_add_recipient(struct t_cose_encrypt_enc_ctx  *context,
-                             struct t_cose_recipient_enc    *recipient);
+t_cose_encrypt_add_recipient(struct t_cose_encrypt_enc    *context,
+                             struct t_cose_recipient_enc  *recipient);
 
 
 
@@ -228,9 +228,9 @@ t_cose_encrypt_add_recipient(struct t_cose_encrypt_enc_ctx  *context,
  * allows it. It is typically NULL here
  */
 static void
-t_cose_encrypt_set_key(struct t_cose_encrypt_enc_ctx *context,
-                       struct t_cose_key              cek,
-                       struct q_useful_buf_c          kid);
+t_cose_encrypt_set_key(struct t_cose_encrypt_enc *context,
+                       struct t_cose_key          cek,
+                       struct q_useful_buf_c      kid);
 
 
 /**
@@ -260,8 +260,8 @@ t_cose_encrypt_set_key(struct t_cose_encrypt_enc_ctx *context,
  * is used are they not called.
  */
 enum t_cose_err_t
-t_cose_encrypt_enc(struct t_cose_encrypt_enc_ctx *context,
-                   struct q_useful_buf_c          payload,
+t_cose_encrypt_enc(struct t_cose_encrypt_enc *context,
+                   struct q_useful_buf_c      payload,
                    struct q_useful_buf            encrypted_payload,
                    struct q_useful_buf_c         *encrypted_payload_final,
                    struct q_useful_buf            out_buf,
@@ -273,22 +273,22 @@ t_cose_encrypt_enc(struct t_cose_encrypt_enc_ctx *context,
 /* ----------------------- Private Implementations --------------------*/
 
 static inline void
-t_cose_encrypt_enc_init(struct t_cose_encrypt_enc_ctx *context,
-                        uint32_t                       option_flags,
-                        int32_t                        payload_cose_algorithm_id
+t_cose_encrypt_enc_init(struct t_cose_encrypt_enc *context,
+                        uint32_t                   option_flags,
+                        int32_t                    payload_cose_algorithm_id
                        )
 {
     memset(context, 0, sizeof(*context));
     context->payload_cose_algorithm_id = payload_cose_algorithm_id;
-    context->option_flags = option_flags;
-    context->recipients = 0;
+    context->option_flags              = option_flags;
+    context->recipients                = 0;
 }
 
 
 static inline void
-t_cose_encrypt_set_key(struct t_cose_encrypt_enc_ctx *context,
-                       struct t_cose_key              cek,
-                       struct q_useful_buf_c          cek_kid)
+t_cose_encrypt_set_key(struct t_cose_encrypt_enc *context,
+                       struct t_cose_key          cek,
+                       struct q_useful_buf_c      cek_kid)
 {
     context->cek     = cek;
     context->cek_kid = cek_kid;

--- a/inc/t_cose/t_cose_encrypt_enc.h
+++ b/inc/t_cose/t_cose_encrypt_enc.h
@@ -156,14 +156,48 @@ extern "C" {
 struct t_cose_encrypt_enc_ctx {
     /* Private data structure */
     struct q_useful_buf_c               protected_parameters;
-    int32_t                             cose_algorithm_id;
+    int32_t                             payload_cose_algorithm_id;
     uint8_t                            *key;
     size_t                              key_len;
     uint32_t                            option_flags;
     struct q_useful_buf_c               kid;
     uint8_t                             recipients;
-    struct t_cose_encrypt_recipient_ctx recipient_ctx;
+    struct t_cose_recipient_enc        *recipients_list;
 };
+
+
+/**
+ * \brief  Initialize to start creating a \c COSE_Encrypt structure.
+ *
+ * \param[in,out] context        The t_cose_encrypt_enc_ctx context.
+ * \param[in] option_flags       One of \c T_COSE_OPT_XXXX.
+ * \param[in] payload_cose_algorithm_id  The algorithm to use for encrypting
+ *                               data, for example
+ *                               \ref COSE_ALGORITHM_A128GCM.
+ *
+ * Initializes the \ref t_cose_encrypt_enc_ctx context. No
+ * \c option_flags are needed and 0 can be passed. A \c cose_algorithm_id
+ * must always be given.
+ *
+ * The algorithm ID space is from
+ * [COSE (RFC8152)](https://tools.ietf.org/html/rfc8152) and the
+ * [IANA COSE Registry](https://www.iana.org/assignments/cose/cose.xhtml).
+ * \ref COSE_ALGORITHM_A128GCM and a few others are defined here for
+ * convenience. The supported algorithms depend on the
+ * cryptographic library that t_cose is integrated with.
+ * The algorithm ID given here is for the bulk encryption of the payload,
+ * typically an AES AEAD algorithm. (Non-recpient HPKE will be an exception
+ * here.)
+ *
+ * The algorithm ID for the COSE_Recipient is set in the particular
+ * t_cose_recipient_enc being used. You can even have serveral with
+ * different algorithms (but there can only be one payload encryption
+ * algorithm).
+ */
+void
+t_cose_encypt_enc_init(struct t_cose_encrypt_enc_ctx*   context,
+                       uint32_t                         option_flags,
+                       int32_t                          payload_cose_algorithm_id);
 
 
 /**
@@ -175,17 +209,10 @@ struct t_cose_encrypt_enc_ctx {
  *         multiple recipients.
  *
  * \param[in] context                  The t_cose_encrypt_enc_ctx context.
- * \param[in] cose_algorithm_id        COSE algorithm id.
- * \param[in] recipient_key            Key used with the recipient.
- * \param[in] kid                      Key identifier.
- *
- * \return This returns one of the error codes defined by \ref t_cose_err_t.
  */
-enum t_cose_err_t
+void
 t_cose_encrypt_add_recipient(struct t_cose_encrypt_enc_ctx*   context,
-                             int32_t                          cose_algorithm_id,
-                             struct t_cose_key                recipient_key,
-                             struct q_useful_buf_c            kid);
+                             struct t_cose_recipient_enc     *recipient);
 
 
 /**
@@ -217,34 +244,18 @@ t_cose_encrypt_enc(struct t_cose_encrypt_enc_ctx *context,
                    struct q_useful_buf            out_buf,
                    struct q_useful_buf_c         *result);
 
-/**
- * \brief  Initialize to start creating a \c COSE_Encrypt structure.
- *
- * \param[in,out] context        The t_cose_encrypt_enc_ctx context.
- * \param[in] option_flags       One of \c T_COSE_OPT_XXXX.
- * \param[in] cose_algorithm_id  The algorithm to use for encrypting
- *                               data, for example
- *                               \ref COSE_ALGORITHM_A128GCM.
- *
- * Initializes the \ref t_cose_encrypt_enc_ctx context. No
- * \c option_flags are needed and 0 can be passed. A \c cose_algorithm_id
- * must always be given.
- *
- * The algorithm ID space is from
- * [COSE (RFC8152)](https://tools.ietf.org/html/rfc8152) and the
- * [IANA COSE Registry](https://www.iana.org/assignments/cose/cose.xhtml).
- * \ref COSE_ALGORITHM_A128GCM and a few others are defined here for
- * convenience. The supported algorithms depend on the
- * cryptographic library that t_cose is integrated with.
- */
+
+
+/* ----------------------- Private Implementations --------------------*/
+
 static inline void
-t_cose_encrypt_enc_init( struct t_cose_encrypt_enc_ctx *context,
-                         uint32_t                       option_flags,
-                         int32_t                        cose_algorithm_id
+t_cose_encrypt_enc_init(struct t_cose_encrypt_enc_ctx *context,
+                        uint32_t                       option_flags,
+                        int32_t                        payload_cose_algorithm_id
                        )
 {
     memset(context, 0, sizeof(*context));
-    context->cose_algorithm_id = cose_algorithm_id;
+    context->payload_cose_algorithm_id = payload_cose_algorithm_id;
     context->option_flags = option_flags;
     context->recipients = 0;
 }

--- a/inc/t_cose/t_cose_recipient_enc.h
+++ b/inc/t_cose/t_cose_recipient_enc.h
@@ -14,6 +14,7 @@
 #define t_cose_recipient_enc_h
 
 #include "qcbor/qcbor_encode.h"
+#include "t_cose/t_cose_common.h"
 
 
 /* This is an "abstract base class" for all creators of COSE_Recipients

--- a/inc/t_cose/t_cose_recipient_enc.h
+++ b/inc/t_cose/t_cose_recipient_enc.h
@@ -16,28 +16,49 @@
 #include "t_cose_parameters.h"
 #include "t_cose_crypto.h"
 
+struct t_cose_recipient_enc;
+
+
+/**
+ * \brief Creating a COSE recipient for use with AES Key Wrap.
+ *
+ * \param[in] context                COSE context for use with AES-KW
+ * \param[in] cose_algorithm_id      Algorithm id
+ * \param[in] recipient_key          Recipient key (symmetric key, KEK)
+ * \param[in] plaintext              Plaintext (typically the CEK)
+ * \param[out] encrypt_ctx           Resulting encryption structure
+ *
+ * \retval T_COSE_SUCCESS
+ *         Operation was successful.
+ * \retval Error messages otherwise.
+ */
+
 /**
  * \brief Function pointer for use with different key agreement / key transport
  *        schemes used within the recipient structure of COSE_Encrypt.
  *
  * \param[in] ...TBD...
  *
- * \return \return The \ref t_cose_err_t.
+ * \return The \ref t_cose_err_t.
  */
 
-typedef enum t_cose_err_t t_cose_create_recipient(
-                           void                                *context,
-                           int32_t                              cose_algorithm_id,
-                           struct t_cose_key                    recipient_key,
-                           struct q_useful_buf_c                plaintext,
-                           QCBOREncodeContext                  *encrypt_ctx);
+typedef enum t_cose_err_t
+t_cose_create_recipient(struct t_cose_recipient_enc  *me,
+                        struct t_cose_key             recipient_key,
+                        struct q_useful_buf_c         cek,
+                        QCBOREncodeContext           *cbor_encoder);
+
 
 /**
  * This is the context for storing a recipient structure for use with
  * HPKE and AES-KW. The caller should allocate it.
  * The size of this structure is around 56 bytes.
  */
-struct t_cose_encrypt_recipient_ctx {
+struct t_cose_recipient_enc {
+    t_cose_create_recipient *creat_cb;
+    struct t_cose_recipient_enc *next_in_list;
+    
+    
     /* Private data structure */
     int32_t                   cose_algorithm_id;
     struct q_useful_buf_c     kid;

--- a/inc/t_cose/t_cose_recipient_enc_aes_kw.h
+++ b/inc/t_cose/t_cose_recipient_enc_aes_kw.h
@@ -16,7 +16,6 @@
 #include <stdbool.h>
 #include <stdlib.h>
 #include "t_cose_parameters.h"
-#include "t_cose_crypto.h"
 #include "t_cose/t_cose_recipient_enc.h"
 
 #ifdef __cplusplus

--- a/inc/t_cose/t_cose_recipient_enc_aes_kw.h
+++ b/inc/t_cose/t_cose_recipient_enc_aes_kw.h
@@ -16,30 +16,35 @@
 #include <stdlib.h>
 #include "t_cose_parameters.h"
 #include "t_cose_crypto.h"
+#include "t_cose/t_cose_recipient_enc.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-/**
- * \brief Creating a COSE recipient for use with AES Key Wrap.
- *
- * \param[in] context                COSE context for use with AES-KW
- * \param[in] cose_algorithm_id      Algorithm id
- * \param[in] recipient_key          Recipient key (symmetric key, KEK)
- * \param[in] plaintext              Plaintext (typically the CEK)
- * \param[out] encrypt_ctx           Resulting encryption structure
- *
- * \retval T_COSE_SUCCESS
- *         Operation was successful.
- * \retval Error messages otherwise.
- */
-enum t_cose_err_t t_cose_create_recipient_aes_kw(
-                           void                                *context,
-                           int32_t                              cose_algorithm_id,
-                           struct t_cose_key                    recipient_key,
-                           struct q_useful_buf_c                plaintext,
-                           QCBOREncodeContext                  *encrypt_ctx);
+
+struct t_cose_recipient_enc_keywrap {
+    struct t_cose_recipient_enc e;
+
+    int32_t cose_algorithm_id;
+    struct t_cose_key wrapping_key;
+    struct q_useful_buf_c kid;
+};
+
+
+
+
+
+enum t_cose_err_t
+t_cose_recipient_enc_keywrap_init(struct t_cose_recipient_enc_keywrap *me,
+                                  int32_t                              cose_algoroithm_id);
+
+
+enum t_cose_err_t
+t_cose_recipient_enc_keywrap_set_recipient_key(struct t_cose_recipient_enc_keywrap *me,
+                                               struct t_cose_key wrapping_key,
+                                               struct q_useful_buf_c kid);
+
 
 #ifdef __cplusplus
 }

--- a/inc/t_cose/t_cose_recipient_enc_hpke.h
+++ b/inc/t_cose/t_cose_recipient_enc_hpke.h
@@ -25,7 +25,7 @@ struct t_cose_recipient_enc_hpke {
     /* Private data structure */
 
     /* t_cose_recipient_enc must be the first item for the polymorphism to
-      * work.  This structure, t_cose_recipient_enc_keywrap, will sometimes be
+      * work.  This structure, t_cose_recipient_enc_hpke, will sometimes be
       * uses as a t_cose_recipient_enc.
       */
     struct t_cose_recipient_enc e;
@@ -52,7 +52,7 @@ struct t_cose_recipient_enc_hpke {
  * called and the error code will be returned there.
  */
 static void
-t_cose_recipient_enc_hpke_init(struct t_cose_recipient_enc_hpke *me,
+t_cose_recipient_enc_hpke_init(struct t_cose_recipient_enc_hpke *context,
                                int32_t                     cose_algorithm_id);
 
 
@@ -62,7 +62,7 @@ t_cose_recipient_enc_hpke_init(struct t_cose_recipient_enc_hpke *me,
  * The kid is optional and can be NULL
  */
 static void
-t_cose_recipient_enc_hpke_set_key(struct t_cose_recipient_enc_hpke *me,
+t_cose_recipient_enc_hpke_set_key(struct t_cose_recipient_enc_hpke *context,
                                   struct t_cose_key                 recipient,
                                   struct q_useful_buf_c             kid);
 

--- a/inc/t_cose/t_cose_recipient_enc_hpke.h
+++ b/inc/t_cose/t_cose_recipient_enc_hpke.h
@@ -2,6 +2,7 @@
  * t_cose_recipient_enc_hpke.h
  *
  * Copyright (c) 2022, Arm Limited. All rights reserved.
+ * Copyright (c) 2023, Laurence Lundblade. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *
@@ -12,10 +13,8 @@
 #define __T_COSE_RECIPIENT_ENC_HPKE_H__
 
 #include <stdint.h>
-#include <stdbool.h>
 #include <stdlib.h>
 #include "t_cose_parameters.h"
-#include "t_cose_crypto.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -23,6 +22,12 @@ extern "C" {
 
 
 struct t_cose_recipient_enc_hpke {
+    /* Private data structure */
+
+    /* t_cose_recipient_enc must be the first item for the polymorphism to
+      * work.  This structure, t_cose_recipient_enc_keywrap, will sometimes be
+      * uses as a t_cose_recipient_enc.
+      */
     struct t_cose_recipient_enc e;
 
     struct t_cose_key           pkR; /* recipient public key */
@@ -31,37 +36,66 @@ struct t_cose_recipient_enc_hpke {
 };
 
 
-enum t_cose_err_t
+
+/**
+ * @brief Initialize the creator COSE_Recipient for HPKE content key distribution.
+
+ * @param[in]  cose_algorithm_id  The key wrap algorithm ID.
+ *
+ * This must be called not only to set the algorithm ID, but also because
+ * this sets up the callbacks in the t_cose_recipient_enc_keywrap. That is when
+ * all the real work of keywrapping gets done.
+ *
+ * This typically only supports AES key wrap.
+ *
+ * If an unknown algortihm ID is passed, the error will occur when t_cose_encrypt_enc() is
+ * called and the error code will be returned there.
+ */
+static void
 t_cose_recipient_enc_hpke_init(struct t_cose_recipient_enc_hpke *me,
                                int32_t                     cose_algorithm_id);
 
 
-
-void
+/**
+ * @brief Sets the recipient key, pkR
+ *
+ * The kid is optional and can be NULL
+ */
+static void
 t_cose_recipient_enc_hpke_set_key(struct t_cose_recipient_enc_hpke *me,
                                   struct t_cose_key                 recipient,
                                   struct q_useful_buf_c             kid);
 
 
-/**
- * \brief Creating a COSE recipient for use with HPKE.
- *
- * \param[in] context                COSE recipient context for use with HPKE
- * \param[in] cose_algorithm_id      Algorithm id
- * \param[in] recipient_key          Recipient key
- * \param[in] plaintext              Plaintext (typically the CEK)
- * \param[out] encrypt_ctx           Resulting encryption structure
- *
- * \retval T_COSE_SUCCESS
- *         Operation was successful.
- * \retval Error messages otherwise.
- */
-enum t_cose_err_t t_cose_create_recipient_hpke(
-                           void                                *context,
-                           int32_t                              cose_algorithm_id,
-                           struct t_cose_key                    recipient_key,
-                           struct q_useful_buf_c                plaintext,
-                           QCBOREncodeContext                  *encrypt_ctx);
+
+/* =========================================================================
+     BEGINNING OF PRIVATE INLINE IMPLEMENTATION
+   ========================================================================= */
+
+enum t_cose_err_t
+t_cose_recipient_create_hpke_cb_private(struct t_cose_recipient_enc  *me_x,
+                                        struct q_useful_buf_c         cek,
+                                        QCBOREncodeContext           *cbor_encoder);
+
+
+static inline void
+t_cose_recipient_enc_hpke_init(struct t_cose_recipient_enc_hpke *me,
+                               int32_t                           cose_algorithm_id)
+{
+    memset(me, 0, sizeof(*me));
+    me->e.creat_cb = t_cose_recipient_create_hpke_cb_private;
+    me->cose_algorithm_id = cose_algorithm_id;
+}
+
+
+static inline void
+t_cose_recipient_enc_hpke_set_key(struct t_cose_recipient_enc_hpke *me,
+                                  struct t_cose_key                 pkR,
+                                  struct q_useful_buf_c             kid)
+{
+    me->pkR = pkR;
+    me->kid = kid;
+}
 
 #ifdef __cplusplus
 }

--- a/inc/t_cose/t_cose_recipient_enc_hpke.h
+++ b/inc/t_cose/t_cose_recipient_enc_hpke.h
@@ -14,7 +14,8 @@
 
 #include <stdint.h>
 #include <stdlib.h>
-#include "t_cose_parameters.h"
+#include "t_cose/t_cose_parameters.h"
+#include "t_cose/t_cose_common.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/t_cose_crypto.h
+++ b/src/t_cose_crypto.h
@@ -935,7 +935,7 @@ t_cose_crypto_export_symmetric_key(struct t_cose_key      key,
  * encryption key) using another key, the KEK (key encryption
  * key). This key wrap provides both confidentiality and integrity.
  *
- * OIther than AES is faciliated here, but in practice only AES is needed.
+ * OIther than AES is facilitated here, but in practice only AES is needed.
  *
  * Implementations of this must error out on incorrect algorithm IDs. They
  * can't just assume AES and go off the key size. This is so callers of this
@@ -977,7 +977,7 @@ t_cose_crypto_kw_wrap(int32_t                 cose_algorithm_id,
  * encryption key) using another key, the KEK (key encryption
  * key). This key wrap provides both confidentiality and integrity.
  *
- * OIther than AES could work here, but in practice only AES is needed.
+ * OIther than AES is facilitated here, but in practice only AES is needed.
  *
  * Implementations of this must error out on incorrect algorithm IDs. They
  * can't just assume AES and go off the key size. This is so callers of this

--- a/src/t_cose_crypto.h
+++ b/src/t_cose_crypto.h
@@ -884,17 +884,29 @@ t_cose_crypto_export_public_key(struct t_cose_key      key,
  * \param[in] key               Handle to key
  * \param[in] key_buffer        Pointer and length of buffer into which
  *                              the resulting key is put.
- * \param[out] key_len          Length of the returned key.
+ * \param[out] exported_key          Length of the returned key.
  *
  * \retval T_COSE_SUCCESS
  *         Successfully exported the key.
  * \retval T_COSE_ERR_KEY_EXPORT_FAILED
  *         The key export operation failed.
+ *
+ * The t_cose implementation tries to avoid use of this, preferring
+ * to use keys in the form of a struct t_cose_key rather than
+ * have the actual bytes of the key in memory. This allows
+ * crypto adaptors to work with crypto implementations in
+ * HSMs and such that can encrypt/decrypt without the
+ * key being present outside the HSM.
+ *
+ * The one place this is used outside of the PSA crypto layer
+ * is the option that lets the caller set the CEK and the
+ * CEK needs to be given to a key distribtion method.
  */
+// TODO: say how to know the length
 enum t_cose_err_t
-t_cose_crypto_export_key(struct t_cose_key      key,
-                         struct q_useful_buf    key_buffer,
-                         size_t                *key_len);
+t_cose_crypto_export_symmetric_key(struct t_cose_key      key,
+                                   struct q_useful_buf    key_buffer,
+                                   struct q_useful_buf_c *exported_key);
 
 
 /**
@@ -923,17 +935,15 @@ t_cose_crypto_export_key(struct t_cose_key      key,
  * encryption key) using another key, the KEK (key encryption
  * key). This key wrap provides both confidentiality and integrity.
  *
- * OIther than AES could work here, but in practice only AES is needed.
+ * OIther than AES is faciliated here, but in practice only AES is needed.
  *
  * Implementations of this must error out on incorrect algorithm IDs. They
  * can't just assume AES and go off the key size. This is so callers of this
  * can rely on this to check the algorithm ID and not have to check it.
  */
-// TODO: change to a key handle so key doesn't have to be exported even though mbedtls doesn't support this yet?
-// Probably should to accommodate crypto engines that don't allow export, especially important for symmetric keys
 enum t_cose_err_t
 t_cose_crypto_kw_wrap(int32_t                 cose_algorithm_id,
-                      struct q_useful_buf_c   kek,
+                      struct t_cose_key       kek,
                       struct q_useful_buf_c   plaintext,
                       struct q_useful_buf     ciphertext_buffer,
                       struct q_useful_buf_c  *ciphertext_result);
@@ -975,7 +985,7 @@ t_cose_crypto_kw_wrap(int32_t                 cose_algorithm_id,
  */
 enum t_cose_err_t
 t_cose_crypto_kw_unwrap(int32_t                 cose_algorithm_id,
-                        struct q_useful_buf_c   kek,
+                        struct t_cose_key       kek,
                         struct q_useful_buf_c   ciphertext,
                         struct q_useful_buf     plaintext_buffer,
                         struct q_useful_buf_c  *plaintext_result);

--- a/src/t_cose_crypto.h
+++ b/src/t_cose_crypto.h
@@ -911,6 +911,8 @@ t_cose_crypto_export_key(struct t_cose_key      key,
  * \retval T_COSE_ERR_AES_KW_FAILED
  *         AES key wrap operation failed.
  */
+// TODO: change to a key handle so key doesn't have to be exported even though mbedtls doesn't support this yet?
+// Probably should to accommodate crypto engines that don't allow export, especially important for symmetric keys
 enum t_cose_err_t
 t_cose_crypto_aes_kw(int32_t                 algorithm_id,
                      struct q_useful_buf_c   kek,

--- a/src/t_cose_encrypt_enc.c
+++ b/src/t_cose_encrypt_enc.c
@@ -20,7 +20,7 @@
 
 
 enum t_cose_err_t
-t_cose_encrypt_enc(struct t_cose_encrypt_enc_ctx *context,
+t_cose_encrypt_enc(struct t_cose_encrypt_enc *context,
                    struct q_useful_buf_c          payload,
                    struct q_useful_buf            encrypted_payload,
                    struct q_useful_buf_c         *encrypted_payload_final,
@@ -285,8 +285,8 @@ t_cose_encrypt_enc(struct t_cose_encrypt_enc_ctx *context,
 
 
 void
-t_cose_encrypt_add_recipient(struct t_cose_encrypt_enc_ctx*   me,
-                             struct t_cose_recipient_enc     *recipient)
+t_cose_encrypt_add_recipient(struct t_cose_encrypt_enc   *me,
+                             struct t_cose_recipient_enc *recipient)
 {
     if(me->recipients_list == NULL) {
         me->recipients_list = recipient;
@@ -297,7 +297,7 @@ t_cose_encrypt_add_recipient(struct t_cose_encrypt_enc_ctx*   me,
 
 
 void
-t_cose_encypt_enc_init(struct t_cose_encrypt_enc_ctx*   context,
+t_cose_encypt_enc_init(struct t_cose_encrypt_enc*   context,
                        uint32_t                         option_flags,
                        int32_t                          payload_cose_algorithm_id)
 {

--- a/src/t_cose_recipient_enc_aes_kw.c
+++ b/src/t_cose_recipient_enc_aes_kw.c
@@ -2,6 +2,7 @@
  * \file t_cose_recipient_enc_aes_kw.c
  *
  * Copyright (c) 2022, Arm Limited. All rights reserved.
+ * Copyright (c) 2023, Laurence Lundblade. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *
@@ -10,112 +11,60 @@
  */
 
 #include "t_cose/t_cose_recipient_enc_aes_kw.h" /* Interface implemented */
-#include "qcbor/qcbor.h"
+#include "qcbor/qcbor_encode.h"
 #include "t_cose_crypto.h"
-#include <stdint.h>
 #include "t_cose/t_cose_common.h"
 #include "t_cose/q_useful_buf.h"
-#include "t_cose/t_cose_standard_constants.h"
 
 
 #ifndef T_COSE_DISABLE_AES_KW
 
-static enum t_cose_err_t
-recipient_create_keywrap_cb(struct t_cose_recipient_enc  *me_x,
-                            struct q_useful_buf_c   plaintext,
-                            QCBOREncodeContext     *cbor_encoder)
+enum t_cose_err_t
+t_cose_recipient_create_keywrap_cb_private(struct t_cose_recipient_enc  *me_x,
+                                           const struct q_useful_buf_c   plaintext,
+                                           QCBOREncodeContext           *cbor_encoder)
 {
-    UsefulBufC             scratch;
-    enum t_cose_err_t      return_value;
-    enum t_cose_err_t      cose_result;
-    size_t                 recipient_key_len;
-    struct t_cose_recipient_enc_keywrap *context;
+    struct t_cose_recipient_enc_keywrap *me;
+    enum t_cose_err_t                    return_value;
+    struct t_cose_parameter              params[2];
+    struct q_useful_buf                  encrypted_cek_destiation;
+    struct q_useful_buf_c                encrypted_cek_result;
 
-
-    Q_USEFUL_BUF_MAKE_STACK_UB(recipient_key_buf, T_COSE_ENCRYPTION_MAX_KEY_LENGTH);
-    // TODO: make sure this has room for key wrap authentication tag
-    Q_USEFUL_BUF_MAKE_STACK_UB(encrypted_cek, T_COSE_CIPHER_ENCRYPT_OUTPUT_MAX_SIZE(T_COSE_ENCRYPTION_MAX_KEY_LENGTH));
-    struct q_useful_buf_c  recipient_key_result={NULL,0};
-    struct q_useful_buf_c  encrypted_cek_result={NULL,0};
-
-    context=(struct t_cose_recipient_enc_keywrap *) me_x;
-
-
-    cose_result = t_cose_crypto_export_key(
-                                    context->wrapping_key,
-                                    recipient_key_buf,
-                                    &recipient_key_len);
-
-    if (cose_result != T_COSE_SUCCESS) {
-        return(cose_result);
-    }
-
-    recipient_key_result.ptr = recipient_key_buf.ptr;
-    recipient_key_result.len = recipient_key_len;
-
-    /* AES key wrap encryption */
-    return_value = t_cose_crypto_kw_wrap(
-                        0,
-                        recipient_key_result,
-                        plaintext,
-                        encrypted_cek,
-                        &encrypted_cek_result);
-
-    if (return_value != T_COSE_SUCCESS) {
-        return(return_value);
-    }
+    me = (struct t_cose_recipient_enc_keywrap *) me_x;
 
     /* Create recipient array */
     QCBOREncode_OpenArray(cbor_encoder);
 
-    /* Add empty protected map encoded as bstr */
-    QCBOREncode_BstrWrap(cbor_encoder);
-    QCBOREncode_CloseBstrWrap2(cbor_encoder, false, &scratch);
+    /* Output the header parameters */
+    params[0]  = t_cose_make_alg_id_parameter(me->keywrap_cose_algorithm_id);
+    params[0].in_protected = false; /* Override t_cose_make_alg_id_parameter() because there is no protection in AES Keywrap */
+    if(!q_useful_buf_c_is_null(me->kid)) {
+        params[1] = t_cose_make_kid_parameter(me->kid);
+        params[0].next = &params[1];
+    }
+    // TODO: allow custom headers here
+    // TODO: make sure no custom headers are protected because there is no protect with key wrap
+    return_value = t_cose_encode_headers(cbor_encoder, params, NULL);
+    if (return_value != T_COSE_SUCCESS) {
+        goto Done;
+    }
 
-    /* Add unprotected header alg and kid parameters */
-    QCBOREncode_OpenMap(cbor_encoder);
-
-    // TODO: pretty sure algorithm ID has to be a protected parameter
-    QCBOREncode_AddInt64ToMapN(cbor_encoder,
-                               T_COSE_HEADER_PARAM_ALG,
-                               context->cose_algorithm_id);
-
-    QCBOREncode_AddBytesToMapN(cbor_encoder,
-                               T_COSE_HEADER_PARAM_KID,
-                               context->kid);
-
-    /* Close protected header map */
-    QCBOREncode_CloseMap(cbor_encoder);
-
-    /* Add encrypted CEK */
-    QCBOREncode_AddBytes(cbor_encoder, encrypted_cek_result);
+    /* Do the keywrap directly into the output buffer */
+    /* t_cose_crypto_kw_wrap() will catch incorrect algorithm ID errors */
+    QCBOREncode_OpenBytes(cbor_encoder, &encrypted_cek_destiation);
+    return_value = t_cose_crypto_kw_wrap(me->keywrap_cose_algorithm_id,
+                                         me->wrapping_key,
+                                         plaintext,
+                                         encrypted_cek_destiation,
+                                        &encrypted_cek_result);
+    QCBOREncode_CloseBytes(cbor_encoder, encrypted_cek_result.len);
+    /* Error is just returned directly and no need to skip CloseArray */
 
     /* Close recipient array */
     QCBOREncode_CloseArray(cbor_encoder);
 
-    return(T_COSE_SUCCESS);
-}
-
-
-enum t_cose_err_t
-t_cose_recipient_enc_keywrap_init(struct t_cose_recipient_enc_keywrap *me,
-                                  int32_t                              cose_algorithm_id)
-{
-    memset(me, 0, sizeof(*me));
-    me->e.creat_cb = recipient_create_keywrap_cb;
-    me->cose_algorithm_id = cose_algorithm_id;
-
-    return T_COSE_SUCCESS;
-}
-
-
-void
-t_cose_recipient_enc_keywrap_set_key(struct t_cose_recipient_enc_keywrap *me,
-                                     struct t_cose_key wrapping_key,
-                                     struct q_useful_buf_c kid)
-{
-    me->wrapping_key = wrapping_key;
-    me->kid          = kid;
+Done:
+    return return_value;
 }
 
 #else /* T_COSE_DISABLE_AES_KW */

--- a/src/t_cose_recipient_enc_hpke.c
+++ b/src/t_cose_recipient_enc_hpke.c
@@ -2,6 +2,7 @@
  * \file t_cose_recipient_enc_hpke.c
  *
  * Copyright (c) 2022, Arm Limited. All rights reserved.
+ * Copyright (c) 2023, Laurence Lundblade. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *
@@ -313,8 +314,8 @@ t_cose_create_recipient_hpke2(
 }
 
 
-static enum t_cose_err_t
-recipient_create_hpke_cb(struct t_cose_recipient_enc  *me_x,
+enum t_cose_err_t
+t_cose_recipient_create_hpke_cb_private(struct t_cose_recipient_enc  *me_x,
                          struct q_useful_buf_c         cek,
                          QCBOREncodeContext           *cbor_encoder)
 {
@@ -332,25 +333,6 @@ recipient_create_hpke_cb(struct t_cose_recipient_enc  *me_x,
     return err;
 }
 
-
-enum t_cose_err_t
-t_cose_recipient_enc_hpke_init(struct t_cose_recipient_enc_hpke *me,
-                               int32_t cose_algorithm_id)
-{
-    me->e.creat_cb = recipient_create_hpke_cb;
-    me->cose_algorithm_id = cose_algorithm_id;
-    return T_COSE_SUCCESS;
-}
-
-
-void
-t_cose_recipient_enc_hpke_set_key(struct t_cose_recipient_enc_hpke *me,
-                                  struct t_cose_key                 pkR,
-                                  struct q_useful_buf_c             kid)
-{
-    me->pkR = pkR;
-    me->kid = kid;
-}
 
 
 

--- a/t_cose.xcodeproj/project.pbxproj
+++ b/t_cose.xcodeproj/project.pbxproj
@@ -93,6 +93,9 @@
 		E772027C23CAEC84006E966E /* main.c in Sources */ = {isa = PBXBuildFile; fileRef = E7E36E7B226CB8400040613B /* main.c */; };
 		E772027D23CAEC84006E966E /* run_tests.c in Sources */ = {isa = PBXBuildFile; fileRef = E72FB01C231ADAA8000970FE /* run_tests.c */; };
 		E772027E23CAEC84006E966E /* t_cose_sign1_sign.c in Sources */ = {isa = PBXBuildFile; fileRef = E7E36E8E226CB9460040613B /* t_cose_sign1_sign.c */; };
+		E78247EF297AADE1008ED9C8 /* encryption_examples_ossl.c in Sources */ = {isa = PBXBuildFile; fileRef = E78247EE297AADE1008ED9C8 /* encryption_examples_ossl.c */; };
+		E78247F0297AAF2D008ED9C8 /* t_cose_encrypt_enc.c in Sources */ = {isa = PBXBuildFile; fileRef = E77108092917EDA900D8ADF4 /* t_cose_encrypt_enc.c */; };
+		E78247F1297AB428008ED9C8 /* t_cose_recipient_enc_aes_kw.c in Sources */ = {isa = PBXBuildFile; fileRef = E771080C2917EDA900D8ADF4 /* t_cose_recipient_enc_aes_kw.c */; };
 		E7AF703628DADF5E00F07637 /* t_cose_param_test.c in Sources */ = {isa = PBXBuildFile; fileRef = E7AF703528DADF5E00F07637 /* t_cose_param_test.c */; };
 		E7AF703728DADFCF00F07637 /* t_cose_param_test.c in Sources */ = {isa = PBXBuildFile; fileRef = E7AF703528DADF5E00F07637 /* t_cose_param_test.c */; };
 		E7AF703828DADFD000F07637 /* t_cose_param_test.c in Sources */ = {isa = PBXBuildFile; fileRef = E7AF703528DADF5E00F07637 /* t_cose_param_test.c */; };
@@ -330,6 +333,8 @@
 		E77108332918577500D8ADF4 /* t_cose_encryption_example_psa.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = t_cose_encryption_example_psa.c; sourceTree = "<group>"; };
 		E772028523CAEC84006E966E /* t_cose_psa_noss */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = t_cose_psa_noss; sourceTree = BUILT_PRODUCTS_DIR; };
 		E77F343028F979DF0089FC2A /* t_cose_standard_constants.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = t_cose_standard_constants.h; path = t_cose/t_cose_standard_constants.h; sourceTree = "<group>"; };
+		E78247ED297AADE1008ED9C8 /* encryption_examples_ossl.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = encryption_examples_ossl.h; sourceTree = "<group>"; };
+		E78247EE297AADE1008ED9C8 /* encryption_examples_ossl.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = encryption_examples_ossl.c; sourceTree = "<group>"; };
 		E7AF703428DADF5E00F07637 /* t_cose_param_test.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = t_cose_param_test.h; sourceTree = "<group>"; };
 		E7AF703528DADF5E00F07637 /* t_cose_param_test.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = t_cose_param_test.c; sourceTree = "<group>"; };
 		E7C960A527F7569500FB537C /* libqcbor.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libqcbor.a; path = ../../../../../usr/local/lib/libqcbor.a; sourceTree = "<group>"; };
@@ -452,6 +457,8 @@
 				E73BF6F023B07AB200DF5C36 /* t_cose_basic_example_ossl.c */,
 				E73BF6D223AFFA6500DF5C36 /* t_cose_basic_example_psa.c */,
 				E7F1733F2948016800E5ADF3 /* t_cose_encryption_example_psa.h */,
+				E78247ED297AADE1008ED9C8 /* encryption_examples_ossl.h */,
+				E78247EE297AADE1008ED9C8 /* encryption_examples_ossl.c */,
 			);
 			path = examples;
 			sourceTree = "<group>";
@@ -874,11 +881,14 @@
 				E7F17337293B110600E5ADF3 /* t_cose_signature_sign_eddsa.c in Sources */,
 				E73BF70723B07ACF00DF5C36 /* t_cose_sign1_verify.c in Sources */,
 				E7F17334293B110100E5ADF3 /* t_cose_signature_verify_eddsa.c in Sources */,
+				E78247EF297AADE1008ED9C8 /* encryption_examples_ossl.c in Sources */,
 				E7F1733A293ED83100E5ADF3 /* t_cose_basic_example_ossl.c in Sources */,
 				E7FECC4C288754E400420F6F /* t_cose_sign_sign.c in Sources */,
 				E73BF70B23B07ACF00DF5C36 /* t_cose_openssl_crypto.c in Sources */,
+				E78247F0297AAF2D008ED9C8 /* t_cose_encrypt_enc.c in Sources */,
 				E77108302917EDA900D8ADF4 /* t_cose_recipient_enc_hpke.c in Sources */,
 				E7F17331293B10EC00E5ADF3 /* t_cose_signature_verify_main.c in Sources */,
+				E78247F1297AB428008ED9C8 /* t_cose_recipient_enc_aes_kw.c in Sources */,
 				E7F1732E293B10E400E5ADF3 /* t_cose_signature_sign_main.c in Sources */,
 				E73BF70D23B07ACF00DF5C36 /* t_cose_parameters.c in Sources */,
 				E77108242917EDA900D8ADF4 /* t_cose_recipient_dec_hpke.c in Sources */,

--- a/test/t_cose_crypto_test.c
+++ b/test/t_cose_crypto_test.c
@@ -149,8 +149,9 @@ int_fast32_t aead_test(void)
 
 int_fast32_t kw_test(void)
 {
+    struct t_cose_key kek;
     /* These are test vectors from RFC 3394 */
-    const struct q_useful_buf_c kek = Q_USEFUL_BUF_FROM_BYTE_ARRAY_LITERAL(((const uint8_t []){0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F}));
+    const struct q_useful_buf_c kek_x = Q_USEFUL_BUF_FROM_BYTE_ARRAY_LITERAL(((const uint8_t []){0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F}));
     
     const struct q_useful_buf_c key_data = Q_USEFUL_BUF_FROM_BYTE_ARRAY_LITERAL(((const uint8_t []){0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF}));
 
@@ -170,6 +171,13 @@ int_fast32_t kw_test(void)
          * on 2.28, but will fail to run so this exception is needed.
          */
         return 0;
+    }
+
+    e = t_cose_crypto_make_symmetric_key_handle(T_COSE_ALGORITHM_A128GCM,
+                                                kek_x,
+                                               &kek);
+    if(e != T_COSE_SUCCESS) {
+        return 1;
     }
 
     // TODO: test more sizes and algorithms


### PR DESCRIPTION
The public API for COSE_Encrypt and COSE_Encrypt0 now accepts an "object" that implements COSE_Recipient.

This fixes a bug where the layer of CBOR array that holds multiple COSE_Recipients was missing, both for encrypt and decrypt.

This provides some large refactoring of the encryption examples. One reason is because the public API for encryption changed a lot. Another is to make the examples more useful to people that want a clear and simple example of each usage mode of encryption. There is some more work to do to this end.

Make most symmetric key operations take a t_cose_key as input. Eliminate all but one export of t_cose_key into bytes outside of the crypto adaptor layer so t_cose can work better with HSMs.

Key wrap and direct encryption work for OpenSSL!

OpenSSL crypto adaptor returns random numbers.