### PR TITLE
Verification of COSE_Sign with multiple COSE_Signature(s)

### DIFF
--- a/examples/t_cose_basic_example_psa.c
+++ b/examples/t_cose_basic_example_psa.c
@@ -981,7 +981,7 @@ int two_step_sign_example_new_verify(void)
 
     struct t_cose_signature_verify_main verifier;
     t_cose_signature_verify_main_init(&verifier);
-    t_cose_signature_verify_main_set_key(&verifier, key_pair);
+    t_cose_signature_verify_main_set_key(&verifier, key_pair, NULL_Q_USEFUL_BUF_C);
 
     t_cose_sign_add_verifier(&verify_ctx, t_cose_signature_verify_from_main(&verifier));
 

--- a/examples/t_cose_encryption_example_psa.c
+++ b/examples/t_cose_encryption_example_psa.c
@@ -453,7 +453,6 @@ int main(void)
     /* Key id for public key */
     /* Key id for PSK 2 */
 
-    struct t_cose_key t_cose_psk_key;
 
     struct t_cose_key t_cose_pkR_key;
     psa_key_attributes_t pkR_attributes = PSA_KEY_ATTRIBUTES_INIT;
@@ -527,9 +526,6 @@ int main(void)
         printf("Importing key failed\n");
         return(EXIT_FAILURE);
     }
-
-    t_cose_psk_key.k.key_handle = psk_handle;
-    t_cose_psk_key.crypto_lib = T_COSE_CRYPTO_LIB_PSA;
 
 #ifndef T_COSE_DISABLE_HPKE
 

--- a/inc/t_cose/t_cose_common.h
+++ b/inc/t_cose/t_cose_common.h
@@ -599,7 +599,16 @@ enum t_cose_err_t {
 
     /* Trying to protect a parameter when not possible, for example,
      * in an AES Keywrap COSE_Recipient. */
-    T_CODE_ERR_PROTECTED_PARAM_NOT_ALLOWED = 68
+    T_CODE_ERR_PROTECTED_PARAM_NOT_ALLOWED = 68,
+
+    /* No more COSE_Signatures or COSE_Recipients. Returned by
+     * COSE_Signature and COSE_Recipient implementations. */
+    T_COSE_ERR_NO_MORE = 69,
+
+    /* A newer version of QCBOR is needed to processes multiple
+     * COSE_Signature or COSE_Recipients.  (As of Jan 2023, this
+     * QCBOR is not released) */
+    T_COSE_ERR_CANT_PROCESS_MULTIPLE = 70
 };
 
 

--- a/inc/t_cose/t_cose_common.h
+++ b/inc/t_cose/t_cose_common.h
@@ -595,11 +595,11 @@ enum t_cose_err_t {
 
     /* A verifier declined to verify a COSE_Signature for a reason other
      * than algorithm ID or kid. */
-    T_COSE_ERR_DECLINE_TO_VERIFY = 67
+    T_COSE_ERR_DECLINE_TO_VERIFY = 67,
 
     /* Trying to protect a parameter when not possible, for example,
      * in an AES Keywrap COSE_Recipient. */
-    T_CODE_ERR_PROTECTED_PARAM_NOT_ALLOWED = 68,
+    T_CODE_ERR_PROTECTED_PARAM_NOT_ALLOWED = 68
 };
 
 

--- a/inc/t_cose/t_cose_common.h
+++ b/inc/t_cose/t_cose_common.h
@@ -592,6 +592,10 @@ enum t_cose_err_t {
     T_COSE_ERR_AUXILIARY_BUFFER_SIZE = 65,
 
     T_COSE_ERR_NO_VERIFIERS = 66,
+
+    /* A verifier declined to verify a COSE_Signature for a reason other
+     * than algorithm ID or kid. */
+    T_COSE_ERR_DECLINE_TO_VERIFY = 67
 };
 
 
@@ -755,6 +759,41 @@ struct t_cose_sign_inputs {
     struct q_useful_buf_c  sign_protected;
     struct q_useful_buf_c  payload;
 };
+
+
+
+/* This is the base class for all implementations
+ * of COSE_Signature and COSE_Recipient. It implments what
+ * is common to them:
+ *   - The ability to identify the type of one
+ *   - The ability to make a linked list
+ *
+ * The linked list part saves object code because the same
+ * function to add to the linked list is used for all types
+ * of COSE_Recipient and COSE_Signature
+ *
+ * The identification part is to know the type of a concrete
+ * instance to be able to call some special methods it
+ * might implement, particularly for COSE_Signature verifiers
+ * and COSE_Recipient decryptors as the COSE_Sign verifier
+ * and COSE_Encrypt decryptor loops over a set of them.
+ */
+struct t_cose_rs_obj {
+    struct t_cose_rs_obj *next;
+    uint16_t              ident;
+};
+
+
+void
+t_cose_link_rs(struct t_cose_rs_obj **list, struct t_cose_rs_obj *new);
+
+
+/* This is just to make a simple 16 bit unique id for each recipient-signer object */
+#define TYPE_RS_SIGNER 's'
+#define TYPE_RS_VERIFIER 'v'
+#define TYPE_RS_RECIPIENT_CREATOR 'c'
+#define TYPE_RS_RECIPIENT_DECODER 'd'
+#define RS_IDENT(type, id1) (type + (id1 << 8))
 
 
 

--- a/inc/t_cose/t_cose_common.h
+++ b/inc/t_cose/t_cose_common.h
@@ -798,7 +798,7 @@ struct t_cose_rs_obj {
 
 
 void
-t_cose_link_rs(struct t_cose_rs_obj **list, struct t_cose_rs_obj *new);
+t_cose_link_rs(struct t_cose_rs_obj **list, struct t_cose_rs_obj *new_rs);
 
 
 /* This is just to make a simple 16 bit unique id for each recipient-signer object */

--- a/inc/t_cose/t_cose_sign_sign.h
+++ b/inc/t_cose/t_cose_sign_sign.h
@@ -1,7 +1,7 @@
 /*
  * t_cose_sign_sign.h
  *
- * Copyright (c) 2018-2022, Laurence Lundblade. All rights reserved.
+ * Copyright (c) 2018-2023, Laurence Lundblade. All rights reserved.
  * Copyright (c) 2020, Michael Eckel
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/inc/t_cose/t_cose_sign_sign.h
+++ b/inc/t_cose/t_cose_sign_sign.h
@@ -145,7 +145,7 @@ t_cose_sign_sign_init(struct t_cose_sign_sign_ctx *context,
  * t_cose_signature_sign_main. The concrete instance must be
  * configured with a key and algorithm ID before this is called.
  */
-void
+static void
 t_cose_sign_add_signer(struct t_cose_sign_sign_ctx   *context,
                        struct t_cose_signature_sign  *signer);
 
@@ -437,6 +437,14 @@ t_cose_sign_add_body_header_params(struct t_cose_sign_sign_ctx *me,
     me->added_body_parameters = parameters;
 }
 
+
+static inline void
+t_cose_sign_add_signer(struct t_cose_sign_sign_ctx  *context,
+                       struct t_cose_signature_sign *signer)
+{
+    /* Use base class function to add a signer/recipient to the linked list. */
+    t_cose_link_rs((struct t_cose_rs_obj **)&context->signers, (struct t_cose_rs_obj *)signer);
+}
 
 #ifdef __cplusplus
 }

--- a/inc/t_cose/t_cose_sign_verify.h
+++ b/inc/t_cose/t_cose_sign_verify.h
@@ -171,16 +171,16 @@ t_cose_sign_set_param_decoder(struct t_cose_sign_verify_ctx *context,
  *                          or \c COSE_Sign message that is to be verified.
  * \param[in] aad           The Additional Authenticated Data or \c NULL_Q_USEFUL_BUF_C.
  * \param[out] payload      Pointer and length of the payload that is returned. Must not be \c NULL.
- * \param[out] parameters   Place to return parsed parameters. May be \c NULL.
+ * \param[out] parameters   Place to return decoded parameters. May be \c NULL.
  *
  * \return This returns one of the error codes defined by \ref t_cose_err_t.
  *
- * See t_cose_sign1_set_verification_key() for discussion on where
+ * See t_cose_sign_set_verification_key() for discussion on where
  * the verification key comes from.
  *
  * Verification involves the following steps.
  *
- * - The CBOR-format \c COSE_Sign1 or \c COSE_Sign structure is parsed. This makes
+ * - The CBOR-format \c COSE_Sign1 or \c COSE_Sign structure is decoded. This makes
  * sure the CBOR is valid and follows the required structure.
  *
  * - The protected header parameters are decoded, particular the algorithm id.
@@ -238,6 +238,8 @@ t_cose_sign_verify_detached(struct t_cose_sign_verify_ctx *context,
 // TODO: maybe this should return the signature index too?
 static struct t_cose_signature_verify  *
 t_cose_sign_verify_get_last(struct t_cose_sign_verify_ctx *context);
+
+
 
 
 /* ------------------------------------------------------------------------

--- a/inc/t_cose/t_cose_sign_verify.h
+++ b/inc/t_cose/t_cose_sign_verify.h
@@ -1,7 +1,7 @@
 /*
  *  t_cose_sign_verify.h
  *
- * Copyright 2019-2022, Laurence Lundblade
+ * Copyright 2019-2023, Laurence Lundblade
  *
  * SPDX-License-Identifier: BSD-3-Clause
  * Created by Laurence Lundblade on 7/17/22.
@@ -25,7 +25,7 @@ extern "C" {
 #endif
 #endif
 
-/* Warning: this is still early development. Documentation may be incorrect. */
+/* Warning: multiple signatures and verifiers are still early development. Documentation may be incorrect. */
 
 
 #define T_COSE_MAX_TAGS_TO_RETURN2 4
@@ -67,16 +67,14 @@ struct t_cose_sign_verify_ctx {
     struct t_cose_parameter_storage  *p_storage;
     t_cose_parameter_decode_cb       *param_decode_cb;
     void                             *param_decode_cb_context;
-
     struct t_cose_signature_verify   *last_verifier; /* Last verifier that didn't succeed */
-
 };
 
 
 
 
-/* ALL signatures must be verified successfully. The default
- * is that only the first must verify.
+/* Requires that ALL COSE_Signatures must be verified successfully. The default
+ * is that only the one must verify.
  */
 #define T_COSE_VERIFY_ALL_SIGNATURES                  0x0008000
 
@@ -110,10 +108,35 @@ t_cose_sign_verify_init(struct t_cose_sign_verify_ctx *context,
  * are added in they should be configured with any key
  * material (e.g., the verification key) needed.
  *
- * By default the overall result is success if at least
- * one of the signatures verifies. TODO: think
- * more carefully through all the combinations of
- * multiple signatures and verifiers.
+ * The verifiers added must be a complete concrete instance
+ * such as t_cose_signature_verify_main or t_cose_signature_verify_eddsa,
+ * not the abstract base object t_cose_signature_verify.
+ * Some verifiers like t_cose_signature_verify_main handle multiple
+ * cryptographic algorithms.
+ *
+ * For COSE_SIgn messages, t_cose_sign_verify() loops over
+ * all the COSE_Signatures. By default the verification is a success
+ * if one can be verified and there are no decoding errors. The
+ * option \ref T_COSE_VERIFY_ALL_SIGNATURES can be set
+ * to require that all the signatures verify for the overall COSE_Sign
+ * to be a success.
+ *
+ * For COSE_Sign1 messages t_cose_sign_verify() calls
+ * each verifier as described next.
+ *
+ * Each verifier added here is called on each COSE_Signature
+ * until one succeeds. An individual verifier may decline to
+ * attempt verification if it doesn't handle the particular
+ * algorithm, the kid doesn't match or for other reasons it
+ * may have after examining the header parameters in the
+ * COSE_Signature. If it declines, the next verifier will be
+ * invoked. If an individual verifier fails because of a CBOR
+ * decoding issue or if it attempts the actual signature
+ * cryptographic operation and that fails, processing of the
+ * whole COSE_Sign will fail.
+ *
+ * The header parameters for all the COSE_Signatures are
+ * returned in a linked list by t_cose_sign_verify().
  */
 static void
 t_cose_sign_add_verifier(struct t_cose_sign_verify_ctx  *context,
@@ -126,6 +149,8 @@ t_cose_sign_add_verifier(struct t_cose_sign_verify_ctx  *context,
  * \param[in] context     Signed message verification context.
  * \param[in] storage     The parameter storage to add.
  *
+ * This is optionally called to increase the number of storage
+ * nodes for COSE_Sign or COSE_Sign1 message with T_COSE_NUM_VERIFY_DECODE_HEADERS header parameters.
  * Decoded parameters are returned in a linked list of struct t_cose_parameter.
  * The storage for the nodes in the list is not dynamically allocated as there
  * is no dynamic storage allocation used here.
@@ -175,8 +200,9 @@ t_cose_sign_set_param_decoder(struct t_cose_sign_verify_ctx *context,
  *
  * \return This returns one of the error codes defined by \ref t_cose_err_t.
  *
- * See t_cose_sign_set_verification_key() for discussion on where
- * the verification key comes from.
+ * See t_cose_sign_add_verifier() for discussion on where
+ * the verification key comes from, algorithms, formats and
+ * handling of multiple signatures and multiple verifiers.
  *
  * Verification involves the following steps.
  *
@@ -207,9 +233,6 @@ t_cose_sign_set_param_decoder(struct t_cose_sign_verify_ctx *context,
  * they are in the input \c COSE_Sign1 messages. For example, if the
  * payload is an indefinite-length byte string, this error will be
  * returned.
- *
- *
- * 
  *
  * See also t_cose_sign_verify_detached().
  */
@@ -340,7 +363,8 @@ t_cose_sign_add_verifier(struct t_cose_sign_verify_ctx  *me,
                          struct t_cose_signature_verify *verifier)
 {
     /* Use base class function to add a signer/recipient to the linked list. */
-    t_cose_link_rs((struct t_cose_rs_obj **)&me->verifiers, (struct t_cose_rs_obj *)verifier);
+    t_cose_link_rs((struct t_cose_rs_obj **)&me->verifiers,
+                   (struct t_cose_rs_obj *)verifier);
 }
 
 

--- a/inc/t_cose/t_cose_signature_sign.h
+++ b/inc/t_cose/t_cose_signature_sign.h
@@ -171,10 +171,10 @@ t_cose_signature_sign_headers_cb(struct t_cose_signature_sign *me,
  * when the callback is not implemented.
  */
 struct t_cose_signature_sign {
+    struct t_cose_rs_obj             rs;
     t_cose_signature_sign_headers_cb *headers_cb;
     t_cose_signature_sign_cb         *sign_cb;
     t_cose_signature_sign1_cb        *sign1_cb;
-    struct t_cose_signature_sign     *next_in_list; /* linked list of signers */
 };
 
 

--- a/inc/t_cose/t_cose_signature_verify.h
+++ b/inc/t_cose/t_cose_signature_verify.h
@@ -50,6 +50,8 @@ struct t_cose_signature_verify;
  * \param[in] qcbor_decoder           The decoder instance from where the
  *                                     COSE_Signature is decoded.
  * \param[out] decoded_params  Returned linked list of decoded parameters.
+ *
+ * This must return T_COSE_ERR_NO_MORE if there are no more COSE_Signatures.
  */
 typedef enum t_cose_err_t
 t_cose_signature_verify_cb(struct t_cose_signature_verify     *me,

--- a/inc/t_cose/t_cose_signature_verify.h
+++ b/inc/t_cose/t_cose_signature_verify.h
@@ -1,7 +1,7 @@
 /*
  * t_cose_signature_verify.h
  *
- * Copyright (c) 2022, Laurence Lundblade. All rights reserved.
+ * Copyright (c) 2023, Laurence Lundblade. All rights reserved.
  * Created by Laurence Lundblade on 7/17/22.
  *
  * SPDX-License-Identifier: BSD-3-Clause
@@ -55,7 +55,7 @@ typedef enum t_cose_err_t
 t_cose_signature_verify_cb(struct t_cose_signature_verify     *me,
                            uint32_t                            option_flags,
                            const struct t_cose_header_location loc,
-                           const struct t_cose_sign_inputs    *sign_inputs,
+                           struct t_cose_sign_inputs          *sign_inputs,
                            struct t_cose_parameter_storage    *params,
                            QCBORDecodeContext                 *qcbor_decoder,
                            struct t_cose_parameter           **decoded_params);
@@ -87,15 +87,15 @@ t_cose_signature_verify1_cb(struct t_cose_signature_verify *me,
 
 
 /**
- * Data structture that must be the first part of every context of every concrete
+ * Data structure that must be the first part of every context of every concrete
  * implementation of t_cose_signature_verify. Callback functions must not
  * be NULL, but can be stubs that return an error when COSE_SIgn1 or COSE_Sign
  * are not supported.
  */
 struct t_cose_signature_verify {
+    struct t_cose_rs_obj             rs;
     t_cose_signature_verify_cb      *verify_cb;
     t_cose_signature_verify1_cb     *verify1_cb;
-    struct t_cose_signature_verify  *next_in_list; /* Linked list of signers */
 };
 
 

--- a/inc/t_cose/t_cose_signature_verify_eddsa.h
+++ b/inc/t_cose/t_cose_signature_verify_eddsa.h
@@ -1,7 +1,7 @@
 /*
  * t_cose_signature_verify_eddsa.h
  *
- * Copyright (c) 2022, Laurence Lundblade. All rights reserved.
+ * Copyright (c) 2022-2023, Laurence Lundblade. All rights reserved.
  * Created by Laurence Lundblade on 11/18/22.
  *
  * SPDX-License-Identifier: BSD-3-Clause
@@ -35,6 +35,8 @@ struct t_cose_signature_verify_eddsa {
     void                           *param_decode_cb_context;
     uint32_t                        option_flags;
 
+    struct q_useful_buf_c           verification_kid;
+
 
     /**
      * A auxiliary buffer provided by the caller, used to serialize
@@ -59,7 +61,8 @@ t_cose_signature_verify_eddsa_init(struct t_cose_signature_verify_eddsa *me,
 
 static void
 t_cose_signature_verify_eddsa_set_key(struct t_cose_signature_verify_eddsa *me,
-                                      struct t_cose_key verification_key);
+                                      struct t_cose_key verification_key,
+                                      struct q_useful_buf_c verification_kid);
 
 static void
 t_cose_signature_verify_eddsa_set_param_decoder(struct t_cose_signature_verify_eddsa *me,
@@ -127,9 +130,11 @@ t_cose_signature_verify_from_eddsa(struct t_cose_signature_verify_eddsa *context
 
 static inline void
 t_cose_signature_verify_eddsa_set_key(struct t_cose_signature_verify_eddsa *me,
-                                      struct t_cose_key verification_key)
+                                      struct t_cose_key verification_key,
+                                      struct q_useful_buf_c verification_kid)
 {
     me->verification_key = verification_key;
+    me->verification_kid = verification_kid;
 }
 
 static inline void

--- a/inc/t_cose/t_cose_signature_verify_main.h
+++ b/inc/t_cose/t_cose_signature_verify_main.h
@@ -1,7 +1,7 @@
 /*
  * t_cose_signature_verify_main.h
  *
- * Copyright (c) 2022, Laurence Lundblade. All rights reserved.
+ * Copyright (c) 2023, Laurence Lundblade. All rights reserved.
  * Created by Laurence Lundblade on 7/22/22.
  *
  * SPDX-License-Identifier: BSD-3-Clause
@@ -38,10 +38,28 @@ struct t_cose_signature_verify_main {
 };
 
 
+
+/* This verifier supports ECDSA and RSA (but no EdDSA).
+ *
+ * The context initialized here can be cast to t_cose_signature_verify
+ * and given to t_cose_sign_verify which will invoke the verify through
+ * callback functions in this context. Those call back functions
+ * will perform the decoded of a COSE_Signature, hash the inputs
+ * and call the public key crypto algorithms to actually verify
+ * the signature.
+
+ * All that is necessary here is to initialize it and give it the
+ * key material.
+ */
 void
-t_cose_signature_verify_main_init(struct t_cose_signature_verify_main *me);
+t_cose_signature_verify_main_init(struct t_cose_signature_verify_main *context);
 
 
+/* Set the verification key and kid.
+ * Note that only one key may be set, but you can create multiple
+ * instances of this object, each with its own key and kid and
+ * t_cose_signature_verify will select the correct one by kid.
+ */
 static void
 t_cose_signature_verify_main_set_key(struct t_cose_signature_verify_main *me,
                                      struct t_cose_key                    verification_key,

--- a/inc/t_cose/t_cose_signature_verify_main.h
+++ b/inc/t_cose/t_cose_signature_verify_main.h
@@ -31,8 +31,9 @@ struct t_cose_signature_verify_main {
      */
     struct t_cose_signature_verify  s;
     struct t_cose_key               verification_key;
+    struct q_useful_buf_c           verification_kid;
     t_cose_parameter_decode_cb     *param_decode_cb;
-    void                              *crypto_context;
+    void                           *crypto_context;
     void                           *param_decode_cb_context;
 };
 
@@ -43,7 +44,8 @@ t_cose_signature_verify_main_init(struct t_cose_signature_verify_main *me);
 
 static void
 t_cose_signature_verify_main_set_key(struct t_cose_signature_verify_main *me,
-                                      struct t_cose_key verification_key);
+                                     struct t_cose_key                    verification_key,
+                                     struct q_useful_buf_c                verification_kid);
 
 /**
  * \brief  Set the crypto context to be passed to the crypto library..
@@ -80,9 +82,11 @@ t_cose_signature_verify_from_main(struct t_cose_signature_verify_main *context);
 
 static inline void
 t_cose_signature_verify_main_set_key(struct t_cose_signature_verify_main *me,
-                                      struct t_cose_key verification_key)
+                                     struct t_cose_key                    verification_key,
+                                     struct q_useful_buf_c                verification_kid)
 {
     me->verification_key = verification_key;
+    me->verification_kid = verification_kid;
 }
 
 

--- a/src/t_cose_sign1_verify.c
+++ b/src/t_cose_sign1_verify.c
@@ -1,7 +1,7 @@
 /*
  * t_cose_sign1_verify.c
  *
- * Copyright 2019-2022, Laurence Lundblade
+ * Copyright 2019-2023, Laurence Lundblade
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *
@@ -49,9 +49,12 @@ t_cose_sign1_set_verification_key(struct t_cose_sign1_verify_ctx *me,
     /* Set the same key for both. We don't know which verifier will be used
      * until decoding the input. There is only one key in t_cose_sign1(). */
     t_cose_signature_verify_eddsa_set_key(&(me->eddsa_verifier),
-                                          verification_key);
+                                          verification_key,
+                                          // TODO: should this be NULL?
+                                          NULL_Q_USEFUL_BUF_C);
     // TODO: should kid be handled here?
     t_cose_signature_verify_main_set_key(&(me->main_verifier),
-                                         verification_key, NULL_Q_USEFUL_BUF_C);
+                                         verification_key,
+                                         NULL_Q_USEFUL_BUF_C);
 }
 

--- a/src/t_cose_sign1_verify.c
+++ b/src/t_cose_sign1_verify.c
@@ -50,7 +50,8 @@ t_cose_sign1_set_verification_key(struct t_cose_sign1_verify_ctx *me,
      * until decoding the input. There is only one key in t_cose_sign1(). */
     t_cose_signature_verify_eddsa_set_key(&(me->eddsa_verifier),
                                           verification_key);
+    // TODO: should kid be handled here?
     t_cose_signature_verify_main_set_key(&(me->main_verifier),
-                                         verification_key);
+                                         verification_key, NULL_Q_USEFUL_BUF_C);
 }
 

--- a/src/t_cose_sign1_verify.c
+++ b/src/t_cose_sign1_verify.c
@@ -47,12 +47,13 @@ t_cose_sign1_set_verification_key(struct t_cose_sign1_verify_ctx *me,
                                   struct t_cose_key           verification_key)
 {
     /* Set the same key for both. We don't know which verifier will be used
-     * until decoding the input. There is only one key in t_cose_sign1(). */
+     * until decoding the input. There is only one key in t_cose_sign1().
+     * Also, t_cose_sign1 didn't do any kid matching, so it is NULL here.
+     */
     t_cose_signature_verify_eddsa_set_key(&(me->eddsa_verifier),
                                           verification_key,
                                           // TODO: should this be NULL?
                                           NULL_Q_USEFUL_BUF_C);
-    // TODO: should kid be handled here?
     t_cose_signature_verify_main_set_key(&(me->main_verifier),
                                          verification_key,
                                          NULL_Q_USEFUL_BUF_C);

--- a/src/t_cose_sign_sign.c
+++ b/src/t_cose_sign_sign.c
@@ -63,7 +63,7 @@ t_cose_sign_encode_start(struct t_cose_sign_sign_ctx *me,
          * contains a raw signature bytes, not an array of
          * COSE_Signature. */
         signer->headers_cb(signer, &sign1_parameters);
-        if(signer->next_in_list != NULL) {
+        if(signer->rs.next != NULL) {
             /* In COSE_Sign1 mode, but too many signers configured.*/
             return_value = T_COSE_ERR_TOO_MANY_SIGNERS;
             goto Done;
@@ -176,7 +176,7 @@ t_cose_sign_encode_finish(struct t_cose_sign_sign_ctx *me,
             if(return_value != T_COSE_SUCCESS) {
                 goto Done;
             }
-            signer = signer->next_in_list;
+            signer = (struct t_cose_signature_sign *)signer->rs.next;
         }
         QCBOREncode_CloseArray(cbor_encode_ctx);
 
@@ -268,21 +268,3 @@ Done:
     return return_value;
 }
 
-
-/*
- * Public function. See t_cose_sign_sign.h
- */
-void
-t_cose_sign_add_signer(struct t_cose_sign_sign_ctx  *context,
-                       struct t_cose_signature_sign *signer)
-{
-    // TODO: for COSE_Sign1 this can be tiny and inline
-
-    if(context->signers == NULL) {
-        context->signers = signer;
-    } else {
-        struct t_cose_signature_sign *t;
-        for(t = context->signers; t->next_in_list != NULL; t = t->next_in_list);
-        t->next_in_list = signer;
-    }
-}

--- a/src/t_cose_sign_sign.c
+++ b/src/t_cose_sign_sign.c
@@ -1,7 +1,7 @@
 /*
  * t_cose_sign_sign.c
  *
- * Copyright (c) 2018-2022, Laurence Lundblade. All rights reserved.
+ * Copyright (c) 2018-2023, Laurence Lundblade. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *
@@ -38,7 +38,7 @@ t_cose_sign_encode_start(struct t_cose_sign_sign_ctx *me,
     struct t_cose_signature_sign  *signer;
     struct t_cose_parameter       *sign1_parameters;
     struct t_cose_parameter       *body_parameters;
-    uint64_t                       message_type_tag;
+    uint64_t                       message_type_tag_number;
 
     /* There must be at least one signer configured (a signer is an
      * object, a callback and context, that makes a signature). See
@@ -53,15 +53,16 @@ t_cose_sign_encode_start(struct t_cose_sign_sign_ctx *me,
     }
 
     /* --- Is this COSE_Sign or COSE_Sign1? --- */
-    message_type_tag = me->option_flags & T_COSE_OPT_MESSAGE_TYPE_MASK;
+    message_type_tag_number = me->option_flags & T_COSE_OPT_MESSAGE_TYPE_MASK;
 
     /* --- Make list of the body header parameters --- */
     sign1_parameters = NULL;
-    if(message_type_tag == CBOR_TAG_COSE_SIGN1) {
+    if(message_type_tag_number == CBOR_TAG_COSE_SIGN1) {
         /* For a COSE_Sign1, the header parameters go in the main body
          * header parameter section, and the signatures part just
          * contains a raw signature bytes, not an array of
-         * COSE_Signature. */
+         * COSE_Signature. This gets the parameters from the
+         * signer. */
         signer->headers_cb(signer, &sign1_parameters);
         if(signer->rs.next != NULL) {
             /* In COSE_Sign1 mode, but too many signers configured.*/
@@ -80,16 +81,16 @@ t_cose_sign_encode_start(struct t_cose_sign_sign_ctx *me,
         t_cose_parameter_list_append(body_parameters, me->added_body_parameters);
     }
 
-    /* --- Add the CBOR tag indicating COSE_Sign1 --- */
+    /* --- Add the CBOR tag indicating COSE message type --- */
     if(!(me->option_flags & T_COSE_OPT_OMIT_CBOR_TAG)) {
-        QCBOREncode_AddTag(cbor_encode_ctx, message_type_tag);
+        QCBOREncode_AddTag(cbor_encode_ctx, message_type_tag_number);
     }
 
     /* --- Open array-of-four that holds all COSE_Sign(1) messages --- */
     QCBOREncode_OpenArray(cbor_encode_ctx);
 
 
-    /* --- Encode both proteced and unprotected headers --- */
+    /* --- Encode both protected and unprotected headers --- */
     return_value = t_cose_encode_headers(cbor_encode_ctx,
                                          body_parameters,
                                          &me->protected_parameters);
@@ -158,11 +159,13 @@ t_cose_sign_encode_finish(struct t_cose_sign_sign_ctx *me,
 
 
     /* --- Signature for COSE_Sign1 or signatures for COSE_Sign --- */
-    signer = me->signers;
     sign_inputs.body_protected = me->protected_parameters;
     sign_inputs.sign_protected = NULL_Q_USEFUL_BUF_C; /* filled in by sign_cb */
     sign_inputs.payload        = signed_payload;
     sign_inputs.aad            = aad;
+
+    signer = me->signers;
+
     if(T_COSE_OPT_IS_SIGN(me->option_flags)) {
         /* --- One or more COSE_Signatures for COSE_Sign --- */
 

--- a/src/t_cose_sign_verify.c
+++ b/src/t_cose_sign_verify.c
@@ -1,7 +1,7 @@
 /*
  * t_cose_sign_verify.c
  *
- * Copyright 2019-2022, Laurence Lundblade
+ * Copyright 2019-2023, Laurence Lundblade
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *
@@ -120,7 +120,10 @@ process_tags(struct t_cose_sign_verify_ctx *me,
     return T_COSE_SUCCESS;
 }
 
-/* No error stops the calling of further verifiers, but soft verify errors are never returned to the caller.*/
+
+/* These error do not stop the calling of the further verifiers for
+ * a given COSE_Signature.
+ */
 static bool
 is_soft_verify_error(enum t_cose_err_t error)
 {
@@ -128,10 +131,89 @@ is_soft_verify_error(enum t_cose_err_t error)
         case T_COSE_ERR_UNSUPPORTED_SIGNING_ALG:
         case T_COSE_ERR_KID_UNMATCHED:
         case T_COSE_ERR_UNSUPPORTED_HASH:
+        case T_COSE_ERR_DECLINE_TO_VERIFY:
             return true;
         default:
             return false;
     }
+}
+
+
+enum sig_summary_error {
+    VERIFY_SUCCESS,
+    END_OF_SIGNATURES,
+    UNABLE_TO_DECODE,
+    DECLINE, /* algrothm */
+    VERIFY_FAIL, /* The algorithm, kid and such matched and the actual verification of byes via
+                  crypto failed. */
+};
+
+/* It is assumed the compiler will inline this since it is called
+ * only once. Makes the large number of parameters not so
+ * bad. This is a seperate function for code readability. */
+static enum sig_summary_error
+verify_one_signature(struct t_cose_sign_verify_ctx       *me,
+                     const struct t_cose_header_location   header_location,
+                     struct t_cose_sign_inputs      *sign_inputs,
+                     QCBORDecodeContext                   *qcbor_decoder,
+                     struct t_cose_parameter             **decoded_sig_parameter_list,
+                     enum t_cose_err_t                    *error_code)
+{
+    struct t_cose_signature_verify *verifier;
+
+    // QCBORDecode_SaveCursor(&decode_context, &saved_cursor);
+
+    for(verifier = me->verifiers; verifier != NULL; verifier = (struct t_cose_signature_verify *)verifier->rs.next) {
+        *error_code = verifier->verify_cb(verifier,
+                                           me->option_flags,
+                                           header_location,
+                                           sign_inputs,
+                                           me->p_storage,
+                                           qcbor_decoder,
+                                           decoded_sig_parameter_list);
+        if(*error_code == T_COSE_SUCCESS) {
+            /* If here, then the decode was a success, the crypto
+             * verified, and the signature CBOR was consumed. Nothing
+             * to do but leave */
+            return VERIFY_SUCCESS;
+        }
+
+        if(*error_code == 99) { // TODO: which error code?
+            return END_OF_SIGNATURES;
+        }
+
+        /* Remember the last verifier that failed. */
+        me->last_verifier = verifier;
+
+        if(*error_code == T_COSE_ERR_SIG_VERIFY) {
+            /* The verifier was for the right algorithm and the
+             * key was the right kid and such, but the actual
+             * crypto failed to verify the bytes. In most
+             * cases the caller will want to fail the whole
+             * thing if this happens.
+             */
+            // TODO: an option to continue even if this occurs?
+            return VERIFY_FAIL;
+        }
+
+
+        if(!is_soft_verify_error(*error_code)) {
+            /* Something is very wrong. Need to abort the entire
+             * COSE mesage. */
+            return UNABLE_TO_DECODE;
+        }
+
+        /* Go on to the next signature */
+
+        // QCBORDecode_RestoreCursor(&decode_context, &saved_cursor)
+    }
+
+    /* Got to the end of the list without success. The last
+     * verifier called will have consumed the CBOR for the
+     * signature. We arrive here because there was no
+     * verifier for the algorithm or the kid for the verification key
+     * didn't match any of the signatures or general decline failure. */
+    return DECLINE;
 }
 
 
@@ -154,22 +236,21 @@ t_cose_sign_verify_private(struct t_cose_sign_verify_ctx  *me,
     QCBORError                      qcbor_error;
     struct t_cose_signature_verify *verifier;
     struct t_cose_header_location   header_location;
-    QCBORItem                       null_payload;
     struct t_cose_parameter        *decoded_body_parameter_list;
     struct t_cose_parameter        *decoded_sig_parameter_list;
     struct t_cose_sign_inputs       sign_inputs;
-
+    enum sig_summary_error          s_s_e;
 
     /* --- Decoding of the array of four starts here --- */
     QCBORDecode_Init(&decode_context, message, QCBOR_DECODE_MODE_NORMAL);
 
     /* --- The array of 4 and tags --- */
     QCBORDecode_EnterArray(&decode_context, NULL);
-    return_value = qcbor_decode_error_to_t_cose_error(QCBORDecode_GetError(&decode_context),
-                                                      T_COSE_ERR_SIGN1_FORMAT);
-    if(return_value != T_COSE_SUCCESS) {
-        goto Done;
+    if(QCBORDecode_GetError(&decode_context)) {
+        return_value = T_COSE_SUCCESS; /* Needed to quite warnings about lack of initialization even though it will get set below. The compiler doesn't know about QCBOR internal error state */
+        goto Done3;
     }
+
     return_value = process_tags(me, &decode_context);
     if(return_value != T_COSE_SUCCESS) {
         goto Done;
@@ -195,14 +276,7 @@ t_cose_sign_verify_private(struct t_cose_sign_verify_ctx  *me,
 
     /* --- The payload --- */
     if(is_detached) {
-        QCBORDecode_GetNext(&decode_context, &null_payload);
-        /* If there is a decode error here, null_payload.uDataType will be
-         * QCBOR_TYPE_NONE
-         */
-        if (null_payload.uDataType != QCBOR_TYPE_NULL) {
-            return_value = T_COSE_ERR_SIGN1_FORMAT;
-            goto Done;
-        }
+        QCBORDecode_GetNull(&decode_context);
         /* In detached content mode, the payload should be set by
          * function caller, so there is no need to set the payload.
          */
@@ -212,6 +286,9 @@ t_cose_sign_verify_private(struct t_cose_sign_verify_ctx  *me,
 
 
     /* --- The signature or the COSE_Signature(s) --- */
+    if(me->verifiers == NULL) {
+        return T_COSE_ERR_NO_VERIFIERS;
+    }
     sign_inputs.body_protected = protected_parameters;
     sign_inputs.sign_protected = NULL_Q_USEFUL_BUF_C;
     sign_inputs.aad            = aad;
@@ -220,103 +297,100 @@ t_cose_sign_verify_private(struct t_cose_sign_verify_ctx  *me,
     if(T_COSE_OPT_IS_SIGN1(me->option_flags)) {
         /* --- The signature bytes for a COSE_Sign1, not COSE_Signatures */
         QCBORDecode_GetByteString(&decode_context, &signature);
-        return_value = qcbor_decode_error_to_t_cose_error(QCBORDecode_GetError(&decode_context),
-                                                    T_COSE_ERR_SIGN1_FORMAT);
-        if(return_value != T_COSE_SUCCESS) {
-            goto Done;
+        if(QCBORDecode_GetError(&decode_context)) {
+            goto Done3;
         }
 
         /* Loop over all the verifiers configured asking each
          * to verify until one succeeds. If none succeeded, the error
-         * returned is from the last one called.  There are
-         * intentionally no types of errors that one verifier can return
-         * that ends the whole loop and blocks others from being called.
+         * returned is from the last one called.
          */
         verify_error = T_COSE_ERR_NO_VERIFIERS;
-        for(verifier = me->verifiers; verifier != NULL; verifier = verifier->next_in_list) {
-            /* Actually do the signature verification by calling
-             * the main method of the cose_signature_verify. This
-             * will compute the tbs value and call the crypto.
+        for(verifier = me->verifiers; verifier != NULL; verifier = (struct t_cose_signature_verify *)verifier->rs.next) {
+            /* Call the verifyer to attempt a verification. It
+             * will compute the tbs and try to run the crypto.
              */
-            verify_error = verifier->verify1_cb(verifier,
+            return_value = verifier->verify1_cb(verifier,
                                                 me->option_flags,
                                                &sign_inputs,
                                                 decoded_body_parameter_list,
                                                 signature);
-            if(verify_error == T_COSE_SUCCESS) {
+            if(return_value == T_COSE_SUCCESS) {
                 break;
             }
-            if(!is_soft_verify_error(verify_error)) {
-                return_value = verify_error;
+            if(!is_soft_verify_error(return_value)) {
+                /* An error like a decode error or a signature verification failure. */
+                break;
             }
-        }
-        if(return_value == T_COSE_SUCCESS && verify_error != T_COSE_SUCCESS) {
-            /* Only a soft verification error occured. It is still an
-             * error, not success, so it has to be returned. */
-            return_value = verify_error;
+
+            /* Algorithm or kid didn't match or verifier declined, continue
+             * trying other verifiers.
+             */
         }
 
     } else {
         /* --- An array of COSE_Signatures --- */
         QCBORDecode_EnterArray(&decode_context, NULL);
-        verifier = me->verifiers;
+        if(QCBORDecode_GetError(&decode_context)) {
+            /* Not strictly necessary, but very helpful for error reporting. */
+            goto Done3;
+        }
+
         /* Nesting level is 1, index starts at 0 and gets incremented */
         header_location = (struct t_cose_header_location){.nesting = 1,
                                                           .index   = 0 };
+
         while(1) { /* loop over COSE_Signatures */
             header_location.index++;
+            enum t_cose_err_t      sig_error_code;
 
-            // TODO: right now this doesn't work in some cases because
-            // The signature verifier can't rewind the QCBOR decoder to
-            // let the next verifier have a shot at it.  So just testing
-            // with one signature for now...
-            for(verifier = me->verifiers; verifier != NULL; verifier = verifier->next_in_list) {
+            s_s_e = verify_one_signature(me,
+                                         header_location,
+                                         &sign_inputs,
+                                         &decode_context,
+                                         &decoded_sig_parameter_list,
+                                         &sig_error_code);
 
-                /* This call decodes one array entry containing a
-                 * COSE_Signature. */
-                return_value = verifier->verify_cb(verifier,
-                                                   me->option_flags,
-                                                   header_location,
-                                                   &sign_inputs,
-                                                   me->p_storage,
-                                                  &decode_context,
-                                                  &decoded_sig_parameter_list);
+            if(s_s_e == UNABLE_TO_DECODE || s_s_e == VERIFY_FAIL) {
+                /* Exit entire message decode with failure */
+                return_value = sig_error_code;
+                goto Done;
+            }
+            if(s_s_e == END_OF_SIGNATURES) {
+                break;
+            }
+            /* Now what's left is a success or decline */
 
-                // TODO: this may not be in the right place
-                t_cose_parameter_list_append(decoded_body_parameter_list,
-                                             decoded_sig_parameter_list);
-
-                if(return_value == T_COSE_SUCCESS) {
-                     // TODO: correct flag value
-                    if(me->option_flags & T_COSE_VERIFY_ALL) {
-                        continue;
-                    } else {
-                        break; /* success. Don't need to try another verifier*/
-                    }
-#ifdef TODO_FIXME_MULTISIG
-                } else if(return_value == 98) {
-                    continue; /* Didn't know how to decode, try another  */
-                } else if(return_value == 88) {
-                    goto done_with_sigs;/* No more COSE_Signatures to be read*/
-#endif
+            if(me->option_flags & T_COSE_VERIFY_ALL_SIGNATURES) {
+                if(s_s_e == DECLINE) {
+                    /* When verifying all, there can be no declines */
+                    return_value = sig_error_code;
+                    goto Done;
                 } else {
-                    goto Done2;
+                    /* success. Continue on to be sure the rest succeed. */
+                }
+            } else {
+                if(s_s_e == VERIFY_SUCCESS) {
+                    /* Just one success is enough to complete.*/
+                    break;
+                } else {
+                    /* decline. Continue to try other COSE_Signatures. */
                 }
             }
         }
-#ifdef TODO_FIXME_MULTISIG
-     done_with_sigs:
+
         QCBORDecode_ExitArray(&decode_context);
-#endif
     }
+
 
     /* --- Finish up the CBOR decode --- */
     QCBORDecode_ExitArray(&decode_context);
 
+Done3:
     /* This check make sure the array only had the expected four
      * items. It works for definite and indefinte length arrays. Also
-     * makes sure there were no extra bytes. Also that the payload
-     * and signature were decoded correctly. */
+     * makes sure there were no extra bytes. Also maps the error code
+     * for other decode errors detected above. */
     qcbor_error = QCBORDecode_Finish(&decode_context);
     if(qcbor_error != QCBOR_SUCCESS) {
         /* A decode error overrides other errors. */
@@ -332,22 +406,4 @@ Done2:
 
 Done:
     return return_value;
-}
-
-
-/*
- * Public function. See t_cose_sign_sign.h
- */
-void
-t_cose_sign_add_verifier(struct t_cose_sign_verify_ctx  *me,
-                         struct t_cose_signature_verify *verifier)
-{
-    // TODO: for COSE_Sign1 this can be tiny and inline fo DISABLE_COSE_SIGN
-    if(me->verifiers == NULL) {
-        me->verifiers = verifier;
-    } else {
-        struct t_cose_signature_verify *t;
-        for(t = me->verifiers; t->next_in_list != NULL; t = t->next_in_list);
-        t->next_in_list = verifier;
-    }
 }

--- a/src/t_cose_sign_verify.c
+++ b/src/t_cose_sign_verify.c
@@ -160,9 +160,10 @@ verify_one_signature(struct t_cose_sign_verify_ctx       *me,
                      enum t_cose_err_t                    *error_code)
 {
     struct t_cose_signature_verify *verifier;
-    SaveDecodeCursor saved_cursor;
 
 #ifdef QCBOR_FOR_T_COSE_2
+    SaveDecodeCursor saved_cursor;
+
     QCBORDecode_SaveCursor(qcbor_decoder, &saved_cursor);
 #endif
 

--- a/src/t_cose_signature_sign_main.c
+++ b/src/t_cose_signature_sign_main.c
@@ -134,6 +134,7 @@ t_cose_signature_sign_main_init(struct t_cose_signature_sign_main *me,
                                 const int32_t               cose_algorithm_id)
 {
     memset(me, 0, sizeof(*me));
+    me->s.rs.ident        = RS_IDENT(TYPE_RS_SIGNER, 'M');
     me->s.headers_cb      = t_cose_signature_sign_headers_main_cb;
     me->s.sign_cb         = t_cose_signature_sign_main_cb;
     me->s.sign1_cb        = t_cose_signature_sign1_main_cb;

--- a/src/t_cose_signature_verify_eddsa.c
+++ b/src/t_cose_signature_verify_eddsa.c
@@ -35,6 +35,7 @@ t_cose_signature_verify1_eddsa_cb(struct t_cose_signature_verify *me_x,
     struct q_useful_buf_c        tbs;
 
     /* --- Get the parameters values needed --- */
+    // TODO: this will look through all params, not just those of the this COSE_Signature
     cose_algorithm_id = t_cose_find_parameter_alg_id(parameter_list);
     if(cose_algorithm_id == T_COSE_ALGORITHM_NONE) {
         return_value = T_COSE_ERR_NO_ALG_ID;
@@ -103,7 +104,10 @@ Done:
 
  This is an implementation of t_cose_signature_verify_callback
  */
-/** This is an implementation of \ref t_cose_signature_verify_cb. */
+/** This is an implementation of \ref t_cose_signature_verify_cb. It will
+ * decode a COSE_Signature and if the algorithm is EdDSA it will verify it.
+ * It will also decode all headers and return them in a linked list.
+ */
 static enum t_cose_err_t
 t_cose_signature_verify_eddsa_cb(struct t_cose_signature_verify  *me_x,
                                  const uint32_t                   option_flags,

--- a/src/t_cose_signature_verify_main.c
+++ b/src/t_cose_signature_verify_main.c
@@ -1,7 +1,7 @@
 /*
  * t_cose_signature_verify_main.c
  *
- * Copyright (c) 2022, Laurence Lundblade. All rights reserved.
+ * Copyright (c) 2022-2023, Laurence Lundblade. All rights reserved.
  * Created by Laurence Lundblade on 7/19/22.
  *
  * SPDX-License-Identifier: BSD-3-Clause
@@ -131,7 +131,7 @@ static enum t_cose_err_t
 t_cose_signature_verify_main_cb(struct t_cose_signature_verify  *me_x,
                                 const uint32_t                  option_flags,
                                 const struct t_cose_header_location loc,
-                                struct t_cose_sign_inputs *sign_inputs,
+                                struct t_cose_sign_inputs       *sign_inputs,
                                 struct t_cose_parameter_storage *param_storage,
                                 QCBORDecodeContext              *qcbor_decoder,
                                 struct t_cose_parameter        **decoded_params)
@@ -145,6 +145,11 @@ t_cose_signature_verify_main_cb(struct t_cose_signature_verify  *me_x,
 
     /* --- Decode the COSE_Signature ---*/
     QCBORDecode_EnterArray(qcbor_decoder, NULL);
+    qcbor_error = QCBORDecode_GetError(qcbor_decoder);
+    if(qcbor_error == QCBOR_ERR_NO_MORE_ITEMS) {
+        return T_COSE_ERR_NO_MORE;
+    }
+    // TODO: make sure other errors are processed correctly by fall through here
 
     return_value = t_cose_headers_decode(qcbor_decoder,
                                          loc,

--- a/src/t_cose_util.c
+++ b/src/t_cose_util.c
@@ -410,3 +410,18 @@ int16_t t_cose_int16_map(const int16_t map[][2], int16_t query)
         }
     }
 }
+
+
+/* This gets re-used in 6 places (maybe more) and is called by
+ * an inline add_recipient or add_signer or... method. */
+void
+t_cose_link_rs(struct t_cose_rs_obj **list, struct t_cose_rs_obj *new)
+{
+    if(*list == NULL) {
+        *list = new;
+    } else {
+        struct t_cose_rs_obj *t;
+        for(t = *list; t->next != NULL; t = t->next);
+        t->next = new;
+    }
+}

--- a/src/t_cose_util.c
+++ b/src/t_cose_util.c
@@ -415,13 +415,13 @@ int16_t t_cose_int16_map(const int16_t map[][2], int16_t query)
 /* This gets re-used in 6 places (maybe more) and is called by
  * an inline add_recipient or add_signer or... method. */
 void
-t_cose_link_rs(struct t_cose_rs_obj **list, struct t_cose_rs_obj *new)
+t_cose_link_rs(struct t_cose_rs_obj **list, struct t_cose_rs_obj *new_rs)
 {
     if(*list == NULL) {
-        *list = new;
+        *list = new_rs;
     } else {
         struct t_cose_rs_obj *t;
         for(t = *list; t->next != NULL; t = t->next);
-        t->next = new;
+        t->next = new_rs;
     }
 }

--- a/test/run_tests.c
+++ b/test/run_tests.c
@@ -56,6 +56,8 @@ static test_entry2 s_tests2[] = {
 
 static test_entry s_tests[] = {
 
+    TEST_ENTRY(sign_verify_multi),
+
     TEST_ENTRY(aead_test),
 #ifndef T_COSE_DISABLE_AES_KW
     TEST_ENTRY(kw_test),

--- a/test/run_tests.c
+++ b/test/run_tests.c
@@ -56,7 +56,6 @@ static test_entry2 s_tests2[] = {
 
 static test_entry s_tests[] = {
 
-    TEST_ENTRY(sign_verify_multi),
 
     TEST_ENTRY(aead_test),
 #ifndef T_COSE_DISABLE_AES_KW
@@ -84,9 +83,8 @@ static test_entry s_tests[] = {
     TEST_ENTRY(sign_verify_known_good_test),
     TEST_ENTRY(sign_verify_unsupported_test),
     TEST_ENTRY(sign_verify_bad_auxiliary_buffer),
+    
 #endif /* T_COSE_DISABLE_SIGN1 */
-
-
 
 #ifndef T_COSE_DISABLE_MAC0
     // TODO: should these really be conditional on T_COSE_DISABLE_SIGN_VERIFY_TESTS
@@ -96,6 +94,9 @@ static test_entry s_tests[] = {
     TEST_ENTRY(compute_validate_detached_content_mac_sig_fail_test),
     TEST_ENTRY(compute_validate_get_size_detached_content_mac_test),
 #endif /* T_COSE_DISABLE_MAC0 */
+
+    TEST_ENTRY(sign_verify_multi),
+
 #endif /* T_COSE_DISABLE_SIGN_VERIFY_TESTS */
 
 #ifndef T_COSE_DISABLE_SHORT_CIRCUIT_SIGN

--- a/test/t_cose_compute_validate_mac_test.c
+++ b/test/t_cose_compute_validate_mac_test.c
@@ -135,6 +135,7 @@ int_fast32_t compute_validate_mac_sig_fail_test()
     struct q_useful_buf_c        payload;
     QCBORError                   cbor_error;
     struct t_cose_mac_validate_ctx verify_ctx;
+    size_t                       tamper_offset;
 
 
     /* Make an HMAC key that will be used for both signing and
@@ -362,7 +363,6 @@ int_fast32_t compute_validate_detached_content_mac_sig_fail_test()
     struct q_useful_buf_c        payload;
     QCBORError                   cbor_error;
     struct t_cose_mac_validate_ctx verify_ctx;
-    size_t                       tamper_offset;
 
 
     /* ---- Set up ---- */

--- a/test/t_cose_sign_verify_test.c
+++ b/test/t_cose_sign_verify_test.c
@@ -1034,7 +1034,7 @@ int_fast32_t sign_verify_multi(void)
 
 
 
-    t_cose_sign_verify_init(&verify_ctx, T_COSE_OPT_MESSAGE_TYPE_SIGN);
+    t_cose_sign_verify_init(&verify_ctx, T_COSE_OPT_MESSAGE_TYPE_SIGN | T_COSE_VERIFY_ALL_SIGNATURES);
 
     t_cose_signature_verify_main_init(&verify1);
     t_cose_signature_verify_main_set_key(&verify1, key_pair1, Q_USEFUL_BUF_FROM_SZ_LITERAL("kid1"));

--- a/test/t_cose_sign_verify_test.c
+++ b/test/t_cose_sign_verify_test.c
@@ -984,3 +984,71 @@ Done:
 
     return return_value;
 }
+
+
+int_fast32_t sign_verify_multi(void)
+{
+    enum t_cose_err_t              result;
+    struct t_cose_key   key_pair1;
+    struct t_cose_key   key_pair2;
+    struct t_cose_sign_sign_ctx  sign_ctx;
+    struct t_cose_signature_sign_main  signer1;
+    struct t_cose_signature_sign_main  signer2;
+    Q_USEFUL_BUF_MAKE_STACK_UB(    signed_cose_buffer, 300);
+    struct q_useful_buf_c          signed_cose;
+    struct t_cose_sign_verify_ctx  verify_ctx;
+    struct t_cose_signature_verify_main verify1;
+    struct t_cose_signature_verify_main verify2;
+    struct q_useful_buf_c          verified_payload;
+
+
+    result = make_key_pair(T_COSE_ALGORITHM_ES256, &key_pair1);
+    if(result) {
+        return 1000 + (int32_t)result;
+    }
+
+    result = make_key_pair(T_COSE_ALGORITHM_ES512, &key_pair2);
+    if(result) {
+        return 1000 + (int32_t)result;
+    }
+
+    t_cose_sign_sign_init(&sign_ctx, T_COSE_OPT_MESSAGE_TYPE_SIGN);
+
+    t_cose_signature_sign_main_init(&signer1, T_COSE_ALGORITHM_ES256);
+    t_cose_signature_sign_main_set_signing_key(&signer1,
+                                               key_pair1,
+                                               Q_USEFUL_BUF_FROM_SZ_LITERAL("kid1"));
+    t_cose_sign_add_signer(&sign_ctx, (struct t_cose_signature_sign *)&signer1);
+
+    t_cose_signature_sign_main_init(&signer2, T_COSE_ALGORITHM_ES512);
+    t_cose_signature_sign_main_set_signing_key(&signer2,
+                                               key_pair2,
+                                               Q_USEFUL_BUF_FROM_SZ_LITERAL("kid2"));
+    t_cose_sign_add_signer(&sign_ctx, (struct t_cose_signature_sign *)&signer2);
+
+    t_cose_sign_sign(&sign_ctx,
+                     NULL_Q_USEFUL_BUF_C,
+                     Q_USEFUL_BUF_FROM_SZ_LITERAL("payload"),
+                     signed_cose_buffer,
+                     &signed_cose);
+
+
+
+    t_cose_sign_verify_init(&verify_ctx, T_COSE_OPT_MESSAGE_TYPE_SIGN);
+
+    t_cose_signature_verify_main_init(&verify1);
+    t_cose_signature_verify_main_set_key(&verify1, key_pair1, Q_USEFUL_BUF_FROM_SZ_LITERAL("kid1"));
+    t_cose_sign_add_verifier(&verify_ctx, (struct t_cose_signature_verify *)&verify1);
+
+    t_cose_signature_verify_main_init(&verify2);
+    t_cose_signature_verify_main_set_key(&verify2, key_pair2, Q_USEFUL_BUF_FROM_SZ_LITERAL("kid2"));
+    t_cose_sign_add_verifier(&verify_ctx, (struct t_cose_signature_verify *)&verify2);
+
+    t_cose_sign_verify(&verify_ctx,
+                       signed_cose,
+                       NULL_Q_USEFUL_BUF_C,
+                       &verified_payload,
+                       NULL);
+
+    return 0;
+}

--- a/test/t_cose_sign_verify_test.h
+++ b/test/t_cose_sign_verify_test.h
@@ -64,4 +64,11 @@ int_fast32_t sign_verify_unsupported_test(void);
  */
 int_fast32_t sign_verify_bad_auxiliary_buffer(void);
 
+
+/*
+ * Test creation and verification of COSE_Sign with multiple COSE_Signatures
+ */
+int_fast32_t sign_verify_multi(void);
+
+
 #endif /* t_cose_sign_verify_test_h */

--- a/test/t_cose_test.c
+++ b/test/t_cose_test.c
@@ -1782,7 +1782,7 @@ int_fast32_t crypto_context_test()
 
     /* __3__ Successfully verify with a set crypto context  */
     t_cose_signature_verify_main_init(&verifier);
-    t_cose_signature_verify_main_set_key(&verifier, key_pair);
+    t_cose_signature_verify_main_set_key(&verifier, key_pair, NULL_Q_USEFUL_BUF_C);
     t_cose_signature_verify_main_set_crypto_context(&verifier, &crypto_context);
     crypto_context.test_error = T_COSE_SUCCESS;
     t_cose_sign_verify_init(&verify_ctx, T_COSE_OPT_MESSAGE_TYPE_SIGN1);


### PR DESCRIPTION
(still some work to go...)

This mostly completes work on t_cose_sign_verify() so that it can verify a COSE_Sign with multiple signatures with multiple verifiers with multiple algorithms.

To actually verify multiple signatures with multiple verifiers, an updated QCBOR is needed. Multiple signatures with one verifier or one signature with multiple verifiers works with old versions of QCBOR. The new version of QCBOR is detected by #ifdef.

Kid matching is added to the main and eddy verifiers.

A base class for all COSE_Signature and COSE_Recipient objects now exists. It allows the linked list code to be shared across all.