### PR TITLE
Use deterministic ECDSA with PSA interface

### DIFF
--- a/crypto_adapters/t_cose_psa_crypto.c
+++ b/crypto_adapters/t_cose_psa_crypto.c
@@ -93,7 +93,7 @@ static psa_algorithm_t cose_alg_id_to_psa_alg_id(int32_t cose_alg_id)
 
     return
         cose_alg_id == COSE_ALGORITHM_ES256 ?
-#ifdef PSA_WANT_ALG_DETERMINISTIC_ECDSA
+#if PSA_WANT_ALG_DETERMINISTIC_ECDSA
     /* RFC 9053 section 2.1 says
      * "Implementations SHOULD use a deterministic version of ECDSA
      *  such as defined in RFC6979",
@@ -106,7 +106,7 @@ static psa_algorithm_t cose_alg_id_to_psa_alg_id(int32_t cose_alg_id)
 
 #ifndef T_COSE_DISABLE_ES384
         cose_alg_id == COSE_ALGORITHM_ES384 ?
-#ifdef PSA_WANT_ALG_DETERMINISTIC_ECDSA
+#if PSA_WANT_ALG_DETERMINISTIC_ECDSA
             PSA_ALG_DETERMINISTIC_ECDSA(PSA_ALG_SHA_384) :
 #else
             PSA_ALG_ECDSA(PSA_ALG_SHA_384) :
@@ -115,7 +115,7 @@ static psa_algorithm_t cose_alg_id_to_psa_alg_id(int32_t cose_alg_id)
 
 #ifndef T_COSE_DISABLE_ES512
         cose_alg_id == COSE_ALGORITHM_ES512 ?
-#ifdef PSA_WANT_ALG_DETERMINISTIC_ECDSA
+#if PSA_WANT_ALG_DETERMINISTIC_ECDSA
             PSA_ALG_DETERMINISTIC_ECDSA(PSA_ALG_SHA_512) :
 #else
             PSA_ALG_ECDSA(PSA_ALG_SHA_512) :

--- a/examples/t_cose_basic_example_psa.c
+++ b/examples/t_cose_basic_example_psa.c
@@ -92,7 +92,7 @@ enum t_cose_err_t make_psa_ecdsa_key_pair(int32_t            cose_algorithm_id,
         private_key     = private_key_256;
         private_key_len = sizeof(private_key_256);
         key_type        = PSA_KEY_TYPE_ECC_KEY_PAIR(PSA_ECC_FAMILY_SECP_R1);
-#ifdef PSA_WANT_ALG_DETERMINISTIC_ECDSA
+#if PSA_WANT_ALG_DETERMINISTIC_ECDSA
         key_alg         = PSA_ALG_DETERMINISTIC_ECDSA(PSA_ALG_SHA_256);
 #else
         key_alg         = PSA_ALG_ECDSA(PSA_ALG_SHA_256);
@@ -103,7 +103,7 @@ enum t_cose_err_t make_psa_ecdsa_key_pair(int32_t            cose_algorithm_id,
         private_key     = private_key_384;
         private_key_len = sizeof(private_key_384);
         key_type        = PSA_KEY_TYPE_ECC_KEY_PAIR(PSA_ECC_FAMILY_SECP_R1);
-#ifdef PSA_WANT_ALG_DETERMINISTIC_ECDSA
+#if PSA_WANT_ALG_DETERMINISTIC_ECDSA
         key_alg         = PSA_ALG_DETERMINISTIC_ECDSA(PSA_ALG_SHA_384);
 #else
         key_alg         = PSA_ALG_ECDSA(PSA_ALG_SHA_384);
@@ -114,7 +114,7 @@ enum t_cose_err_t make_psa_ecdsa_key_pair(int32_t            cose_algorithm_id,
         private_key     = private_key_521;
         private_key_len = sizeof(private_key_521);
         key_type        = PSA_KEY_TYPE_ECC_KEY_PAIR(PSA_ECC_FAMILY_SECP_R1);
-#ifdef PSA_WANT_ALG_DETERMINISTIC_ECDSA
+#if PSA_WANT_ALG_DETERMINISTIC_ECDSA
         key_alg         = PSA_ALG_DETERMINISTIC_ECDSA(PSA_ALG_SHA_512);
 #else
         key_alg         = PSA_ALG_ECDSA(PSA_ALG_SHA_512);

--- a/examples/t_cose_basic_example_psa.c
+++ b/examples/t_cose_basic_example_psa.c
@@ -92,21 +92,33 @@ enum t_cose_err_t make_psa_ecdsa_key_pair(int32_t            cose_algorithm_id,
         private_key     = private_key_256;
         private_key_len = sizeof(private_key_256);
         key_type        = PSA_KEY_TYPE_ECC_KEY_PAIR(PSA_ECC_FAMILY_SECP_R1);
+#ifdef PSA_WANT_ALG_DETERMINISTIC_ECDSA
+        key_alg         = PSA_ALG_DETERMINISTIC_ECDSA(PSA_ALG_SHA_256);
+#else
         key_alg         = PSA_ALG_ECDSA(PSA_ALG_SHA_256);
+#endif /* PSA_WANT_ALG_DETERMINISTIC_ECDSA */
         break;
 
     case T_COSE_ALGORITHM_ES384:
         private_key     = private_key_384;
         private_key_len = sizeof(private_key_384);
         key_type        = PSA_KEY_TYPE_ECC_KEY_PAIR(PSA_ECC_FAMILY_SECP_R1);
+#ifdef PSA_WANT_ALG_DETERMINISTIC_ECDSA
+        key_alg         = PSA_ALG_DETERMINISTIC_ECDSA(PSA_ALG_SHA_384);
+#else
         key_alg         = PSA_ALG_ECDSA(PSA_ALG_SHA_384);
+#endif /* PSA_WANT_ALG_DETERMINISTIC_ECDSA */
         break;
 
     case T_COSE_ALGORITHM_ES512:
         private_key     = private_key_521;
         private_key_len = sizeof(private_key_521);
         key_type        = PSA_KEY_TYPE_ECC_KEY_PAIR(PSA_ECC_FAMILY_SECP_R1);
+#ifdef PSA_WANT_ALG_DETERMINISTIC_ECDSA
+        key_alg         = PSA_ALG_DETERMINISTIC_ECDSA(PSA_ALG_SHA_512);
+#else
         key_alg         = PSA_ALG_ECDSA(PSA_ALG_SHA_512);
+#endif /* PSA_WANT_ALG_DETERMINISTIC_ECDSA */
         break;
 
     default:

--- a/test/t_cose_make_psa_test_key.c
+++ b/test/t_cose_make_psa_test_key.c
@@ -81,7 +81,7 @@ enum t_cose_err_t make_key_pair(int32_t            cose_algorithm_id,
         private_key     = private_key_256;
         private_key_len = sizeof(private_key_256);
         key_type        = PSA_KEY_TYPE_ECC_KEY_PAIR(PSA_ECC_FAMILY_SECP_R1);
-#ifdef PSA_WANT_ALG_DETERMINISTIC_ECDSA
+#if PSA_WANT_ALG_DETERMINISTIC_ECDSA
         key_alg         = PSA_ALG_DETERMINISTIC_ECDSA(PSA_ALG_SHA_256);
 #else
         key_alg         = PSA_ALG_ECDSA(PSA_ALG_SHA_256);
@@ -92,7 +92,7 @@ enum t_cose_err_t make_key_pair(int32_t            cose_algorithm_id,
         private_key     = private_key_384;
         private_key_len = sizeof(private_key_384);
         key_type        = PSA_KEY_TYPE_ECC_KEY_PAIR(PSA_ECC_FAMILY_SECP_R1);
-#ifdef PSA_WANT_ALG_DETERMINISTIC_ECDSA
+#if PSA_WANT_ALG_DETERMINISTIC_ECDSA
         key_alg         = PSA_ALG_DETERMINISTIC_ECDSA(PSA_ALG_SHA_384);
 #else
         key_alg         = PSA_ALG_ECDSA(PSA_ALG_SHA_384);
@@ -103,7 +103,7 @@ enum t_cose_err_t make_key_pair(int32_t            cose_algorithm_id,
         private_key     = private_key_521;
         private_key_len = sizeof(private_key_521);
         key_type        = PSA_KEY_TYPE_ECC_KEY_PAIR(PSA_ECC_FAMILY_SECP_R1);
-#ifdef PSA_WANT_ALG_DETERMINISTIC_ECDSA
+#if PSA_WANT_ALG_DETERMINISTIC_ECDSA
         key_alg         = PSA_ALG_DETERMINISTIC_ECDSA(PSA_ALG_SHA_512);
 #else
         key_alg         = PSA_ALG_ECDSA(PSA_ALG_SHA_512);

--- a/test/t_cose_make_psa_test_key.c
+++ b/test/t_cose_make_psa_test_key.c
@@ -81,21 +81,33 @@ enum t_cose_err_t make_key_pair(int32_t            cose_algorithm_id,
         private_key     = private_key_256;
         private_key_len = sizeof(private_key_256);
         key_type        = PSA_KEY_TYPE_ECC_KEY_PAIR(PSA_ECC_FAMILY_SECP_R1);
+#ifdef PSA_WANT_ALG_DETERMINISTIC_ECDSA
+        key_alg         = PSA_ALG_DETERMINISTIC_ECDSA(PSA_ALG_SHA_256);
+#else
         key_alg         = PSA_ALG_ECDSA(PSA_ALG_SHA_256);
+#endif /* PSA_WANT_ALG_DETERMINISTIC_ECDSA */
         break;
 
     case COSE_ALGORITHM_ES384:
         private_key     = private_key_384;
         private_key_len = sizeof(private_key_384);
         key_type        = PSA_KEY_TYPE_ECC_KEY_PAIR(PSA_ECC_FAMILY_SECP_R1);
+#ifdef PSA_WANT_ALG_DETERMINISTIC_ECDSA
+        key_alg         = PSA_ALG_DETERMINISTIC_ECDSA(PSA_ALG_SHA_384);
+#else
         key_alg         = PSA_ALG_ECDSA(PSA_ALG_SHA_384);
+#endif /* PSA_WANT_ALG_DETERMINISTIC_ECDSA */
         break;
 
     case COSE_ALGORITHM_ES512:
         private_key     = private_key_521;
         private_key_len = sizeof(private_key_521);
         key_type        = PSA_KEY_TYPE_ECC_KEY_PAIR(PSA_ECC_FAMILY_SECP_R1);
+#ifdef PSA_WANT_ALG_DETERMINISTIC_ECDSA
+        key_alg         = PSA_ALG_DETERMINISTIC_ECDSA(PSA_ALG_SHA_512);
+#else
         key_alg         = PSA_ALG_ECDSA(PSA_ALG_SHA_512);
+#endif /* PSA_WANT_ALG_DETERMINISTIC_ECDSA */
         break;
 
     case COSE_ALGORITHM_PS256:


### PR DESCRIPTION
Partially solves #157 , only for Mbed TLS with PSA interface.

This PR make t_cose to use deterministic version of ECDSA.
`PSA_ALG_DETERMINISTIC_ECDSA` macro is used instead of `PSA_ALG_ECDSA` if the option `PSA_WANT_ALG_DETERMINISTIC_ECDSA` is enabled.
By default [MBEDTLS_ECDSA_DETERMINISTIC](https://github.com/Mbed-TLS/mbedtls/blob/daa65956c3aabf67146a8535cf1ce081bb878dc0/include/mbedtls/mbedtls_config.h#L747) is defined, so that it is also enabled [here](https://github.com/Mbed-TLS/mbedtls/blob/daa65956c3aabf67146a8535cf1ce081bb878dc0/include/mbedtls/config_psa.h#L606).

The example codes `one_step_sign_example()` and `two_step_sign_example()` in `examples/t_cose_basic_example_psa.c` will produce the same COSE_Sign1 message below, maybe also in your environment.

```
$ ./t_cose_basic_example_psa
Encoded payload (size = 97): 0 (success)
Made EC key with curve prime256v1: 0 (success)
Initialized t_cose and configured signing key
Finished signing: 0 (success)
Completed COSE_Sign1 message:
    172 bytes
    d2 84 43 a1 01 26 a0 58 
    61 a6 69 42 65 69 6e 67 
    54 79 70 65 68 48 75 6d 
    61 6e 6f 69 64 68 47 72 
    65 65 74 69 6e 67 70 57 
    65 20 63 6f 6d 65 20 69 
    6e 20 70 65 61 63 65 68 
    41 72 6d 43 6f 75 6e 74 
    02 69 48 65 61 64 43 6f 
    75 6e 74 01 69 42 72 61 
    69 6e 53 69 7a 65 66 6d 
    65 64 69 75 6d 6b 44 72 
    69 6e 6b 73 57 61 74 65 
    72 f5 58 40 8a 8c 4a 42 
    91 e2 6e 7f bd 25 41 69 
    f5 5f a4 07 1a 3c 7e 70 
    8e 45 66 04 5d 2b 07 b9 
    b1 4c 18 2d 35 bd 26 37 
    3b 27 79 23 cf 10 60 b9 
    9b f2 53 83 25 ae 18 70 
    bc 96 92 9a 3b b4 ba fb 
    79 a0 b3 de 
```