### PR TITLE
Aligning with -04 version of draft.

### DIFF
--- a/inc/t_cose/t_cose_standard_constants.h
+++ b/inc/t_cose/t_cose_standard_constants.h
@@ -136,16 +136,14 @@
  */
 
 /**
- * \def T_COSE_HEADER_ALG_PARAM_EPHEMERAL_KEY
+ * \def T_COSE_HEADER_ALG_PARAM_HPKE_SENDER_INFO
  *
- * \brief CBOR map label of header algorithm parameter containing
- *        an ephemeral key.
- *
- * A COSE_Key structure containing the ephemeral key.
+ * \brief CBOR label of header algorithm parameter containing
+ *        the HPKE_sender_info structure.
  *
  * This implementation only supports a subset of the available algorithms.
  */
-#define T_COSE_HEADER_ALG_PARAM_EPHEMERAL_KEY -1
+#define T_COSE_HEADER_ALG_PARAM_HPKE_SENDER_INFO -4
 
 /* ------------- COSE Algorithms ----------------------------
  * https://www.iana.org/assignments/cose/cose.xhtml#algorithms
@@ -157,6 +155,19 @@
  */
 #define T_COSE_ALGORITHM_RESERVED 0
 
+
+/**
+ * \def T_COSE_ALGORITHM_HPKE_v1_BASE
+ *
+ * \brief Indicates use of HPKE in base mode (version 1).
+ *
+ * Value for \ref T_COSE_HEADER_PARAM_ALG to indicate HPKE usage.
+ *
+ * The HPKE functionality for COSE is specified in draft-ietf-cose-hpke.
+ *
+ * See https://datatracker.ietf.org/doc/html/draft-ietf-cose-hpke
+ */
+#define T_COSE_ALGORITHM_HPKE_v1_BASE  -1
 
 /**
  * \def T_COSE_ALGORITHM_ES256
@@ -582,7 +593,6 @@
  * secp521r1.
  */
 #define T_COSE_ELLIPTIC_CURVE_P_521 3
-
 
 
 


### PR DESCRIPTION
Initial contribution for the IETF#116 hackathon. Updated encryption and decryption functionality for HPKE based on draft version -04. 

Todo's:

* Remove T_COSE_ALGORITHM_HPKE_P256_HKDF256_AES128_GCM and T_COSE_ALGORITHM_HPKE_P521_HKDF512_AES256_GCM from t_cose_standard_constants.h. 

* Change the APIs to use the combination of kem_id, kdf_id and aead_id instead of the cose_algorithm_id. This will remove the need to map algorithms.

* Extend functions to allow additional data to be incorporated.

* Add HPKE functionality for COSE_Encrypt0.

