### PR TITLE
Fixes for full #defines fan-out test

### DIFF
--- a/crypto_adapters/t_cose_test_crypto.c
+++ b/crypto_adapters/t_cose_test_crypto.c
@@ -362,6 +362,7 @@ t_cose_crypto_verify_eddsa(struct t_cose_key     verification_key,
     return T_COSE_ERR_UNSUPPORTED_SIGNING_ALG;
 }
 
+#endif /* !T_COSE_DISABLE_EDDSA */
 
 /*
  * See documentation in t_cose_crypto.h
@@ -530,8 +531,6 @@ t_cose_crypto_aead_decrypt(const int32_t          cose_algorithm_id,
 
     return T_COSE_SUCCESS;
 }
-
-#endif /* T_COSE_DISABLE_EDDSA */
 
 
 static const uint8_t rfc_3394_key_wrap_iv[] = {0xa6, 0xa6, 0xa6, 0xa6, 0xa6, 0xa6, 0xa6, 0xa6};

--- a/examples/encryption_examples.c
+++ b/examples/encryption_examples.c
@@ -131,7 +131,7 @@ Done:
 
 
 
-
+#ifndef T_COSE_DISABLE_AES_KW
 #include "t_cose/t_cose_recipient_enc_aes_kw.h"
 #include "t_cose/t_cose_recipient_dec_aes_kw.h"
 
@@ -251,6 +251,7 @@ key_wrap_example(void)
     return (int32_t)err;
 }
 
+#endif /* !T_COSE_DISABLE_AES_KW */
 
 
 #ifndef T_COSE_DISABLE_HPKE

--- a/examples/examples_main.c
+++ b/examples/examples_main.c
@@ -35,7 +35,9 @@ static test_entry s_tests[] = {
     TEST_ENTRY(two_step_sign_example_new_verify),
 
     TEST_ENTRY(encrypt0_example),
+#ifndef T_COSE_DISABLE_AES_KW
     TEST_ENTRY(key_wrap_example),
+#endif /* !T_COSE_DISABLE_AES_KW */
 #ifndef T_COSE_DISABLE_HPKE
     TEST_ENTRY(hpke_example)
 #endif /* !T_COSE_DISABLE_HPKE */

--- a/inc/t_cose/t_cose_sign1_verify.h
+++ b/inc/t_cose/t_cose_sign1_verify.h
@@ -455,7 +455,12 @@ t_cose_sign1_verify_set_auxiliary_buffer(struct t_cose_sign1_verify_ctx *me,
 static inline size_t
 t_cose_sign1_verify_auxiliary_buffer_size(struct t_cose_sign1_verify_ctx *me)
 {
+#ifndef T_COSE_DISABLE_EDDSA
     return t_cose_signature_verify_eddsa_auxiliary_buffer_size(&(me->eddsa_verifier));
+#else
+    (void)me;
+    return 0;
+#endif
 }
 
 #ifdef __cplusplus

--- a/src/t_cose_signature_sign_eddsa.c
+++ b/src/t_cose_signature_sign_eddsa.c
@@ -143,6 +143,6 @@ t_cose_signature_sign_eddsa_init(struct t_cose_signature_sign_eddsa *me)
 
 #else /* !T_COSE_DISABLE_EDDSA */
 
-void t_cose_signature_verify_eddsa_placeholder(void) {}
+void t_cose_signature_sign_eddsa_placeholder(void) {}
 
 #endif /* !T_COSE_DISABLE_EDDSA */

--- a/test/run_tests.c
+++ b/test/run_tests.c
@@ -22,6 +22,7 @@
 #include "t_cose_param_test.h"
 #include "t_cose_crypto_test.h"
 #include "t_cose_encrypt_decrypt_test.h"
+#include "t_cose/t_cose_common.h"
 
 
 /*
@@ -111,10 +112,10 @@ static test_entry s_tests[] = {
     TEST_ENTRY(bad_parameters_test),
 #ifdef TODO_CRIT_PARAM_FIXED
     TEST_ENTRY(crit_parameters_test),
-#endif
+#endif /* TODO_CRIT_PARAM_FIXED */
 #ifndef T_COSE_DISABLE_CONTENT_TYPE
     TEST_ENTRY(content_type_test),
-#endif
+#endif /* !T_COSE_DISABLE_CONTENT_TYPE */
     TEST_ENTRY(all_header_parameters_test),
 #ifdef FIXME /* Issue with key material for this test */
     TEST_ENTRY(cose_example_test),

--- a/test/t_cose_sign_verify_test.c
+++ b/test/t_cose_sign_verify_test.c
@@ -222,7 +222,9 @@ static struct test_case test_cases[] = {
     { T_COSE_ALGORITHM_PS256, { signed_cose_made_by_psa_crypto_ps256, sizeof(signed_cose_made_by_psa_crypto_ps256) } },
     { T_COSE_ALGORITHM_PS384, { signed_cose_made_by_psa_crypto_ps384, sizeof(signed_cose_made_by_psa_crypto_ps384) } },
     { T_COSE_ALGORITHM_PS512, { signed_cose_made_by_psa_crypto_ps512, sizeof(signed_cose_made_by_psa_crypto_ps512) } },
+#ifndef T_COSE_DISABLE_EDDSA
     { T_COSE_ALGORITHM_EDDSA, { signed_cose_made_by_pycose_eddsa, sizeof(signed_cose_made_by_pycose_eddsa) } },
+#endif /* !T_COSE_DISABLE_EDDSA */
     { 0 }, /* Sentinel value with an invalid algorithm id */
 };
 
@@ -810,9 +812,6 @@ int_fast32_t sign_verify_known_good_test(void)
     const struct test_case* tc;
     for (tc = test_cases; tc->cose_algorithm_id != 0; tc++) {
         if (t_cose_is_algorithm_supported(tc->cose_algorithm_id)) {
-            if((1 + tc - test_cases) == 7) {
-                return_value = 9;
-            }
             return_value = known_good_test(tc->cose_algorithm_id,
                                            tc->known_good_message);
             if (return_value) {

--- a/test/t_cose_test.c
+++ b/test/t_cose_test.c
@@ -838,7 +838,7 @@ int_fast32_t all_header_parameters_test()
 
     return 0;
 }
-#endif
+#endif /* !T_COSE_DISABLE_SHORT_CIRCUIT_SIGN */
 
 struct test_case {
     uint32_t           test_option;


### PR DESCRIPTION
This is mostly correctly turning code/tests on/off with the various #defines, but there is one bug fix for signature verification when EdDSA is disabled.