### PR TITLE
Add restartable api, building on crypto context

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,12 +25,14 @@ jobs:
           crypto-provider: MbedTLS
           crypto-provider-version: 'v2.28.0'
           crypto-provider-extra: ''
+          crypto-provider-build-extra: ''
         
         - os-image: ubuntu-latest
           container: ubuntu:20.04
           crypto-provider: MbedTLS
           crypto-provider-version: 'v3.1.0'
           crypto-provider-extra: ''
+          crypto-provider-build-extra: ''
 
         - os-image: ubuntu-latest
           container: ubuntu:20.04
@@ -38,6 +40,21 @@ jobs:
           # crypto-provider-version: 'b489f1e6bcc54ba09730fb7487c2992e03a571a4'
           crypto-provider-version: '9052cf2f1b755938bf8290b7b068ffe21194486f'
           crypto-provider-extra: '-DTEST_HPKE=True'
+          crypto-provider-build-extra: 'make generated_files'
+
+        - os-image: ubuntu-latest
+          container: ubuntu:20.04
+          crypto-provider: MbedTLS
+          crypto-provider-version: 'v3.4.0'
+          crypto-provider-extra: ''
+          crypto-provider-build-extra: ''
+
+        - os-image: ubuntu-latest
+          container: ubuntu:20.04
+          crypto-provider: MbedTLS
+          crypto-provider-version: 'v3.4.0'
+          crypto-provider-extra: ''
+          crypto-provider-build-extra: 'python3 scripts/config.py set MBEDTLS_ECP_RESTARTABLE'
 
         - os-image: ubuntu-latest
           container: ubuntu:20.04
@@ -57,7 +74,7 @@ jobs:
         export DEBIAN_FRONTEND=noninteractive
         apt-get update
         apt-get install -y build-essential cmake python3 ${{ matrix.c-compiler }} \
-                python3-jinja2
+                python3-jinja2 python3-jsonschema
         echo "CC=${{ matrix.c-compiler }}" >> $GITHUB_ENV
     
     - name: Install OpenSSL
@@ -73,19 +90,10 @@ jobs:
         path: mbedtls
 
     - name: Install MbedTLS
-      if: matrix.config.crypto-provider == 'MbedTLS' &&
-          matrix.config.crypto-provider-extra == ''
+      if: matrix.config.crypto-provider == 'MbedTLS'
       run: |
         cd mbedtls
-        make -j $(nproc)
-        make install
-
-    - name: Install MbedTLS
-      if: matrix.config.crypto-provider == 'MbedTLS' &&
-          matrix.config.crypto-provider-extra != ''
-      run: |
-        cd mbedtls
-        make generated_files
+        ${{ matrix.config.crypto-provider-build-extra }}
         make -j $(nproc)
         make install
 
@@ -116,4 +124,15 @@ jobs:
       run: build/t_cose_examples
 
     - name: Run tests
+      if: matrix.config.crypto-provider == 'MbedTLS' &&
+          matrix.config.crypto-provider-version == 'v3.4.0' &&
+          matrix.config.crypto-provider-build-extra == ''
+      # This Mbed TLS version has the option of restartable ECP, however it is
+      # not turned on. In this case the restartable testcase should fail.
+      run: build/t_cose_test | grep 'restart_test_2_step FAILED'
+
+    - name: Run tests
+      if: ${{ ! ( matrix.config.crypto-provider == 'MbedTLS' &&
+              matrix.config.crypto-provider-version == 'v3.4.0' &&
+              matrix.config.crypto-provider-build-extra == '' ) }}
       run: build/t_cose_test

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,6 +70,7 @@ set(T_COSE_SRC_COMMON
     src/t_cose_sign_sign.c
     src/t_cose_mac_compute.c
     src/t_cose_signature_sign_main.c
+    src/t_cose_signature_sign_restart.c
     src/t_cose_signature_sign_eddsa.c
     src/t_cose_sign_verify.c
     src/t_cose_mac_validate.c

--- a/Makefile.common
+++ b/Makefile.common
@@ -2,7 +2,7 @@
 #
 # Copyright (c) 2019-2023, Laurence Lundblade. All rights reserved.
 # Copyright (c) 2020, Michael Eckel, Fraunhofer SIT.
-# Copyright (c) 2022 Arm Limited. All rights reserved.
+# Copyright (c) 2022-2023 Arm Limited. All rights reserved.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 #
@@ -23,6 +23,7 @@ SRC_OBJ=src/t_cose_util.o \
         src/t_cose_sign1_sign.o \
         src/t_cose_sign1_verify.o \
         src/t_cose_signature_sign_main.o \
+        src/t_cose_signature_sign_restart.o \
         src/t_cose_signature_sign_eddsa.o \
         src/t_cose_signature_verify_main.o \
         src/t_cose_signature_verify_eddsa.o \

--- a/crypto_adapters/t_cose_psa_crypto.h
+++ b/crypto_adapters/t_cose_psa_crypto.h
@@ -1,0 +1,27 @@
+/*
+ * t_cose_psa_crypto.h
+ *
+ * Copyright 2022, Laurence Lundblade
+ * Copyright (c) 2023, Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * See BSD-3-Clause license in README.md
+ */
+
+#ifndef t_cose_psa_crypto_h
+#define t_cose_psa_crypto_h
+
+#include <psa/crypto.h>
+
+#define PSA_CRYPTO_HAS_RESTARTABLE_SIGNING \
+    ((MBEDTLS_VERSION_MAJOR == 3 && MBEDTLS_VERSION_MINOR >= 4) || \
+     MBEDTLS_VERSION_MAJOR > 3)
+
+#if PSA_CRYPTO_HAS_RESTARTABLE_SIGNING
+struct t_cose_psa_crypto_context {
+    psa_sign_hash_interruptible_operation_t operation;
+};
+#endif /* PSA_CRYPTO_HAS_RESTARTABLE_SIGNING */
+
+#endif /* t_cose_psa_crypto_h */

--- a/crypto_adapters/t_cose_test_crypto.c
+++ b/crypto_adapters/t_cose_test_crypto.c
@@ -2,7 +2,7 @@
  *  t_cose_test_crypto.c
  *
  * Copyright 2019-2023, Laurence Lundblade
- * Copyright (c) 2022, Arm Limited. All rights reserved.
+ * Copyright (c) 2022-2023, Arm Limited. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *
@@ -17,6 +17,7 @@
 #include "t_cose_test_crypto.h"
 #include "t_cose_util.h"
 
+#define SIGN_ITERATION_COUNT 5
 
 /*
  * This file is stub crypto for initial bring up and test of t_cose.
@@ -167,6 +168,36 @@ t_cose_crypto_sign(int32_t                cose_algorithm_id,
 
 Done:
     return return_value;
+}
+
+/*
+ * See documentation in t_cose_crypto.h
+ */
+enum t_cose_err_t
+t_cose_crypto_sign_restart(bool                   started,
+                           int32_t                cose_algorithm_id,
+                           struct t_cose_key      signing_key,
+                           void                  *crypto_context,
+                           struct q_useful_buf_c  hash_to_sign,
+                           struct q_useful_buf    signature_buffer,
+                           struct q_useful_buf_c *signature)
+{
+    struct t_cose_test_crypto_context *cc = (struct t_cose_test_crypto_context *)crypto_context;
+
+    /* If this is the first iteration */
+    if(!started) {
+        cc->sign_iterations_left = SIGN_ITERATION_COUNT;
+    }
+    if(cc->sign_iterations_left-- > 1) {
+        return T_COSE_ERR_SIG_IN_PROGRESS;
+    }
+
+    return t_cose_crypto_sign(cose_algorithm_id,
+                              signing_key,
+                              crypto_context,
+                              hash_to_sign,
+                              signature_buffer,
+                              signature);
 }
 
 

--- a/crypto_adapters/t_cose_test_crypto.h
+++ b/crypto_adapters/t_cose_test_crypto.h
@@ -2,6 +2,7 @@
  * t_cose_test_crypto.h
  *
  * Copyright 2022, Laurence Lundblade
+ * Copyright (c) 2023, Arm Limited. All rights reserved.
  * Created by Laurence Lundblade on 12/9/22.
  *
  * SPDX-License-Identifier: BSD-3-Clause
@@ -12,11 +13,17 @@
 #ifndef t_cose_test_crypto_h
 #define t_cose_test_crypto_h
 
-/* This is used to test the crypto_context feature. If its
- * value is SUCCESS, then operation is as normal. If it's
- * value is something else, then that error is returned. */
 struct t_cose_test_crypto_context {
+    /* This is used to test the crypto_context feature. If its
+     * value is SUCCESS, then operation is as normal. If it's
+     * value is something else, then that error is returned.
+     */
     enum t_cose_err_t test_error;
+    /* This is used to test the restartable behaviour of t_cose. If its value
+     * is greater than 1 when operating in restartable mode, then
+     * T_COSE_ERR_SIG_IN_PROGRESS is returned instead of T_COSE_SUCCESS.
+     */
+    size_t sign_iterations_left;
 };
 
 #endif /* t_cose_test_crypto_h */

--- a/inc/t_cose/t_cose_common.h
+++ b/inc/t_cose/t_cose_common.h
@@ -610,6 +610,11 @@ enum t_cose_err_t {
 
     /** The HMAC did not successfully verify.  */
     T_COSE_ERR_HMAC_VERIFY = 80,
+
+    /* A signing operation is in progress. The function returning this value
+     * can be called again until it returns \ref T_COSE_SUCCESS or error.
+     */
+    T_COSE_ERR_SIG_IN_PROGRESS = 81,
 };
 
 

--- a/inc/t_cose/t_cose_common.h
+++ b/inc/t_cose/t_cose_common.h
@@ -2,7 +2,7 @@
  * t_cose_common.h
  *
  * Copyright 2019-2023, Laurence Lundblade
- * Copyright (c) 2020-2022, Arm Limited. All rights reserved.
+ * Copyright (c) 2020-2023, Arm Limited. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *
@@ -218,6 +218,25 @@ extern "C" {
 
 /* Definition of struct t_cose_key is moved to t_cose_key.h */
 
+
+/**
+ * The size of the output of SHA-256.
+ *
+ * (It is safe to define these independently here as they are
+ * well-known and fixed. There is no need to reference
+ * platform-specific headers and incur messy dependence.)
+ */
+#define T_COSE_CRYPTO_SHA256_SIZE 32
+
+/**
+ * The size of the output of SHA-384 in bytes.
+ */
+#define T_COSE_CRYPTO_SHA384_SIZE 48
+
+/**
+ * The size of the output of SHA-512 in bytes.
+ */
+#define T_COSE_CRYPTO_SHA512_SIZE 64
 
 // TODO: this may not belong in common.h
 enum t_cose_key_usage_flags {

--- a/inc/t_cose/t_cose_sign_sign.h
+++ b/inc/t_cose/t_cose_sign_sign.h
@@ -3,6 +3,7 @@
  *
  * Copyright (c) 2018-2023, Laurence Lundblade. All rights reserved.
  * Copyright (c) 2020, Michael Eckel
+ * Copyright (c) 2023, Arm Limited. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *
@@ -56,7 +57,7 @@ extern "C" {
 /**
  * The context for creating a \c COSE_Sign1 or \c COSE_Sign message. The
  * allocates it and pass it to the functions here.  At
- * about 40  bytes it fits easily on the stack.
+ * about 44 bytes it fits easily on the stack.
  */
 struct t_cose_sign_sign_ctx {
     /* Private data structure */
@@ -64,6 +65,8 @@ struct t_cose_sign_sign_ctx {
     uint32_t                       option_flags;
     struct t_cose_signature_sign  *signers;
     struct t_cose_parameter       *added_body_parameters;
+    /* Fields related to restartable operation */
+    bool                           started;
 };
 
 

--- a/inc/t_cose/t_cose_signature_main.h
+++ b/inc/t_cose/t_cose_signature_main.h
@@ -1,0 +1,29 @@
+/*
+ * t_cose_signature_main.h
+ *
+ * Copyright (c) 2019-2023, Laurence Lundblade. All rights reserved.
+ * Copyright (c) 2023, Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * See BSD-3-Clause license in README.md
+ */
+
+#ifndef t_cose_signature_main_h
+#define t_cose_signature_main_h
+
+/**
+ * The maximum needed to hold a hash. It is smaller and less stack is needed
+ * if the larger hashes are disabled.
+ */
+#if !defined(T_COSE_DISABLE_ES512) || !defined(T_COSE_DISABLE_PS512)
+    #define T_COSE_MAIN_MAX_HASH_SIZE T_COSE_CRYPTO_SHA512_SIZE
+#else
+    #if !defined(T_COSE_DISABLE_ES384) || !defined(T_COSE_DISABLE_PS384)
+        #define T_COSE_MAIN_MAX_HASH_SIZE T_COSE_CRYPTO_SHA384_SIZE
+    #else
+        #define T_COSE_MAIN_MAX_HASH_SIZE T_COSE_CRYPTO_SHA256_SIZE
+    #endif
+#endif
+
+#endif /* t_cose_signature_main_h */

--- a/inc/t_cose/t_cose_signature_sign_restart.h
+++ b/inc/t_cose/t_cose_signature_sign_restart.h
@@ -1,0 +1,171 @@
+/*
+ * t_cose_signature_sign_restart.h
+ *
+ * Copyright (c) 2022, Laurence Lundblade. All rights reserved.
+ * Copyright (c) 2023, Arm Limited. All rights reserved.
+ * Created by Laurence Lundblade on 5/23/22.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * See BSD-3-Clause license in README.md
+ */
+
+
+#ifndef t_cose_signature_sign_restart_h
+#define t_cose_signature_sign_restart_h
+
+#include "t_cose/t_cose_signature_main.h"
+#include "t_cose/t_cose_signature_sign.h"
+#include "t_cose/t_cose_common.h"
+#include "t_cose/t_cose_parameters.h"
+#include "t_cose/t_cose_key.h"
+
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+
+struct t_cose_signature_sign_restart {
+    /* Private data structure */
+
+    /* t_cose_signer must be the first item for the polymorphism to
+     * work.  This structure, t_cose_signature_sign_restart, will sometimes be
+     * uses as a t_cose_signature_sign.
+     */
+    struct t_cose_signature_sign s;
+
+    /* Mostly specific to ECDSA signing */
+    int32_t                      cose_algorithm_id;
+    struct t_cose_key            signing_key;
+    void                        *crypto_context;
+    struct t_cose_parameter      local_params[2];
+    struct t_cose_parameter     *added_signer_params;
+
+    /*Context for restartable signing. */
+    bool                  started;
+    struct q_useful_buf_c tbs_hash;
+    uint8_t               c_buffer_for_tbs_hash[T_COSE_MAIN_MAX_HASH_SIZE];
+    struct q_useful_buf   buffer_for_tbs_hash;
+    struct q_useful_buf   buffer_for_signature;
+};
+
+
+/*
+ * This signer supports the ECDSA algorithms PS256, PS384 and PS512.
+ */
+void
+t_cose_signature_sign_restart_init(struct t_cose_signature_sign_restart *context,
+                                   int32_t                             cose_algorithm_id);
+
+/*
+ * Set the signing key.
+ */
+static void
+t_cose_signature_sign_restart_set_signing_key(struct t_cose_signature_sign_restart *context,
+                                              struct t_cose_key                   signing_key);
+
+
+/**
+ * \brief  Set the crypto context to be passed to the crypto library..
+ *
+ * \param[in] context The signer context.
+ * \param[in] crypto_context   Pointer to the crypto context.
+ *
+ * The crypto context will be passed down to the crypto adapter
+ * layer. It can be used to configure special features, track special
+ * state or to return information for the crypto library.  The
+ * structure pointed to by the crypto context is specific to the
+ * crypto adapter that is in use. Many crypto adapters don't support
+ * this at all as it is not needed for most use cases.
+ */
+static void
+t_cose_signature_sign_restart_set_crypto_context(struct t_cose_signature_sign_restart *context,
+                                                 void *crypto_context);
+
+
+/* The header parameter for the algorithm ID is generated automatically.
+ *  and should not be added in this list.
+ *
+ * This is for the header parameters that go in the COSE_Signature. See
+ * t_cose_sign_add_body_header_parameters() for the parameters that go in
+ * the COSE_Sign and COSE_Sign1 main body.
+ *
+ * The parameters to add are passed in as an array of t_cose_header_param.
+ * Note that individual parameters in this array can have a call back that does
+ * the encoding, so it is possible to handle complicated parameters, such
+ * as ones that are maps and arrays themselves.
+ */
+static void
+t_cose_signature_sign_restart_set_header_parameter(struct t_cose_signature_sign_restart *context,
+                                                   struct t_cose_parameter   *header_parameters);
+
+
+/* This is how you get the general interface / instance for a signer,
+ * a t_cose_signer, from the specific and concrete instance of a
+ * signer. Because the t_cose_signer is the first member in a
+ * t_cose_ecdsa_signer, the implementation for this is in essence just
+ * a cast and in the end no code is generated.
+ *
+ * t_cose calls signers as follows:
+ *   struct t_cose_signature_sign *signer;
+ *   signer = t_cose_signature_sign_from_restart(me);
+ *
+ *   result = (signer->s.callback)(signer, ....);
+ *
+ * It makes use of the function pointer in signer->s. This callback is
+ * when all the interesting work id done by
+ * t_cose_signature_sign_restart.
+ *
+ */
+static struct t_cose_signature_sign *
+t_cose_signature_sign_from_restart(struct t_cose_signature_sign_restart *me);
+
+
+
+/* =========================================================================
+ * BEGINNING OF PRIVATE INLINE IMPLEMENTATION
+ * =========================================================================
+ */
+
+static inline void
+t_cose_signature_sign_restart_set_signing_key(struct t_cose_signature_sign_restart *context,
+                                              struct t_cose_key                   signing_key)
+{
+    context->signing_key = signing_key;
+}
+
+
+
+static inline struct t_cose_signature_sign *
+t_cose_signature_sign_from_restart(struct t_cose_signature_sign_restart *me)
+{
+    /* Because s is the first item in the t_cose_ecdsa_signer, this
+     * function should compile to nothing. It is here to keep the type
+     * checking safe.
+     */
+    return &(me->s);
+}
+
+
+static inline void
+t_cose_signature_sign_restart_set_header_parameter(struct t_cose_signature_sign_restart *me,
+                                                   struct t_cose_parameter   *header_parameters)
+{
+    me->added_signer_params = header_parameters;
+}
+
+
+static inline void
+t_cose_signature_sign_restart_set_crypto_context(struct t_cose_signature_sign_restart *me,
+                                                 void *crypto_context)
+{
+    me->crypto_context = crypto_context;
+}
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* t_cose_signature_sign_restart_h */

--- a/src/t_cose_crypto.h
+++ b/src/t_cose_crypto.h
@@ -267,6 +267,43 @@ t_cose_crypto_sign(int32_t                cose_algorithm_id,
 
 
 /**
+ * \brief Perform public key signing in a restartable manner. Part of the t_cose
+ * crypto adaptation layer.
+ *
+ * \param[in] started           If false, then this is the first call of a
+ *                              signing operation. If it is true, this is a
+ *                              subsequent call.
+ *
+ * \retval T_COSE_ERR_SIG_IN_PROGRESS
+ *         Signing is in progress, the function needs to be called again with
+ *         the same parameters.
+ *
+ * For other parameters and possible return values and general description see
+ * t_cose_crypto_sign.
+ *
+ * To complete a signing operation this function needs to be called multiple
+ * times. For a signing operation the first call to this function must happen
+ * with \c started == false, and all subsequent calls for this signing operation
+ * must happen with \c started == true. When the return value is
+ * \c T_COSE_ERR_SIG_IN_PROGRESS the data in the output parameters is undefined.
+ * The function must be called again (and again...) until \c T_COSE_SUCCESS or
+ * an error is returned.
+ *
+ * Note that this function is only implemented if the crypto adapter supports
+ * restartable operation, and even in that case it might not be available for
+ * all algorithms.
+ */
+enum t_cose_err_t
+t_cose_crypto_sign_restart(bool                   started,
+                           int32_t                cose_algorithm_id,
+                           struct t_cose_key      signing_key,
+                           void                  *crypto_context,
+                           struct q_useful_buf_c  hash_to_sign,
+                           struct q_useful_buf    signature_buffer,
+                           struct q_useful_buf_c *signature);
+
+
+/**
  * \brief Perform public key signature verification. Part of the
  * t_cose crypto adaptation layer.
  *

--- a/src/t_cose_crypto.h
+++ b/src/t_cose_crypto.h
@@ -83,8 +83,6 @@ extern "C" {
  * - Support for a new T_COSE_ALGORITHM_XXX signature algorithm
  *    - See t_cose_algorithm_is_ecdsa()
  *    - If not ECDSA add another function like t_cose_algorithm_is_ecdsa()
- * - Support for a new T_COSE_ALGORITHM_XXX signature algorithm is added
- *    - See \ref T_COSE_CRYPTO_MAX_HASH_SIZE for additional hashes
  * - Support another hash implementation that is not a service
  *    - See struct \ref t_cose_crypto_hash
  *
@@ -525,25 +523,6 @@ struct t_cose_crypto_hmac {
 };
 
 /**
- * The size of the output of SHA-256.
- *
- * (It is safe to define these independently here as they are
- * well-known and fixed. There is no need to reference
- * platform-specific headers and incur messy dependence.)
- */
-#define T_COSE_CRYPTO_SHA256_SIZE 32
-
-/**
- * The size of the output of SHA-384 in bytes.
- */
-#define T_COSE_CRYPTO_SHA384_SIZE 48
-
-/**
- * The size of the output of SHA-512 in bytes.
- */
-#define T_COSE_CRYPTO_SHA512_SIZE 64
-
-/**
  * Size of the signature (tag) output for the HMAC-SHA256.
  */
 #define T_COSE_CRYPTO_HMAC256_TAG_SIZE   T_COSE_CRYPTO_SHA256_SIZE
@@ -572,20 +551,6 @@ struct t_cose_crypto_hmac {
  * holding a key. It is set at 200, far above what is needed to be generous and because
  * 200 bytes isn't very much. */
 #define T_COSE_CRYPTO_HMAC_MAX_KEY 200
-
-/**
- * The maximum needed to hold a hash. It is smaller and less stack is needed
- * if the larger hashes are disabled.
- */
-#if !defined(T_COSE_DISABLE_ES512) || !defined(T_COSE_DISABLE_PS512)
-    #define T_COSE_CRYPTO_MAX_HASH_SIZE T_COSE_CRYPTO_SHA512_SIZE
-#else
-    #if !defined(T_COSE_DISABLE_ES384) || !defined(T_COSE_DISABLE_PS384)
-        #define T_COSE_CRYPTO_MAX_HASH_SIZE T_COSE_CRYPTO_SHA384_SIZE
-    #else
-        #define T_COSE_CRYPTO_MAX_HASH_SIZE T_COSE_CRYPTO_SHA256_SIZE
-    #endif
-#endif
 
 
 /**

--- a/src/t_cose_sign_sign.c
+++ b/src/t_cose_sign_sign.c
@@ -2,6 +2,7 @@
  * t_cose_sign_sign.c
  *
  * Copyright (c) 2018-2023, Laurence Lundblade. All rights reserved.
+ * Copyright (c) 2023, Arm Limited. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *
@@ -168,6 +169,12 @@ t_cose_sign_encode_finish(struct t_cose_sign_sign_ctx *me,
          * as a byte string to the CBOR encode context.
          */
         return_value = signer->sign1_cb(signer, &sign_inputs, cbor_encoder);
+        if(return_value == T_COSE_ERR_SIG_IN_PROGRESS) {
+            me->started = true;
+        } else {
+            /* Reset the started value to enable reuse of the context */
+            me->started = false;
+        }
     }
     if(return_value != T_COSE_SUCCESS) {
         goto Done;

--- a/src/t_cose_signature_sign_main.c
+++ b/src/t_cose_signature_sign_main.c
@@ -2,6 +2,7 @@
  * t_cose_signature_sign_main.c
  *
  * Copyright (c) 2023, Laurence Lundblade. All rights reserved.
+ * Copyright (c) 2023, Arm Limited. All rights reserved.
  * Created by Laurence Lundblade on 5/23/22.
  *
  * SPDX-License-Identifier: BSD-3-Clause
@@ -11,6 +12,7 @@
 
 #include "qcbor/qcbor_encode.h"
 #include "t_cose/q_useful_buf.h"
+#include "t_cose/t_cose_signature_main.h"
 #include "t_cose/t_cose_signature_sign_main.h"
 #include "t_cose/t_cose_signature_sign.h"
 #include "t_cose/t_cose_common.h"
@@ -46,7 +48,7 @@ t_cose_signature_sign1_main_cb(struct t_cose_signature_sign     *me_x,
     struct t_cose_signature_sign_main *me =
                                      (struct t_cose_signature_sign_main *)me_x;
     enum t_cose_err_t           return_value;
-    Q_USEFUL_BUF_MAKE_STACK_UB( buffer_for_tbs_hash, T_COSE_CRYPTO_MAX_HASH_SIZE);
+    Q_USEFUL_BUF_MAKE_STACK_UB( buffer_for_tbs_hash, T_COSE_MAIN_MAX_HASH_SIZE);
     struct q_useful_buf         buffer_for_signature;
     struct q_useful_buf_c       tbs_hash;
     struct q_useful_buf_c       signature;

--- a/src/t_cose_signature_sign_restart.c
+++ b/src/t_cose_signature_sign_restart.c
@@ -1,0 +1,138 @@
+/*
+ * t_cose_signature_sign_restart.c
+ *
+ * Copyright (c) 2023, Laurence Lundblade. All rights reserved.
+ * Copyright (c) 2023, Arm Limited. All rights reserved.
+ * Created by Laurence Lundblade on 5/23/22.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * See BSD-3-Clause license in README.md
+ */
+
+#include "qcbor/qcbor_encode.h"
+#include "t_cose/q_useful_buf.h"
+#include "t_cose/t_cose_signature_sign_restart.h"
+#include "t_cose/t_cose_signature_sign.h"
+#include "t_cose/t_cose_common.h"
+#include "t_cose/t_cose_parameters.h"
+#include "t_cose_util.h"
+#include "t_cose_crypto.h"
+
+
+/** This is an implementation of \ref t_cose_signature_sign_headers_cb */
+static void
+t_cose_signature_sign_headers_restart_cb(struct t_cose_signature_sign   *me_x,
+                                         struct t_cose_parameter       **params)
+{
+    struct t_cose_signature_sign_restart *me =
+                                (struct t_cose_signature_sign_restart *)me_x;
+
+    me->local_params[0] = t_cose_param_make_alg_id(me->cose_algorithm_id);
+
+    *params = me->local_params;
+}
+
+
+/** This is an implementation of \ref t_cose_signature_sign_cb */
+static enum t_cose_err_t
+t_cose_signature_sign1_restart_cb(struct t_cose_signature_sign     *me_x,
+                                  const struct t_cose_sign_inputs *sign_inputs,
+                                  QCBOREncodeContext              *qcbor_encoder)
+{
+    struct t_cose_signature_sign_restart *me =
+                                     (struct t_cose_signature_sign_restart *)me_x;
+    enum t_cose_err_t           return_value;
+    struct q_useful_buf_c       signature;
+    bool                        do_signing_step = true;
+
+    if(!me->started) {
+        me->buffer_for_tbs_hash.ptr = me->c_buffer_for_tbs_hash;
+        me->buffer_for_tbs_hash.len = sizeof(me->c_buffer_for_tbs_hash);
+
+        /* The signature gets written directly into the output buffer.
+         * The matching QCBOREncode_CloseBytes call further down still
+         * needs do a memmove to make space for the CBOR header, but
+         * at least we avoid the need to allocate an extra buffer.
+         */
+        QCBOREncode_OpenBytes(qcbor_encoder, &(me->buffer_for_signature));
+
+        if(QCBOREncode_IsBufferNULL(qcbor_encoder)) {
+            /* Size calculation mode */
+            signature.ptr = NULL;
+            t_cose_crypto_sig_size(me->cose_algorithm_id,
+                                   me->signing_key,
+                                   &signature.len);
+
+            return_value = T_COSE_SUCCESS;
+            do_signing_step = false;
+
+        } else {
+            /* Run the crypto to produce the signature */
+
+            /* Create the hash of the to-be-signed bytes. Inputs to the
+             * hash are the protected parameters, the payload that is
+             * getting signed, the cose signature alg from which the hash
+             * alg is determined. The cose_algorithm_id was checked in
+             * t_cose_sign_init() so it doesn't need to be checked here.
+             */
+            return_value = create_tbs_hash(me->cose_algorithm_id,
+                                           sign_inputs,
+                                           me->buffer_for_tbs_hash,
+                                           &me->tbs_hash);
+            if(return_value) {
+                goto Done;
+            }
+        }
+    }
+
+    if(do_signing_step) {
+        return_value = t_cose_crypto_sign_restart(
+                    me->started,
+                    me->cose_algorithm_id,
+                    me->signing_key,
+                    me->crypto_context,
+                    me->tbs_hash,
+                    me->buffer_for_signature,
+                    &signature);
+        if(return_value == T_COSE_ERR_SIG_IN_PROGRESS) {
+            me->started = true;
+            goto Done;
+        } else {
+            /* Reset the started value to enable reuse of the context */
+            me->started = false;
+        }
+    }
+
+    QCBOREncode_CloseBytes(qcbor_encoder, signature.len);
+
+Done:
+    return return_value;
+}
+
+
+/** This is an implementation of \ref t_cose_signature_sign1_cb */
+static enum t_cose_err_t
+t_cose_signature_sign_restart_cb(struct t_cose_signature_sign  *me_x,
+                              struct t_cose_sign_inputs     *sign_inputs,
+                              QCBOREncodeContext            *qcbor_encoder)
+{
+    (void)me_x;
+    (void)sign_inputs;
+    (void)qcbor_encoder;
+
+    return T_COSE_ERR_FAIL;
+}
+
+
+void
+t_cose_signature_sign_restart_init(struct t_cose_signature_sign_restart *me,
+                                   const int32_t               cose_algorithm_id)
+{
+    memset(me, 0, sizeof(*me));
+    me->s.rs.ident        = RS_IDENT(TYPE_RS_SIGNER, 'M');
+    me->s.headers_cb      = t_cose_signature_sign_headers_restart_cb;
+    me->s.sign_cb         = t_cose_signature_sign_restart_cb;
+    me->s.sign1_cb        = t_cose_signature_sign1_restart_cb;
+    me->cose_algorithm_id = cose_algorithm_id;
+}

--- a/src/t_cose_signature_verify_main.c
+++ b/src/t_cose_signature_verify_main.c
@@ -2,6 +2,7 @@
  * t_cose_signature_verify_main.c
  *
  * Copyright (c) 2022-2023, Laurence Lundblade. All rights reserved.
+ * Copyright (c) 2023, Arm Limited. All rights reserved.
  * Created by Laurence Lundblade on 7/19/22.
  *
  * SPDX-License-Identifier: BSD-3-Clause
@@ -11,6 +12,7 @@
 
 #include "qcbor/qcbor_decode.h"
 #include "qcbor/qcbor_spiffy_decode.h"
+#include "t_cose/t_cose_signature_main.h"
 #include "t_cose/t_cose_signature_verify_main.h"
 #include "t_cose/t_cose_signature_verify.h"
 #include "t_cose/t_cose_parameters.h"
@@ -88,7 +90,7 @@ t_cose_signature_verify1_main_cb(struct t_cose_signature_verify   *me_x,
     int32_t                      cose_algorithm_id;
     enum t_cose_err_t            return_value;
     struct q_useful_buf_c        kid;
-    Q_USEFUL_BUF_MAKE_STACK_UB(  tbs_hash_buffer, T_COSE_CRYPTO_MAX_HASH_SIZE);
+    Q_USEFUL_BUF_MAKE_STACK_UB(  tbs_hash_buffer, T_COSE_MAIN_MAX_HASH_SIZE);
     struct q_useful_buf_c        tbs_hash;
 
     (void)kid;

--- a/src/t_cose_util.c
+++ b/src/t_cose_util.c
@@ -51,7 +51,7 @@ hash_alg_id_from_sig_alg_id(int32_t cose_algorithm_id)
     /* If other hashes, particularly those that output bigger hashes
      * are added here, various other parts of this code have to be
      * changed to have larger buffers, in particular
-     * \ref T_COSE_CRYPTO_MAX_HASH_SIZE.
+     * \ref T_COSE_XXX_MAX_HASH_SIZE.
      */
     // TODO: allows disabling ES256
 

--- a/test/run_tests.c
+++ b/test/run_tests.c
@@ -71,7 +71,7 @@ static test_entry s_tests[] = {
     TEST_ENTRY(sign_verify_unsupported_test),
     TEST_ENTRY(sign_verify_bad_auxiliary_buffer),
     TEST_ENTRY(verify_multi_test),
-
+    TEST_ENTRY(restart_test_2_step),
 #endif /* T_COSE_DISABLE_SIGN1 */
 
     // TODO: should these really be conditional on T_COSE_DISABLE_SIGN_VERIFY_TESTS

--- a/test/t_cose_make_test_messages.c
+++ b/test/t_cose_make_test_messages.c
@@ -2,6 +2,7 @@
  * t_cose_make_test_messages.c
  *
  * Copyright (c) 2019-2022, Laurence Lundblade. All rights reserved.
+ * Copyright (c) 2023, Arm Limited. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *
@@ -12,6 +13,7 @@
 #include "qcbor/qcbor.h"
 #include "t_cose_crypto.h"
 #include "t_cose_util.h"
+#include "t_cose/t_cose_signature_main.h"
 
 
 /**
@@ -444,7 +446,7 @@ t_cose_sign1_test_message_output_signature(struct t_cose_sign1_sign_ctx *me,
     /* Pointer and length of the buffer for the signature */
     struct q_useful_buf          buffer_for_signature;
     /* Buffer for the tbs hash. */
-    Q_USEFUL_BUF_MAKE_STACK_UB(  buffer_for_tbs_hash, T_COSE_CRYPTO_MAX_HASH_SIZE);
+    Q_USEFUL_BUF_MAKE_STACK_UB(  buffer_for_tbs_hash, T_COSE_MAIN_MAX_HASH_SIZE);
     struct q_useful_buf_c        signed_payload;
     struct t_cose_sign_inputs           sign_inputs;
 

--- a/test/t_cose_sign_verify_test.h
+++ b/test/t_cose_sign_verify_test.h
@@ -2,6 +2,7 @@
  *  t_cose_sign_verify_test.h
  *
  * Copyright 2019, 2022, Laurence Lundblade
+ * Copyright (c) 2023, Arm Limited. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *
@@ -74,5 +75,10 @@ int_fast32_t sign_verify_multi(void);
 
 int32_t verify_multi_test(void);
 
+
+/*
+ * Test restartable behaviour
+ */
+int_fast32_t restart_test_2_step(void);
 
 #endif /* t_cose_sign_verify_test_h */


### PR DESCRIPTION
This PR adds the functionality to sign a token in a restartable manner (see https://tls.mbed.org/kb/development/restartable-ecc)

This PR replaces an [old PR](https://github.com/laurencelundblade/t_cose/pull/70), that was opened in 2022. Opening a new seemed to be the right thing to do because:
- This one builds on the crypto context concept, that is only available on the dev branch
- Since the previous Pull request restartable operation become available in the PSA Crypto API in Mbed TLS, so there is no need to add a new Crypto adapter to have this functionality.

The motivation for this PR is that for a supervisory software, that runs at an uninterruptible priority level, and generates an attestation token, It can be unacceptable to not respond for the entire process of signing.

This PR adds new API to t_cose to call signing in a restartable manner. For a certain crypto adapter it is possible to not implement the restartable behaviour. A new error code is added that can be returned by the implementation, if it is not supported.

I tried to break up the change to logical blocks, to keep the commit size reasonable. All the commits pass all the tests, and keep t_cose in a working state. 

Some additional notes to the PR:
- The restartable API is not released yet in Mbed TLS, it is currently available on the developement branch.
- I haven't touched documentation files , I can add documentation in an additional commit, if the code changes are accepted at least on the concept level.
- The restartable mode is not conditionally compiled, and it might add extra data on the stack (though I didn't measure exactly how much). I can add `ifdef`s to enable conditional compiling if necessary.