### PR TITLE
first multi-sig verify test passing

### DIFF
--- a/inc/t_cose/t_cose_common.h
+++ b/inc/t_cose/t_cose_common.h
@@ -541,7 +541,10 @@ enum t_cose_err_t {
 
     T_COSE_ERR_NO_VERIFIERS = 66,
 
-    /* A verifier declined to verify a COSE_Signature for a reason other
+    /* When \ref T_COSE_OPT_VERIFY_ALL_SIGNATURES is requested, one of the
+     * signatures could not be verified because no verifier was configured
+     * to handle it, typically because there was not verify for the algorithm.
+     * Also returned by a verifier when it declines to verify a COSE_Signature for a reason other
      * than algorithm ID or kid. */
     T_COSE_ERR_DECLINE = 67,
 

--- a/inc/t_cose/t_cose_parameters.h
+++ b/inc/t_cose/t_cose_parameters.h
@@ -239,10 +239,10 @@ struct t_cose_parameter {
 
     /** The value of the parameter. */
     union {
-        int64_t               int64;
-        struct q_useful_buf_c string;
+        int64_t                            int64;
+        struct q_useful_buf_c              string;
         struct t_cose_special_param_encode special_encode;
-        struct t_cose_special_param_decode  special_decode;
+        struct t_cose_special_param_decode special_decode;
     } value;
 
     /** next parameter in the linked list or NULL at the end of the list. */

--- a/inc/t_cose/t_cose_parameters.h
+++ b/inc/t_cose/t_cose_parameters.h
@@ -29,17 +29,17 @@ extern "C" {
  *
  * @brief Parameter encoding and decoding.
  *
- * Parameter encoding and decoding hinges around \ref t_cose_parameter
+ * Parameter encoding and decoding centers on \ref t_cose_parameter
  * and functions for encoding and decoding linked lists of it. Users
  * of the t_cose public APIs for verifying signing, encrypting,
  * decrypting and MACing will mainly use struct t_cose_parameter, not
  * the encoding and decoding functions.
  *
- * Struct \ref t_cose_parameter holds a single header parameter that
+ * Struct \ref t_cose_parameter holds a single parameter that
  * is to be encoded or has been decoded. The same structure is used
  * for both. Most parameter values are either integers or strings and
  * are held directly in struct t_cose_parameter. Parameters that are
- * not integer or strings are special and must be encoded or decoded
+ * not integers or strings are special and must be encoded or decoded
  * by a callback. "Special" here is only a characteristic of t_cose
  * not anything in the COSE standard.
  *
@@ -50,7 +50,7 @@ extern "C" {
  * this file.
  *
  * When decoding a COSE message (verification, decryption, ...) the
- * full set of header parameters decoded are returned as an array of
+ * full set of header parameters decoded are returned as linked list of
  * struct t_cose_parameter. In many cases the caller will not need to
  * examine what is returned.
  *
@@ -64,26 +64,34 @@ extern "C" {
  * parameter.
  *
  * Some COSE messages, COSE_Sign1, COSE_Mac0 and COSE_Encrypt0 have
- * just one set of headers those for the main body. The other
- * messages, COSE_Sign, COSE_Encrypt and COSE_Mac have body headers
+ * just one set of headers, those for the main body.  Other
+ * messages, COSE_Sign, COSE_Encrypt and COSE_Mac, have body headers
  * and additionally headers per recipient or signer. The data
- * structures and functions here handle all of those cases.
+ * structures and functions here handle all of these.
  *
- * When encoding, the multiple header sets are handled in the
+ * When encoding, multiple header sets are handled in the
  * interface for signing, encrypting and such. There are separate
  * functions for passing in the body header and the header per signer
  * and per recipient.
  *
- * When decoding all the headers for the entire message are returned
- * in one list. The caller can know which parameters are for the body and
- * an index number for the recipient or signer. Even the nesting of
- * recipients within recipients is indicated.
+ * When decoding, all the headers for the entire message are returned
+ * in one list. Each bucket of headers is assigned a location
+ * (t_cose_header_location) that indicates nesting level and
+ * index in the COSE message.
  *
- * The APIs for decoding here don't allocate any storage for decoded
- * parameters, but the callers of these APIs need to.  A convention is
- * for the decoder (verifier, decryptor,...) context to contain
- * storage for a moderate number of parameters so those APIs are
- * simpler to use for the caller.
+ * The nodes for the linked lists are allocated out of a pool that
+ * is represented by t_cose_parameter_storage. It is a very
+ * simple allocation scheme that takes nodes out of the pool
+ * as the COSE message is decoded. There is not a
+ * free operation. The whole pool is just destroyed when
+ * all processing on a COSE message is complete. The
+ * actual memory for the pool can be allocated by any
+ * means, but it is allocated all at once up front.
+ *
+ * Each message decoder (e.g., verifier, decryptor) has
+ * a small pool built into their context that is enough
+ * for simple message. A larger pool can be added
+ * for complex messages with lots of parameters.
  */
 
 /**
@@ -135,26 +143,42 @@ t_cose_special_param_encode_cb(const struct t_cose_parameter  *parameter,
 
 
 /**
- * \brief Type of callback to decode the QCBOR of a special parameter.
+ * \brief Type of callback to decode a special parameter.
  *
  * \param[in] cb_context  Context for callback.
  * \param[in] cbor_decoder     QCBOR decoder to pull from.
  * \param[in,out] parameter     On input, label and other. On output
  *                              the decoded value.
+ * \retval T_COSE_SUCCESS -- Decoded and input consumed
+ * \retval T_COSE_DECLINE -- Not decoded and input was NOT consumed
+ * \retval Any other error will stop the decode and return that error up to top-level message decode.
  *
  * This is called back from t_cose_decode_headers() when a parameter
- * that is not an integer or string is encountered. The callback must
- * consume all the CBOR that makes up the particular parameter and no
- * more.
+ * that is not an integer or string is encountered.
  *
  * On input, the label, protected, critical and value_type are set
  * based on peeking at the first data item in the header. The value is
- * not set.
+ * not set and none of the items in the parameter have been consumed.
  *
- * On exit, this function must set the value_type and the value.
+ * A callback can decided not to process the parameter by checking
+ * the parameter label and such passed in. If it ia not to be process return \ref T_COSE_ERR_DECLINE.
+ * The parameter will be ignored. If a critical parameter
+ * is declined, this will be noticed and the COSE message processing
+ * will error out with \ref T_COSE_ERR_UNKNOWN_CRITICAL_PARAMETER.
  *
- * Unlike t_cose_special_param_encode_cb() there is just one
- * implementation of this that switches on the label.
+ * For a successful decode, all of the CBOR items for the parameter must
+ * be consumed from the cbor decoder. T_COSE_SUCCESS should be
+ * returned. The decoded value(s) is(are)  put into \c parameter.value.
+ * Any of the the members of \c parameter.value may be used,
+ * particularly \c parameter.value.special_decode.
+ *
+ * For an unsuccesful decode return an appropriate error like
+ * T_COSE_ERR_NOT_WELL_FORMED. It will halt processing
+ * of the message flow and be returned to the top level call.
+ *
+ * Unlike t_cose_special_param_encode_cb() only one of these may be set.
+ * Implementation of this switche on the label to know which parameter
+ * to output.
  */
 typedef enum t_cose_err_t
 t_cose_special_param_decode_cb(void                    *cb_context,
@@ -178,8 +202,7 @@ struct t_cose_special_param_encode {
 
 
 struct t_cose_special_param_decode {
-    enum {SP_DECODED, SP_ERR, SP_NOT_DECODED} status;
-    /** Decoder callbacks can use any one of these types that
+    /** Decoder callbacks of type t_cose_special_param_encode_cb can use any one of these types that
      * they see fit. The variety is for the convenience of the
      * decoder callback. */
     union {
@@ -201,6 +224,7 @@ struct t_cose_header_location {
      * starting from 0. */
     uint8_t  index;
 };
+
 
 /**
  * This holds one parameter such as an algorithm ID or kid. When that
@@ -267,6 +291,10 @@ struct t_cose_parameter {
 
 
 /**
+ * This is primarily for backwards compatibility with t_cose v1. Instead
+ * use the linked list of parameters returned and functions like
+ * t_cose_find_parameter_alg_id().
+ *
  * This holds the common header parameters defined in section 3 of RFC
  * 9052. It was the only way that parameters were returned in t_cose
  * 1.x which did not support any parameters but these. For t_cose 2.x
@@ -343,22 +371,24 @@ struct t_cose_parameter_storage {
  * \param[out] protected_parameters  Place to put pointer and length of
  *                                   encoded protected headers. May be NULL.
  *
+ * For most COSE message creation (e.g., signing a COSE_Sign1), this is not
+ * needed. It use is more for implementors of t_cose_signature_sign.
+ *
  * This encodes COSE "Headers" that are used in COSE_Sign, COSE_Sign1,
  * COSE_Signature, COSE_Encrypt, COSE_Encrypt0, COSE_Mac, COSE_Mac0
  * and COSE_Recipient.
  *
  * The input to this is a linked list of struct t_cose_parameter containing
  * both protected and unprotected header parameters. They will be
- * encoded and output to the encoder context into first the protected
- * header bucket and then the unprotected header bucket.
+ * encoded and output to the CBOR encoder context first into the protected
+ * header bucket and second the unprotected header bucket.
  *
- * The input set is a linked list through the "next" member
- * of struct t_cose_parameter and ends with a NULL pointer.
+ * The input set is a linked list through the \c next member
+ * of struct t_cose_parameter and ends with a \c NULL pointer.
  *
- * t_cose_parameter.protected indicated whether the parameter should
+ * \c t_cose_parameter.protected indicates whether the parameter should
  * go into the protected or unprotected bucket. The order of the
- * parameters in the input doesn't matter as to whether the protected
- * parameters go first or not.
+ * parameters in the input doesn't matter.
  *
  * Each parameter has a label, data type and value.  Only integer
  * label types are supported (so far). Most header parameters will be
@@ -388,7 +418,7 @@ t_cose_headers_encode(QCBOREncodeContext            *cbor_encoder,
 
 
 /**
- * \brief Decode both protected and unprotected header buckets.
+ * \brief Decode protected and unprotected header buckets.
  *
  * \param[in] cbor_decoder           QCBOR decoder to decode from.
  * \param[in] location               Location in message of the parameters.
@@ -396,9 +426,13 @@ t_cose_headers_encode(QCBOREncodeContext            *cbor_encoder,
  *                                   non-string parameters.
  * \param[in] special_decode_ctx      Context for the above callback
  * \param[in] parameter_storage      Storage for parameters.
- * \param[in,out] decoded_params        Parameter list to append to.
+ * \param[in,out] decoded_params        Pointer to parameter list to append to or to  \c NULL.
  * \param[out] protected_parameters  Pointer and length of encoded protected
  *                                   parameters.
+ *
+ * For most COSE message decoding (e.g. verification of a COSE_SIgn1), this
+ * is not needed. This is mainly used by implemention of a new
+ * \c t_cose_signature_verify or \c t_cose_recipient_decrypt.
  *
  * Use this to decode "Headers" that occurs throughout COSE. The QCBOR
  * decoder should be positioned so the protected header bucket is the
@@ -407,8 +441,8 @@ t_cose_headers_encode(QCBOREncodeContext            *cbor_encoder,
  *
  * The decoded headers are put into a linked list the
  * nodes for which are allocated out of \c parameter_storage.
- * They are appended to the list in \c *decoded_params which
- * may be \c NULL.
+ * They are appended to the list in \c *decoded_params. It may
+ * be an empty list (e.g., \c NULL) or a linked list to append to.
  *
  * The number of parameters in the crititical parameters parameter is
  * limited to \ref T_COSE_MAX_CRITICAL_PARAMS for each bucket of
@@ -431,13 +465,13 @@ t_cose_headers_encode(QCBOREncodeContext            *cbor_encoder,
  * and non-critical parameters will be ignored.
  */
 enum t_cose_err_t
-t_cose_headers_decode(QCBORDecodeContext                *cbor_decoder,
+t_cose_headers_decode(QCBORDecodeContext                 *cbor_decoder,
                       const struct t_cose_header_location location,
-                      t_cose_special_param_decode_cb    *special_decode_cb,
-                      void                              *special_decode_ctx,
-                      struct t_cose_parameter_storage   *parameter_storage,
-                      struct t_cose_parameter          **decoded_params,
-                      struct q_useful_buf_c             *protected_parameters);
+                      t_cose_special_param_decode_cb     *special_decode_cb,
+                      void                               *special_decode_ctx,
+                      struct t_cose_parameter_storage    *parameter_storage,
+                      struct t_cose_parameter           **decoded_params,
+                      struct q_useful_buf_c              *protected_parameters);
 
 
 
@@ -449,11 +483,11 @@ t_cose_headers_decode(QCBORDecodeContext                *cbor_decoder,
  *                            added to the end or a pointer to \c NULL.
  * \param[in] to_be_appended  A parameter link list which is to added.
  *
- * If \c *existing is not \c NULL, this finds the end of \c existing and sets the \c next member in
+ * If \c *existing is not \c NULL, this finds the end of \c *existing and sets the \c next member in
  * the last node to \c to_be_appended. If it is \c NULL, this just assigns
  * \c to_be_appended to \c *existing.
  *
- * \c to_be_appended may be \c NULL. \c existing may not.
+ * \c to_be_appended may be \c NULL.
  */
 static void
 t_cose_parameter_list_append(struct t_cose_parameter **existing,
@@ -599,6 +633,7 @@ t_cose_find_parameter_partial_iv(const struct t_cose_parameter *parameter_list);
 enum t_cose_err_t
 t_cose_common_header_parameters(const struct t_cose_parameter *decoded_params,
                                 struct t_cose_parameters      *returned_params);
+
 
 
 

--- a/inc/t_cose/t_cose_sign_verify.h
+++ b/inc/t_cose/t_cose_sign_verify.h
@@ -25,7 +25,7 @@ extern "C" {
 #endif
 #endif
 
-/* Warning: multiple signatures and verifiers are still early development. Documentation may be incorrect. */
+/* TODO: Warning: multiple signatures and verifiers are still early development. Documentation may be incorrect. */
 
 
 #define T_COSE_MAX_TAGS_TO_RETURN2 4
@@ -52,6 +52,12 @@ extern "C" {
 #define T_COSE_OPT_ALLOW_SHORT_CIRCUIT 0x00004000
 
 
+/* Requires that ALL COSE_Signatures must be verified successfully. The default
+ * is that only the one must verify.
+ */
+#define T_COSE_OPT_VERIFY_ALL_SIGNATURES  0x0008000
+
+
 
 
 /**
@@ -71,14 +77,6 @@ struct t_cose_sign_verify_ctx {
 };
 
 
-
-
-/* Requires that ALL COSE_Signatures must be verified successfully. The default
- * is that only the one must verify.
- */
-#define T_COSE_VERIFY_ALL_SIGNATURES                  0x0008000
-
-
 /**
  * \brief Initialize for \c COSE_Sign and \c COSE_Sign1 message verification.
  *
@@ -86,6 +84,8 @@ struct t_cose_sign_verify_ctx {
  * \param[in]      option_flags  Options controlling the verification.
  *
  * This must be called before using the verification context.
+ *
+ * TODO: describe (and implement) selection of COSE_Sign1 vs COSE_Sign.
  */
 static void
 t_cose_sign_verify_init(struct t_cose_sign_verify_ctx *context,
@@ -99,7 +99,7 @@ t_cose_sign_verify_init(struct t_cose_sign_verify_ctx *context,
  * \param[in] verifier   Pointer to verifier object.
 
  * Verifiers are objects that do the cryptographic operations
- * to verify a COSE_Sign or COSE_Sign1. This is both the
+ * to verify a COSE_Sign or COSE_Sign1. They do both the
  * hashing and the public key cryptography. They also
  * implement the decoding of the COSE_Signature(s) in a
  * COSE_Sign.
@@ -117,7 +117,7 @@ t_cose_sign_verify_init(struct t_cose_sign_verify_ctx *context,
  * For COSE_SIgn messages, t_cose_sign_verify() loops over
  * all the COSE_Signatures. By default the verification is a success
  * if one can be verified and there are no decoding errors. The
- * option \ref T_COSE_VERIFY_ALL_SIGNATURES can be set
+ * option \ref T_COSE_OPT_VERIFY_ALL_SIGNATURES can be set
  * to require that all the signatures verify for the overall COSE_Sign
  * to be a success.
  *
@@ -178,14 +178,14 @@ t_cose_sign_add_param_storage(struct t_cose_sign_verify_ctx   *context,
 
 
 /*
- * If customer headers that are not strings or integers needed to be
+ * If custom headers that are not strings or integers needed to be
  * decoded and processed, then use this to set a call back handler.
  * Typically this is not needed.
  */
 static void
-t_cose_sign_set_special_param_decoder(struct t_cose_sign_verify_ctx *context,
-                                      t_cose_special_param_decode_cb  *decode_cb,
-                                      void                            *decode_ctx);
+t_cose_sign_set_special_param_decoder(struct t_cose_sign_verify_ctx  *context,
+                                      t_cose_special_param_decode_cb *decode_cb,
+                                      void                           *decode_ctx);
 
 
 /**
@@ -270,7 +270,7 @@ t_cose_sign_verify_get_last(struct t_cose_sign_verify_ctx *context);
  */
 
 /**
- * \brief Semi-private function to verify a COSE_Sign1.
+ * \brief Semi-private function to verify a COSE_Sign or COSE_Sign1.
  *
  * \param[in,out] me   The t_cose signature verification context.
  * \param[in] message         Pointer and length of CBOR encoded \c COSE_Sign1
@@ -282,10 +282,10 @@ t_cose_sign_verify_get_last(struct t_cose_sign_verify_ctx *context);
  *
  * \return This returns one of the error codes defined by \ref t_cose_err_t.
  *
- * This does the work for t_cose_sign1_verify(),
- * t_cose_sign1_verify_aad() and t_cose_sign1_verify_detached(). It is
+ * This does the work for t_cose_sign_verify()
+ * and t_cose_sign_verify_detached(). It is
  * a semi-private function which means its interface isn't guaranteed
- * so it should not to call it directly.
+ * so it should not be called directly.
  */
 enum t_cose_err_t
 t_cose_sign_verify_private(struct t_cose_sign_verify_ctx *me,

--- a/inc/t_cose/t_cose_signature_sign_main.h
+++ b/inc/t_cose/t_cose_signature_sign_main.h
@@ -38,7 +38,6 @@ struct t_cose_signature_sign_main {
     struct q_useful_buf_c        kid;
     struct t_cose_key            signing_key;
     void                        *crypto_context;
-    uint32_t                     option_flags; // TODO: use or get rid of
     struct t_cose_parameter      local_params[2];
     struct t_cose_parameter     *added_signer_params;
 };

--- a/src/t_cose_encrypt_dec.c
+++ b/src/t_cose_encrypt_dec.c
@@ -73,7 +73,7 @@ decrypt_one_recipient(struct t_cose_encrypt_dec_ctx      *me,
 #ifdef QCBOR_FOR_T_COSE_2
     SaveDecodeCursor saved_cursor;
 
-    QCBORDecode_SaveCursor(qcbor_decoder, &saved_cursor);
+    QCBORDecode_SaveCursor(cbor_decoder, &saved_cursor);
 #endif
 
     /* Loop over the configured recipients */
@@ -111,7 +111,7 @@ decrypt_one_recipient(struct t_cose_encrypt_dec_ctx      *me,
 
         /* Loop continues on for the next recipient */
 #ifdef QCBOR_FOR_T_COSE_2
-        QCBORDecode_RestoreCursor(qcbor_decoder, &saved_cursor);
+        QCBORDecode_RestoreCursor(cbor_decoder, &saved_cursor);
 #else
         return T_COSE_ERR_CANT_PROCESS_MULTIPLE;
 #endif

--- a/src/t_cose_encrypt_dec.c
+++ b/src/t_cose_encrypt_dec.c
@@ -173,6 +173,7 @@ t_cose_encrypt_dec_detached(struct t_cose_encrypt_dec_ctx* me,
     /* The location of body header parameters is 0, 0 */
     header_location.nesting = 0;
     header_location.index   = 0;
+    body_params_list = NULL;
 
     return_value =
         t_cose_headers_decode(
@@ -245,11 +246,8 @@ t_cose_encrypt_dec_detached(struct t_cose_encrypt_dec_ctx* me,
         /* Successfully decoded one recipient */
         QCBORDecode_ExitArray(&cbor_decoder);
 
-        if(all_params_list == NULL) {
-            all_params_list = rcpnt_params_list;
-        } else {
-            t_cose_parameter_list_append(all_params_list, rcpnt_params_list);
-        }
+
+        t_cose_parameter_list_append(&all_params_list, rcpnt_params_list);
 
         /* The decrypted cek bytes must be a t_cose_key for the AEAD API */
         return_value =

--- a/src/t_cose_encrypt_dec.c
+++ b/src/t_cose_encrypt_dec.c
@@ -174,6 +174,7 @@ t_cose_encrypt_dec_detached(struct t_cose_encrypt_dec_ctx* me,
     header_location.nesting = 0;
     header_location.index   = 0;
     body_params_list = NULL;
+    rcpnt_params_list = NULL;
 
     return_value =
         t_cose_headers_decode(

--- a/src/t_cose_encrypt_enc.c
+++ b/src/t_cose_encrypt_enc.c
@@ -98,7 +98,7 @@ t_cose_encrypt_enc_detached(struct t_cose_encrypt_enc *me,
 
 
     /* ---- The body header parameters ---- */
-    return_value = t_cose_encode_headers(&cbor_encoder, /* in: cbor encoder */
+    return_value = t_cose_headers_encode(&cbor_encoder, /* in: cbor encoder */
                                          &params[0],    /* in: param linked list */
                                          &body_prot_headers); /* out: bytes for CBOR-encoded protected params */
     if(return_value != T_COSE_SUCCESS) {

--- a/src/t_cose_mac_compute.c
+++ b/src/t_cose_mac_compute.c
@@ -84,6 +84,7 @@ t_cose_mac_encode_parameters(struct t_cose_mac_calculate_ctx *me,
     size_t                  tag_len;
     enum t_cose_err_t       return_value;
     struct t_cose_parameter param_storage[2];
+    struct t_cose_parameter *p_tmp;
 
     /*
      * Check the algorithm now by getting the algorithm as an early
@@ -107,10 +108,11 @@ t_cose_mac_encode_parameters(struct t_cose_mac_calculate_ctx *me,
     param_storage[0] = t_cose_make_alg_id_parameter(me->cose_algorithm_id);
     param_storage[1] = t_cose_make_kid_parameter(me->kid);
     param_storage[0].next = &param_storage[1];
+    p_tmp = &param_storage[0];
 
-    t_cose_parameter_list_append(&param_storage[0], me->added_body_parameters);
+    t_cose_parameter_list_append(&p_tmp, me->added_body_parameters);
 
-    return_value = t_cose_encode_headers(cbor_encode_ctx,
+    return_value = t_cose_headers_encode(cbor_encode_ctx,
                                          &param_storage[0],
                                          &me->protected_parameters);
 

--- a/src/t_cose_mac_validate.c
+++ b/src/t_cose_mac_validate.c
@@ -159,6 +159,7 @@ t_cose_mac_validate_private(struct t_cose_mac_validate_ctx *context,
     }
 
     const struct t_cose_header_location l = {0,0};
+    decoded_params = NULL;
     /* --- The protected parameters --- */
     t_cose_headers_decode(&decode_context,
                           l,

--- a/src/t_cose_parameters.c
+++ b/src/t_cose_parameters.c
@@ -1,7 +1,7 @@
 /*
  * t_cose_parameters.c
  *
- * Copyright 2019-2022, Laurence Lundblade
+ * Copyright 2019-2023, Laurence Lundblade
  * Copyright (c) 2021, Arm Limited. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
@@ -251,10 +251,13 @@ encode_crit_parameter(QCBOREncodeContext            *cbor_encoder,
  * \param[in] special_decode_cb   Function called for parameters that are not strings or ints.
  * \param[in] special_decode_ctx  Context for the \c callback function.
  * \param [in] param_storage   Memory pool from which to take parameter storage.
- * \param[out] decoded_params  Linked list of decoded parameters.
+ * \param[in,out] decoded_params  Linked list of decoded parameters the parameters will be added to.
  *
  * This decode a CBOR map of parameters into a linked list. The nodes
  * are allocated out of \c param_storage.
+ *
+ * \c *decoded_params must be \c NULL or point to a valid parameter list to which
+ * the newly decoded parameters will be appended.
  *
  * If \c is_protected is set then every parameter decode is marked
  * as protected and vice versa.
@@ -267,13 +270,13 @@ encode_crit_parameter(QCBOREncodeContext            *cbor_encoder,
  * is called.
  */
 static enum t_cose_err_t
-decode_parameters_bucket(QCBORDecodeContext               *cbor_decoder,
-                         const struct t_cose_header_location location,
-                         bool                              is_protected,
-                         t_cose_special_param_decode_cb   *special_decode_cb,
-                         void                             *special_decode_ctx,
-                         struct t_cose_parameter_storage  *param_storage,
-                         struct t_cose_parameter         **decoded_params)
+t_cose_params_decode(QCBORDecodeContext                 *cbor_decoder,
+                     const struct t_cose_header_location location,
+                     bool                                is_protected,
+                     t_cose_special_param_decode_cb     *special_decode_cb,
+                     void                               *special_decode_ctx,
+                     struct t_cose_parameter_storage    *param_storage,
+                     struct t_cose_parameter           **decoded_params)
 {
     /* Stack usage:
       Item   56
@@ -288,11 +291,19 @@ decode_parameters_bucket(QCBORDecodeContext               *cbor_decoder,
     enum t_cose_err_t         return_value;
     struct t_cose_label_list  critical_parameter_labels;
     struct t_cose_parameter  *parameter;
-    struct t_cose_parameter  *preceding_parameter;
+    struct t_cose_parameter  *last_in_list;
     QCBORItem                 item;
 
-    clear_label_list(&critical_parameter_labels);
+    if(*decoded_params != NULL) {
+        /* Find end of list to append to */
+        for(last_in_list = *decoded_params;
+            last_in_list->next != NULL;
+            last_in_list = last_in_list->next);
+    }
+
     QCBORDecode_EnterMap(cbor_decoder, NULL);
+
+    clear_label_list(&critical_parameter_labels);
 
 #ifdef TODO_CRIT_PARAM_FIXED
     /* TODO: There is a bug in QCBOR where mixing of get by
@@ -301,6 +312,9 @@ decode_parameters_bucket(QCBORDecodeContext               *cbor_decoder,
      * For now there is no decoding of crit.
      */
     if(is_protected) {
+        /* Get the list of critical parameters first so each one can
+         * be marked so as they are decoded.
+         */
         // TODO: should there be an error check for crit
         // parameter occuring in an unprotected bucket?
         clear_label_list(&critical_parameter_labels);
@@ -312,10 +326,9 @@ decode_parameters_bucket(QCBORDecodeContext               *cbor_decoder,
     }
 #endif
 
-    /* Loop reading entries out of the map until the end of the map. */
-    *decoded_params = NULL;
-    parameter = NULL;
+    /* Main loop to decode the parameters in the map. */
     while(1) {
+        /* Can't consume it because it be special to be consumed by callback */
         QCBORDecode_VPeekNext(cbor_decoder, &item);
         cbor_error = QCBORDecode_GetAndResetError(cbor_decoder);
         if(cbor_error == QCBOR_ERR_NO_MORE_ITEMS) {
@@ -339,22 +352,16 @@ decode_parameters_bucket(QCBORDecodeContext               *cbor_decoder,
             continue;
         }
 
+        /* ---- Allocate a node for it --- */
         // TODO: test this at boundary condition!
         if(param_storage->used >= param_storage->size) {
             return_value = T_COSE_ERR_TOO_MANY_PARAMETERS;
             goto Done;
         }
-
-        preceding_parameter = parameter;
         parameter = &param_storage->storage[param_storage->used];
         param_storage->used++;
-        if(*decoded_params == NULL) {
-            *decoded_params = parameter;
-        } else {
-            preceding_parameter->next = parameter;
-        }
 
-
+        /* --- Fill in the decoded values --- */
         parameter->value_type    = item.uDataType;
         parameter->location      = location;
         parameter->label         = item.label.int64;
@@ -367,36 +374,48 @@ decode_parameters_bucket(QCBORDecodeContext               *cbor_decoder,
             case T_COSE_PARAMETER_TYPE_BYTE_STRING:
             case T_COSE_PARAMETER_TYPE_TEXT_STRING:
                 parameter->value.string = item.val.string;
-                QCBORDecode_VGetNextConsume(cbor_decoder, &item);
                 break;
 
             case T_COSE_PARAMETER_TYPE_INT64:
                 parameter->value.int64 = item.val.int64;
-                QCBORDecode_VGetNextConsume(cbor_decoder, &item);
                 break;
 
             default:
                 if(special_decode_cb == NULL) {
                     /* No callback configured to handle the unknown */
                     if(parameter->critical) {
-                        /* It is critical and unknown, so must error out */
+                        /* It is critical and unknown, so error out */
                         return_value = T_COSE_ERR_UNKNOWN_CRITICAL_PARAMETER;
                         goto Done;
                     } else {
                         /* Not critical. Just skip over it. */
-                        QCBORDecode_VGetNextConsume(cbor_decoder, &item);
                     }
                 } else {
                     /* Processed and consumed by the callback. */
-                    // TODO: What if the cb doesn't know how to process? Maybe do it here rather than make every decoder do it? Special error code?
+                    // TODO: What if the cb doesn't know how to process?
+                    // Maybe do it here rather than make every decoder do it?
+                    // Special error code?
                     return_value = special_decode_cb(special_decode_ctx,
                                                      cbor_decoder,
                                                      parameter);
-                    if(return_value != T_COSE_SUCCESS) {
-                        break;
-                    }
+                /*    if(return_value != T_COSE_SUCCESS) {
+                        break; // TODO: this is probably not right
+                    }*/
+                    goto Next;
                 }
         }
+
+        /* Now actually consume it from the CBOR input. */
+        QCBORDecode_VGetNextConsume(cbor_decoder, &item);
+
+    Next:
+        /* --- Add it to end of the linked list --- */
+        if(*decoded_params == NULL) {
+            *decoded_params = parameter;
+        } else {
+            last_in_list->next = parameter;
+        }
+        last_in_list = parameter;
     }
 
     QCBORDecode_ExitMap(cbor_decoder);
@@ -460,44 +479,38 @@ t_cose_headers_decode(QCBORDecodeContext               *cbor_decoder,
     /* stack usage:
      vars: 16
      decode_bucket  324
-
      */
 
-    QCBORError                cbor_error;
-    enum t_cose_err_t         return_value;
-    struct t_cose_parameter  *decoded_protected;
-    struct t_cose_parameter  *decoded_unprotected;
-
+    QCBORError         cbor_error;
+    enum t_cose_err_t  return_value;
 
     /* --- The protected parameters --- */
-     QCBORDecode_EnterBstrWrapped(cbor_decoder,
-                                  QCBOR_TAG_REQUIREMENT_NOT_A_TAG,
-                                  protected_parameters);
+    QCBORDecode_EnterBstrWrapped(cbor_decoder,
+                                 QCBOR_TAG_REQUIREMENT_NOT_A_TAG,
+                                 protected_parameters);
 
-     decoded_protected = NULL;
-     if(protected_parameters->len) {
-         return_value = decode_parameters_bucket(cbor_decoder,
-                                                 location,
-                                                 true,
-                                                 special_decode_cb,
-                                                 special_decode_ctx,
-                                                 param_storage,
-                                                 &decoded_protected);
+    if(protected_parameters->len) {
+        return_value = t_cose_params_decode(cbor_decoder,
+                                                location,
+                                                true,
+                                                special_decode_cb,
+                                                special_decode_ctx,
+                                                param_storage,
+                                                decoded_params);
+        if(return_value != T_COSE_SUCCESS) {
+            goto Done;
+        }
+    }
+    QCBORDecode_ExitBstrWrapped(cbor_decoder);
 
-         if(return_value != T_COSE_SUCCESS) {
-             goto Done;
-         }
-     }
-     QCBORDecode_ExitBstrWrapped(cbor_decoder);
-
-     /* ---  The unprotected parameters --- */
-    return_value = decode_parameters_bucket(cbor_decoder,
+    /* ---  The unprotected parameters --- */
+    return_value = t_cose_params_decode(cbor_decoder,
                                             location,
                                             false,
                                             special_decode_cb,
                                             special_decode_ctx,
                                             param_storage,
-                                            &decoded_unprotected);
+                                            decoded_params);
 
     if(return_value != T_COSE_SUCCESS) {
         goto Done;
@@ -508,13 +521,6 @@ t_cose_headers_decode(QCBORDecodeContext               *cbor_decoder,
     if(cbor_error != QCBOR_SUCCESS) {
         return_value = qcbor_decode_error_to_t_cose_error(cbor_error, T_COSE_ERR_PARAMETER_CBOR);
         goto Done;
-    }
-
-    if(decoded_protected == NULL) {
-        *decoded_params = decoded_unprotected;
-    } else {
-        *decoded_params = decoded_protected;
-        t_cose_parameter_list_append(*decoded_params, decoded_unprotected);
     }
 
     if(dup_detect_list(*decoded_params)) {
@@ -545,9 +551,9 @@ t_cose_headers_decode(QCBORDecodeContext               *cbor_decoder,
  * header will be constructed and output.
  **/
 static enum t_cose_err_t
-encode_parameters_bucket(QCBOREncodeContext            *cbor_encoder,
-                         const struct t_cose_parameter *parameters,
-                         const bool                     is_protected_bucket)
+t_cose_params_encode(QCBOREncodeContext            *cbor_encoder,
+                     const struct t_cose_parameter *parameters,
+                     const bool                     is_protected_bucket)
 {
     const struct t_cose_parameter  *p_param;
     bool                            criticals_present;
@@ -624,7 +630,7 @@ Done:
  * Public function. See t_cose_parameters.h
  */
 enum t_cose_err_t
-t_cose_encode_headers(QCBOREncodeContext            *cbor_encoder,
+t_cose_headers_encode(QCBOREncodeContext            *cbor_encoder,
                       const struct t_cose_parameter *parameters,
                       struct q_useful_buf_c         *protected_parameters)
 {
@@ -638,7 +644,7 @@ t_cose_encode_headers(QCBOREncodeContext            *cbor_encoder,
 
     /* --- Protected Headers --- */
     QCBOREncode_BstrWrap(cbor_encoder);
-    return_value = encode_parameters_bucket(cbor_encoder,
+    return_value = t_cose_params_encode(cbor_encoder,
                                             parameters,
                                             true);
     if(return_value != T_COSE_SUCCESS) {
@@ -648,7 +654,7 @@ t_cose_encode_headers(QCBOREncodeContext            *cbor_encoder,
 
 
     /* --- Unprotected Parameters --- */
-    return_value = encode_parameters_bucket(cbor_encoder, parameters, false);
+    return_value = t_cose_params_encode(cbor_encoder, parameters, false);
 Done:
     return return_value;
 }

--- a/src/t_cose_recipient_dec_keywrap.c
+++ b/src/t_cose_recipient_dec_keywrap.c
@@ -42,7 +42,6 @@ t_cose_recipient_dec_keywrap_cb_private(struct t_cose_recipient_dec *me_x,
 
     // TODO: support the header decode callbacks
     /* ----  First and second items -- protected & unprotected headers  ---- */
-    *params = NULL;
     err = t_cose_headers_decode(cbor_decoder, /* in: decoder to read from */
                                 loc,          /* in: location in COSE message */
                                 NULL,         /* in: callback for specials */

--- a/src/t_cose_recipient_enc_keywrap.c
+++ b/src/t_cose_recipient_enc_keywrap.c
@@ -27,6 +27,7 @@ t_cose_recipient_create_keywrap_cb_private(struct t_cose_recipient_enc  *me_x,
     struct t_cose_recipient_enc_keywrap *me;
     enum t_cose_err_t                    return_value;
     struct t_cose_parameter              params[2];
+    struct t_cose_parameter             *params2;
     struct q_useful_buf                  encrypted_cek_destiation;
     struct q_useful_buf_c                encrypted_cek_result;
     struct q_useful_buf_c                protected_params_not;
@@ -43,9 +44,10 @@ t_cose_recipient_create_keywrap_cb_private(struct t_cose_recipient_enc  *me_x,
         params[1] = t_cose_make_kid_parameter(me->kid);
         params[0].next = &params[1];
     }
-    t_cose_parameter_list_append(params, me->added_params);
+    params2 = params;
+    t_cose_parameter_list_append(&params2, me->added_params);
     // TODO: make sure no custom headers are protected because there is no protect with key wrap
-    return_value = t_cose_encode_headers(cbor_encoder, params, &protected_params_not);
+    return_value = t_cose_headers_encode(cbor_encoder, params2, &protected_params_not);
     if (return_value != T_COSE_SUCCESS) {
         goto Done;
     }

--- a/src/t_cose_sign_sign.c
+++ b/src/t_cose_sign_sign.c
@@ -36,8 +36,7 @@ t_cose_sign_encode_start(struct t_cose_sign_sign_ctx *me,
 {
     enum t_cose_err_t              return_value;
     struct t_cose_signature_sign  *signer;
-    struct t_cose_parameter       *sign1_parameters;
-    struct t_cose_parameter       *body_parameters;
+    struct t_cose_parameter       *parameters;
     uint64_t                       message_type_tag_number;
 
     /* There must be at least one signer configured (a signer is an
@@ -56,14 +55,14 @@ t_cose_sign_encode_start(struct t_cose_sign_sign_ctx *me,
     message_type_tag_number = me->option_flags & T_COSE_OPT_MESSAGE_TYPE_MASK;
 
     /* --- Make list of the body header parameters --- */
-    sign1_parameters = NULL;
+    parameters = NULL;
     if(message_type_tag_number == CBOR_TAG_COSE_SIGN1) {
         /* For a COSE_Sign1, the header parameters go in the main body
          * header parameter section, and the signatures part just
          * contains a raw signature bytes, not an array of
          * COSE_Signature. This gets the parameters from the
          * signer. */
-        signer->headers_cb(signer, &sign1_parameters);
+        signer->headers_cb(signer, &parameters);
         if(signer->rs.next != NULL) {
             /* In COSE_Sign1 mode, but too many signers configured.*/
             return_value = T_COSE_ERR_TOO_MANY_SIGNERS;
@@ -74,12 +73,7 @@ t_cose_sign_encode_start(struct t_cose_sign_sign_ctx *me,
     /* Form up the full list of body header parameters which may
      * include the COSE_Sign1 algorithm ID and kid. It may also
      * include the caller-added parameters like content type. */
-    if(sign1_parameters == NULL) {
-        body_parameters = me->added_body_parameters;
-    } else {
-        body_parameters = sign1_parameters;
-        t_cose_parameter_list_append(body_parameters, me->added_body_parameters);
-    }
+    t_cose_parameter_list_append(&parameters, me->added_body_parameters);
 
     /* --- Add the CBOR tag indicating COSE message type --- */
     if(!(me->option_flags & T_COSE_OPT_OMIT_CBOR_TAG)) {
@@ -91,8 +85,8 @@ t_cose_sign_encode_start(struct t_cose_sign_sign_ctx *me,
 
 
     /* --- Encode both protected and unprotected headers --- */
-    return_value = t_cose_encode_headers(cbor_encode_ctx,
-                                         body_parameters,
+    return_value = t_cose_headers_encode(cbor_encode_ctx,
+                                         parameters,
                                          &me->protected_parameters);
     if(return_value != T_COSE_SUCCESS) {
         goto Done;

--- a/src/t_cose_sign_verify.c
+++ b/src/t_cose_sign_verify.c
@@ -155,7 +155,7 @@ verify_one_signature(struct t_cose_sign_verify_ctx       *me,
 #ifdef QCBOR_FOR_T_COSE_2
     SaveDecodeCursor saved_cursor;
 
-    QCBORDecode_SaveCursor(qcbor_decoder, &saved_cursor);
+    QCBORDecode_SaveCursor(cbor_decoder, &saved_cursor);
 #endif
 
     for(verifier = me->verifiers;
@@ -201,7 +201,7 @@ verify_one_signature(struct t_cose_sign_verify_ctx       *me,
 
         /* Go on to the next signature */
 #ifdef QCBOR_FOR_T_COSE_2
-        QCBORDecode_RestoreCursor(qcbor_decoder, &saved_cursor);
+        QCBORDecode_RestoreCursor(cbor_decoder, &saved_cursor);
 #else
         return T_COSE_ERR_CANT_PROCESS_MULTIPLE;
 #endif
@@ -377,7 +377,7 @@ t_cose_sign_verify_private(struct t_cose_sign_verify_ctx  *me,
                 }
             }
 
-            if(me->option_flags & (T_COSE_VERIFY_ALL_SIGNATURES | T_COSE_OPT_DECODE_ONLY)) {
+            if(me->option_flags & (T_COSE_OPT_VERIFY_ALL_SIGNATURES | T_COSE_OPT_DECODE_ONLY)) {
                 if(sig_error_code == T_COSE_ERR_DECLINE) {
                     /* When verifying all, there can be no declines.
                      * Also only decoding (not verifying) there can be

--- a/src/t_cose_sign_verify.c
+++ b/src/t_cose_sign_verify.c
@@ -28,6 +28,21 @@
  */
 
 
+
+/*
+ Body protected
+ Body unprotected
+ 1st COSE_Signature protected
+ 1st COSE_Signature unprotected
+ ...
+ ...
+ 
+
+
+
+
+ */
+
 /**
  * \brief Check the tagging of the COSE about to be verified.
  *
@@ -138,46 +153,143 @@ is_soft_verify_error(enum t_cose_err_t error)
 }
 
 
+#ifdef QCBOR_FOR_T_COSE_2
 
-/* It is assumed the compiler will inline this since it is called
+/* Return the number of parameters in a linked list of parameters. */
+static int
+count_params(const struct t_cose_parameter  *params)
+{
+    int count = 0;
+
+    while(params != NULL) {
+        count++;
+        params = params->next;
+    }
+
+    return count;
+}
+
+
+static size_t
+squeeze_nodes(struct t_cose_parameter *new_ones,
+              struct t_cose_parameter *old_ones)
+{
+    struct t_cose_parameter *p1, *p2;
+
+    p1 = old_ones;
+    p2 = new_ones;
+
+    if(p1 > p2) {
+        /* Check to make cast from ptrdiff_t to size_t safe */
+        return 0;
+    }
+    size_t num_squeezed = (size_t)(p2 - p1);
+
+    while(1) {
+        *p1 = *p2;
+        if(p2->next == NULL) {
+            break;
+        }
+        p1++;
+        p2++;
+    }
+
+    return num_squeezed;
+}
+
+
+
+/*
+ * The work of this is to call multiple verifiers on one
+ * signature until one succeeds.
+
+
+ It is assumed the compiler will inline this since it is called
  * only once. Makes the large number of parameters not so
- * bad. This is a seperate function for code readability. */
+ * bad. This is a seperate function for code readability.
+
+ * This needs to add the decoded parameters once and only once even
+ * though multiple verifiers are called on the same signature.
+
+ * Different verifiers may do better or worse job of decoding
+ * the parameters to be returned. In particular, some may
+ * have special parameter decode callbacks and some may not.
+ * Note also that success, declining or failure of a verifier
+ * may or may not be an indication of how well parameter
+ * decoding went.
+ *
+ * What happens here is that parameters decoded by the verifier
+ * that decoded the most parameters will be returned. The logic
+ * is that integer and string value parameters will always be
+ * be decoded by every verifier, but only some will be able
+ * to decoded the special parameters. Those that do
+ * decode the specials should be preferred and this is
+ * indicated by their having a higher count. If two
+ * verifiers both produce the same count, the parameters
+ * decoded by the first one added will be preferred.
+ */
 static enum t_cose_err_t
 verify_one_signature(struct t_cose_sign_verify_ctx       *me,
                      const struct t_cose_header_location  header_location,
                      struct t_cose_sign_inputs           *sign_inputs,
                      QCBORDecodeContext                  *cbor_decoder,
-                     struct t_cose_parameter            **sig_param_list)
+                     struct t_cose_parameter            **param_list)
 {
     struct t_cose_signature_verify *verifier;
     enum t_cose_err_t               return_value;
-
-#ifdef QCBOR_FOR_T_COSE_2
-    SaveDecodeCursor saved_cursor;
+    SaveDecodeCursor                saved_cursor;
+    struct t_cose_parameter        *tmp_sig_param_list;
+    struct t_cose_parameter        *best_sig_param_list;
+    int                             param_count;
+    int                             best_param_count;
 
     QCBORDecode_SaveCursor(cbor_decoder, &saved_cursor);
-#endif
+
+    best_param_count = 0;
+    best_sig_param_list = NULL;
 
     for(verifier = me->verifiers;
         verifier != NULL;
         verifier = (struct t_cose_signature_verify *)verifier->rs.next) {
+
+        /* Save state of parameters storage and list. */
+
+        size_t saved = me->p_storage->used;
+
+        tmp_sig_param_list = NULL;
+
         return_value =
-            verifier->verify_cb(verifier,         /* in:  me context */
+            verifier->verify_cb(verifier,         /* in: verifier me context */
                                 me->option_flags, /* in: option_flags */
                                 header_location,  /* in: nesting/index */
                                 sign_inputs,      /* in: everything covered by signature */
                                 me->p_storage,    /* in: pool of t_cose_parameter structs */
                                 cbor_decoder,     /* in: decoder */
-                                sig_param_list);  /* out: linked list of decoded params*/
+                               &tmp_sig_param_list);  /* out: linked list of decoded params */
+
+        param_count = count_params(tmp_sig_param_list);
+        if(param_count > best_param_count) {
+            /* Remove the old best out of the pool. */
+            if( best_sig_param_list != NULL) {
+                me->p_storage->used -= squeeze_nodes(best_sig_param_list,tmp_sig_param_list);
+            }
+            best_param_count = param_count;
+            best_sig_param_list = tmp_sig_param_list;
+        } else {
+            /* Put the nodes back in the pool */
+            me->p_storage->used = saved;
+        }
+
+
         if(return_value == T_COSE_SUCCESS) {
             /* If here, then the decode was a success, the crypto
              * verified, and the signature CBOR was consumed. Nothing
              * to do but leave */
-            return T_COSE_SUCCESS;
+            goto Done;;
         }
 
         if(return_value == T_COSE_ERR_NO_MORE) {
-            return T_COSE_ERR_NO_MORE;
+            goto Done;;
         }
 
         /* Remember the last verifier that failed. */
@@ -189,22 +301,18 @@ verify_one_signature(struct t_cose_sign_verify_ctx       *me,
              * failed to verify the bytes. In most cases the caller
              * will want to fail the whole thing if this happens.
              */
-            return T_COSE_ERR_SIG_VERIFY;
+            goto Done;;
         }
 
 
         if(!is_soft_verify_error(return_value)) {
             /* Something is very wrong. Need to abort the entire
              * COSE mesage. */
-            return return_value;
+            goto Done;;
         }
 
-        /* Go on to the next signature */
-#ifdef QCBOR_FOR_T_COSE_2
+        /* Go on to the next verifier */
         QCBORDecode_RestoreCursor(cbor_decoder, &saved_cursor);
-#else
-        return T_COSE_ERR_CANT_PROCESS_MULTIPLE;
-#endif
     }
 
     /* Got to the end of the list without success. The last verifier
@@ -212,8 +320,203 @@ verify_one_signature(struct t_cose_sign_verify_ctx       *me,
      * here because there was no verifier for the algorithm or the kid
      * for the verification key didn't match any of the signatures or
      * general decline failure. */
-    return T_COSE_ERR_DECLINE;
+    return_value = T_COSE_ERR_DECLINE;
+
+Done:
+    t_cose_parameter_list_append(param_list, best_sig_param_list);
+    return return_value;
 }
+
+#else /* QCBOR_FOR_T_COSE_2 */
+
+#warning "Linking against QCBOR 1.x, not 2.x. No use of multiple verifiers on COSE_Signatures"
+
+static enum t_cose_err_t
+verify_one_signature(struct t_cose_sign_verify_ctx       *me,
+                     const struct t_cose_header_location  header_location,
+                     struct t_cose_sign_inputs           *sign_inputs,
+                     QCBORDecodeContext                  *cbor_decoder,
+                     struct t_cose_parameter            **sig_param_list)
+{
+    struct t_cose_signature_verify *verifier;
+    enum t_cose_err_t               return_value;
+
+    verifier = me->verifiers;
+
+    return_value =
+        verifier->verify_cb(verifier,         /* in:  me context */
+                            me->option_flags, /* in: option_flags */
+                            header_location,  /* in: nesting/index */
+                            sign_inputs,      /* in: everything covered by signature */
+                            me->p_storage,    /* in: pool of t_cose_parameter structs */
+                            cbor_decoder,     /* in: decoder */
+                            sig_param_list);  /* out: linked list of decoded params*/
+    if(return_value == T_COSE_SUCCESS) {
+        /* If here, then the decode was a success, the crypto
+         * verified, and the signature CBOR was consumed. Nothing
+         * to do but leave. */
+        return T_COSE_SUCCESS;
+    }
+
+    if(return_value == T_COSE_ERR_NO_MORE) {
+        return T_COSE_ERR_NO_MORE;
+    }
+
+    /* Remember the last verifier that failed. */
+    me->last_verifier = verifier;
+
+    if(return_value == T_COSE_ERR_SIG_VERIFY) {
+        /* The verifier was for the right algorithm and the key
+         * was the right kid and such, but the actual crypto
+         * failed to verify the bytes. In most cases the caller
+         * will want to fail the whole thing if this happens.
+         */
+        return T_COSE_ERR_SIG_VERIFY;
+    }
+
+
+    if(!is_soft_verify_error(return_value)) {
+        /* Something is very wrong. Need to abort the entire
+         * COSE mesage. */
+        return return_value;
+    }
+
+    /* Without QCBOR 2.x, it's not possible to rewind and try
+     * a different verifier, so error out.
+     */
+    return T_COSE_ERR_CANT_PROCESS_MULTIPLE;
+}
+
+
+#endif /* QCBOR_FOR_T_COSE_2 */
+
+
+
+/* Run all the verifiers against one signature (not a COSE_Signature) for
+ * a COSE_Sign1.
+ *
+ * Called once. Expect it will be inlined. Separate function for
+ * code readability.
+ */
+static enum t_cose_err_t
+call_sign1_verifiers(struct t_cose_sign_verify_ctx   *me,
+                     const struct t_cose_parameter   *body_params_list,
+                     const struct t_cose_sign_inputs *sign_inputs,
+                     const struct q_useful_buf_c      signature)
+{
+    enum t_cose_err_t               return_value;
+    struct t_cose_signature_verify *verifier;
+
+    return_value = T_COSE_ERR_NO_VERIFIERS;
+
+    for(verifier = me->verifiers;
+        verifier != NULL;
+        verifier = (struct t_cose_signature_verify *)(verifier)->rs.next) {
+
+        /* Call the verifier to attempt a verification. It will
+         * compute the tbs and try to run the crypto (unless
+         * T_COSE_OPT_DECODE_ONLY is set). Note also that the only
+         * reason that the verifier is called even when
+         * T_COSE_OPT_DECODE_ONLY is set here for a COSE_Sign1 is
+         * so the aux buffer size can be computed for EdDSA.
+         */
+        return_value =
+            verifier->verify1_cb(verifier,         /* in/out: me pointer for this verifier */
+                                 me->option_flags, /* in: option flags from top-level caller */
+                                 sign_inputs,      /* in: everything covered by signing */
+                                 body_params_list, /* in: linked list of header params from body */
+                                 signature);       /* in: the signature */
+        if(return_value == T_COSE_SUCCESS) {
+            break;
+        }
+        if(!is_soft_verify_error(return_value)) {
+            /* Decode error or a signature verification failure or such. */
+            break;
+        }
+
+        /* Algorithm or kid didn't match or verifier
+         * declined. Continue trying other verifiers.
+         */
+    }
+
+    return return_value;
+}
+
+
+/*
+ *
+ * @param[in,out] decode_parameters param list to append newly decoded params to
+ *
+ * Process all the COSE_Signatures in a COSE_Sign. The main job
+ * here is knowing whether all signatures must be validated
+ * or just one. */
+static enum t_cose_err_t
+process_cose_signatures(struct t_cose_sign_verify_ctx *me,
+                        QCBORDecodeContext            *cbor_decoder,
+                        struct t_cose_sign_inputs     *sign_inputs,
+                        struct t_cose_parameter      **decode_parameters)
+{
+    enum t_cose_err_t               return_value;
+    struct t_cose_header_location   header_location;
+
+    header_location.nesting = 1;
+
+    /* --- loop over COSE_Signatures --- */
+    for(header_location.index = 0;  ; header_location.index++) {
+
+        return_value = verify_one_signature(me, /* in: main sig verification context */
+                                            header_location, /* in: for header decoding */
+                                            sign_inputs, /* in: what to verify */
+                                            cbor_decoder, /* in: CBOR decoder */
+                                            decode_parameters /* in,out: parameter list to append to */
+                                            );
+
+        if(return_value == T_COSE_ERR_NO_MORE) {
+            /* End of the array of signatures. */
+            // TODO: What about condition where there are no COSE_Signatures?
+            (void)QCBORDecode_GetAndResetError(cbor_decoder);
+            return_value = T_COSE_SUCCESS;
+            break;
+        }
+
+        if(return_value != T_COSE_SUCCESS && return_value != T_COSE_ERR_DECLINE) {
+            /* Some error condition. Do not continue. */
+            break;
+        }
+
+        /* Now what's left is a T_COSE_SUCCESS or T_COSE_ERR_DECLINE */
+
+        if(me->option_flags & (T_COSE_OPT_VERIFY_ALL_SIGNATURES | T_COSE_OPT_DECODE_ONLY)) {
+            if(return_value == T_COSE_ERR_DECLINE) {
+                /* When verifying all, there can be no declines.
+                 * Also only decoding (not verifying) there can be
+                 * no declines because every signature must be
+                 * decoded so its parameters can be returned.
+                 * TODO: is this really true? It might be OK to
+                 * only decode some as long as the caller knows
+                 * that some weren't decoded. How to indicate this
+                 * if it happens? An error code? A special
+                 * indicator parameter in the returned list?
+                 */
+                break;
+            } else {
+                /* success. Continue on to check that the rest succeed. */
+            }
+        } else {
+            /* Not verifying all. Looking for one success */
+            if(return_value == T_COSE_SUCCESS) {
+                /* Just one success is enough to complete.*/
+                break;
+            } else {
+                /* decline. Continue to try other COSE_Signatures. */
+            }
+        }
+    }
+
+Done:
+    return return_value;
+}
+
 
 
 /*
@@ -232,12 +535,9 @@ t_cose_sign_verify_private(struct t_cose_sign_verify_ctx  *me,
     enum t_cose_err_t               return_value;
     struct q_useful_buf_c           signature;
     QCBORError                      qcbor_error;
-    struct t_cose_signature_verify *verifier;
     struct t_cose_header_location   header_location;
-    struct t_cose_parameter        *body_params_list;
-    struct t_cose_parameter        *sig_params_list;
+    struct t_cose_parameter        *decoded_parameters;
     struct t_cose_sign_inputs       sign_inputs;
-    enum t_cose_err_t               sig_error_code;
 
 
     /* --- Decoding of the array of four starts here --- */
@@ -259,17 +559,18 @@ t_cose_sign_verify_private(struct t_cose_sign_verify_ctx  *me,
     }
 
 
-    /* --- The header parameters --- */
+    /* --- The main body header parameters --- */
     /* The location of body header parameters is 0, 0 */
     header_location.nesting = 0;
     header_location.index   = 0;
+    decoded_parameters      = NULL;
 
     return_value = t_cose_headers_decode(&cbor_decoder,
                                           header_location,
                                           me->special_param_decode_cb,
                                           me->special_param_decode_ctx,
                                           me->p_storage,
-                                         &body_params_list,
+                                         &decoded_parameters,
                                          &protected_parameters);
     if(return_value != T_COSE_SUCCESS) {
         goto Done;
@@ -288,9 +589,6 @@ t_cose_sign_verify_private(struct t_cose_sign_verify_ctx  *me,
 
 
     /* --- The signature or the COSE_Signature(s) --- */
-    if(me->verifiers == NULL) {
-        return T_COSE_ERR_NO_VERIFIERS;
-    }
     sign_inputs.body_protected = protected_parameters;
     sign_inputs.sign_protected = NULL_Q_USEFUL_BUF_C;
     sign_inputs.aad            = aad;
@@ -303,108 +601,24 @@ t_cose_sign_verify_private(struct t_cose_sign_verify_ctx  *me,
             goto Done2;
         }
 
-        /* Loop over all the verifiers configured asking each to
-         * verify until one succeeds. If none succeeded, the return
-         * value is from the last one called.
-         */
-        for(verifier = me->verifiers;
-            verifier != NULL;
-            verifier = (struct t_cose_signature_verify *)verifier->rs.next) {
-            /* Call the verifier to attempt a verification. It will
-             * compute the tbs and try to run the crypto (unless
-             * T_COSE_OPT_DECODE_ONLY is set). Note also that the only
-             * reason that the verifier is called even when
-             * T_COSE_OPT_DECODE_ONLY is set here for a COSE_Sign1 is
-             * so the aux buffer size can be computed for EdDSA.
-             */
-            return_value =
-                verifier->verify1_cb(verifier,         /* in/out: me pointer for this verifier */
-                                     me->option_flags, /* in: option flags from top-level caller */
-                                    &sign_inputs,      /* in: everything covered by signing */
-                                     body_params_list, /* in: linked list of header params from body */
-                                     signature);       /* in: the signature */
-            if(return_value == T_COSE_SUCCESS) {
-                break;
-            }
-            if(!is_soft_verify_error(return_value)) {
-                /* Decode error or a signature verification failure or such. */
-                break;
-            }
-
-            /* Algorithm or kid didn't match or verifier
-             * declined. Continue trying other verifiers.
-             */
-        }
+        /* Call the signature verifier(s) */
+        return_value = call_sign1_verifiers(me,
+                                            decoded_parameters,
+                                           &sign_inputs,
+                                            signature);
 
     } else {
-        /* --- An array of COSE_Signatures --- */
+        /* --- The array of COSE_Signatures --- */
         QCBORDecode_EnterArray(&cbor_decoder, NULL);
         if(QCBORDecode_GetError(&cbor_decoder)) {
-            /* Not strictly necessary, but very helpful for error reporting. */
+            /* Not strictly necessary, but helpful for error reporting. */
             goto Done2;
         }
 
-        /* Nesting level is 1, index starts at 0 and gets incremented */
-        header_location.nesting = 1;
-        header_location.index   = 0;
-
-        while(1) { /* loop over COSE_Signatures */
-            sig_error_code = verify_one_signature(me,
-                                                  header_location,
-                                                 &sign_inputs,
-                                                 &cbor_decoder,
-                                                 &sig_params_list);
-
-            if(sig_error_code == T_COSE_ERR_NO_MORE) {
-                (void)QCBORDecode_GetAndResetError(&cbor_decoder);
-                break;
-            }
-
-            if(sig_error_code != T_COSE_SUCCESS &&
-               sig_error_code != T_COSE_ERR_DECLINE) {
-                return_value = sig_error_code;
-                goto Done;
-            }
-
-            /* Now what's left is a success or decline */
-
-            if(sig_error_code == T_COSE_SUCCESS) {
-                if(body_params_list == NULL) {
-                    body_params_list = sig_params_list;
-                } else {
-                    t_cose_parameter_list_append(body_params_list,
-                                                 sig_params_list);
-                }
-            }
-
-            if(me->option_flags & (T_COSE_OPT_VERIFY_ALL_SIGNATURES | T_COSE_OPT_DECODE_ONLY)) {
-                if(sig_error_code == T_COSE_ERR_DECLINE) {
-                    /* When verifying all, there can be no declines.
-                     * Also only decoding (not verifying) there can be
-                     * no declines because every signature must be
-                     * decoded so its parameters can be returned.
-                     * TODO: is this really true? It might be OK to
-                     * only decode some as long as the caller knows
-                     * that some weren't decoded. How to indicate this
-                     * if it happens? An error code? A special
-                     * indicator parameter in the returned list?
-                     */
-                    return_value = sig_error_code;
-                    goto Done;
-                } else {
-                    /* success. Continue on to be sure the rest succeed. */
-                }
-            } else {
-                if(sig_error_code == T_COSE_SUCCESS) {
-                    /* Just one success is enough to complete.*/
-                    break;
-                } else {
-                    /* decline. Continue to try other COSE_Signatures. */
-                }
-            }
-
-            header_location.index++;
-        }
+        return_value = process_cose_signatures(me,
+                                               &cbor_decoder,
+                                               &sign_inputs,
+                                               &decoded_parameters);
 
         QCBORDecode_ExitArray(&cbor_decoder);
     }
@@ -414,7 +628,7 @@ t_cose_sign_verify_private(struct t_cose_sign_verify_ctx  *me,
     QCBORDecode_ExitArray(&cbor_decoder);
 
     if(returned_parameters != NULL) {
-        *returned_parameters = body_params_list;
+        *returned_parameters = decoded_parameters;
     }
 
   Done2:

--- a/src/t_cose_signature_sign_eddsa.c
+++ b/src/t_cose_signature_sign_eddsa.c
@@ -117,8 +117,8 @@ t_cose_signature_sign_eddsa_cb(struct t_cose_signature_sign  *me_x,
     QCBOREncode_OpenArray(qcbor_encoder);
 
     t_cose_signature_sign_headers_eddsa_cb(me_x, &parameters);
-    t_cose_parameter_list_append(parameters, me->added_signer_params);
-    t_cose_encode_headers(qcbor_encoder,
+    t_cose_parameter_list_append(&parameters, me->added_signer_params);
+    t_cose_headers_encode(qcbor_encoder,
                           parameters,
                           &sign_inputs->sign_protected);
 

--- a/src/t_cose_signature_sign_eddsa.c
+++ b/src/t_cose_signature_sign_eddsa.c
@@ -136,6 +136,7 @@ void
 t_cose_signature_sign_eddsa_init(struct t_cose_signature_sign_eddsa *me)
 {
     memset(me, 0, sizeof(*me));
+    me->s.rs.ident   = RS_IDENT(TYPE_RS_SIGNER, 'E');
     me->s.sign_cb    = t_cose_signature_sign_eddsa_cb;
     me->s.sign1_cb   = t_cose_signature_sign1_eddsa_cb;
     me->s.headers_cb = t_cose_signature_sign_headers_eddsa_cb;

--- a/src/t_cose_signature_sign_main.c
+++ b/src/t_cose_signature_sign_main.c
@@ -114,8 +114,8 @@ t_cose_signature_sign_main_cb(struct t_cose_signature_sign  *me_x,
 
     /* -- The headers for a COSE_Sign -- */
     t_cose_signature_sign_headers_main_cb(me_x, &parameters);
-    t_cose_parameter_list_append(parameters, me->added_signer_params);
-    t_cose_encode_headers(qcbor_encoder,
+    t_cose_parameter_list_append(&parameters, me->added_signer_params);
+    t_cose_headers_encode(qcbor_encoder,
                           parameters,
                           &sign_inputs->sign_protected);
 

--- a/src/t_cose_signature_verify_eddsa.c
+++ b/src/t_cose_signature_verify_eddsa.c
@@ -177,6 +177,7 @@ t_cose_signature_verify_eddsa_init(struct t_cose_signature_verify_eddsa *me,
                                    uint32_t option_flags)
 {
     memset(me, 0, sizeof(*me));
+    me->s.rs.ident   = RS_IDENT(TYPE_RS_VERIFIER, 'E');
     me->s.verify_cb   = t_cose_signature_verify_eddsa_cb;
     me->s.verify1_cb  = t_cose_signature_verify1_eddsa_cb;
     me->option_flags = option_flags;

--- a/t_cose.xcodeproj/project.pbxproj
+++ b/t_cose.xcodeproj/project.pbxproj
@@ -102,12 +102,46 @@
 		E7AF703628DADF5E00F07637 /* t_cose_param_test.c in Sources */ = {isa = PBXBuildFile; fileRef = E7AF703528DADF5E00F07637 /* t_cose_param_test.c */; };
 		E7AF703728DADFCF00F07637 /* t_cose_param_test.c in Sources */ = {isa = PBXBuildFile; fileRef = E7AF703528DADF5E00F07637 /* t_cose_param_test.c */; };
 		E7AF703828DADFD000F07637 /* t_cose_param_test.c in Sources */ = {isa = PBXBuildFile; fileRef = E7AF703528DADF5E00F07637 /* t_cose_param_test.c */; };
-		E7C960A627F7569E00FB537C /* libqcbor.a in Frameworks */ = {isa = PBXBuildFile; fileRef = E7C960A527F7569500FB537C /* libqcbor.a */; };
-		E7C960A727F7569F00FB537C /* libqcbor.a in Frameworks */ = {isa = PBXBuildFile; fileRef = E7C960A527F7569500FB537C /* libqcbor.a */; };
-		E7C960A827F756A000FB537C /* libqcbor.a in Frameworks */ = {isa = PBXBuildFile; fileRef = E7C960A527F7569500FB537C /* libqcbor.a */; };
-		E7C960AA27F756A100FB537C /* libqcbor.a in Frameworks */ = {isa = PBXBuildFile; fileRef = E7C960A527F7569500FB537C /* libqcbor.a */; };
-		E7C960AB27F756A200FB537C /* libqcbor.a in Frameworks */ = {isa = PBXBuildFile; fileRef = E7C960A527F7569500FB537C /* libqcbor.a */; };
 		E7C960B527FC97A800FB537C /* libmbedcrypto.a in Frameworks */ = {isa = PBXBuildFile; fileRef = E751F9F027E1F90F00EBA5FA /* libmbedcrypto.a */; };
+		E7D3CFA629E116DF00F8C764 /* libqcbor.a in Frameworks */ = {isa = PBXBuildFile; fileRef = E7D3CFA529E1167000F8C764 /* libqcbor.a */; };
+		E7D3CFA729E1190800F8C764 /* libqcbor.a in Frameworks */ = {isa = PBXBuildFile; fileRef = E7D3CFA529E1167000F8C764 /* libqcbor.a */; };
+		E7D3CFAA29EE7A4400F8C764 /* t_cose_sign_sign.c in Sources */ = {isa = PBXBuildFile; fileRef = E7FECC452887430600420F6F /* t_cose_sign_sign.c */; };
+		E7D3CFAB29EE7A4400F8C764 /* t_cose_recipient_enc_keywrap.c in Sources */ = {isa = PBXBuildFile; fileRef = E771080C2917EDA900D8ADF4 /* t_cose_recipient_enc_keywrap.c */; };
+		E7D3CFAC29EE7A4400F8C764 /* t_cose_sign1_verify.c in Sources */ = {isa = PBXBuildFile; fileRef = E7E36E8A226CB9460040613B /* t_cose_sign1_verify.c */; };
+		E7D3CFAD29EE7A4400F8C764 /* t_cose_encrypt_dec.c in Sources */ = {isa = PBXBuildFile; fileRef = E771080A2917EDA900D8ADF4 /* t_cose_encrypt_dec.c */; };
+		E7D3CFAE29EE7A4400F8C764 /* t_cose_test.c in Sources */ = {isa = PBXBuildFile; fileRef = E7F70AC52270DFAE007CE07F /* t_cose_test.c */; };
+		E7D3CFAF29EE7A4400F8C764 /* t_cose_param_test.c in Sources */ = {isa = PBXBuildFile; fileRef = E7AF703528DADF5E00F07637 /* t_cose_param_test.c */; };
+		E7D3CFB029EE7A4400F8C764 /* t_cose_recipient_dec_hpke.c in Sources */ = {isa = PBXBuildFile; fileRef = E771080B2917EDA900D8ADF4 /* t_cose_recipient_dec_hpke.c */; };
+		E7D3CFB129EE7A4400F8C764 /* t_cose_psa_crypto.c in Sources */ = {isa = PBXBuildFile; fileRef = E73CDAD223AD4E6D00D262E0 /* t_cose_psa_crypto.c */; };
+		E7D3CFB229EE7A4400F8C764 /* t_cose_encrypt_decrypt_test.c in Sources */ = {isa = PBXBuildFile; fileRef = E7AE889229AB72740093B326 /* t_cose_encrypt_decrypt_test.c */; };
+		E7D3CFB329EE7A4400F8C764 /* t_cose_recipient_enc_hpke.c in Sources */ = {isa = PBXBuildFile; fileRef = E771080D2917EDA900D8ADF4 /* t_cose_recipient_enc_hpke.c */; };
+		E7D3CFB429EE7A4400F8C764 /* t_cose_signature_sign_eddsa.c in Sources */ = {isa = PBXBuildFile; fileRef = E7F173012923E09100E5ADF3 /* t_cose_signature_sign_eddsa.c */; };
+		E7D3CFB529EE7A4400F8C764 /* t_cose_util.c in Sources */ = {isa = PBXBuildFile; fileRef = E7E36E89226CB9460040613B /* t_cose_util.c */; };
+		E7D3CFB629EE7A4400F8C764 /* t_cose_crypto_test.c in Sources */ = {isa = PBXBuildFile; fileRef = E7F17372295D1EC700E5ADF3 /* t_cose_crypto_test.c */; };
+		E7D3CFB729EE7A4400F8C764 /* t_cose_sign_verify.c in Sources */ = {isa = PBXBuildFile; fileRef = E7FECC5E288B266500420F6F /* t_cose_sign_verify.c */; };
+		E7D3CFB829EE7A4400F8C764 /* t_cose_parameters.c in Sources */ = {isa = PBXBuildFile; fileRef = 0F9105792321878F00008572 /* t_cose_parameters.c */; };
+		E7D3CFB929EE7A4400F8C764 /* t_cose_sign_verify_test.c in Sources */ = {isa = PBXBuildFile; fileRef = E721CB9423628D2600C7FD56 /* t_cose_sign_verify_test.c */; };
+		E7D3CFBA29EE7A4400F8C764 /* sha256.c in Sources */ = {isa = PBXBuildFile; fileRef = E730E60723612D2B00175CE0 /* sha256.c */; };
+		E7D3CFBB29EE7A4400F8C764 /* t_cose_mac_validate.c in Sources */ = {isa = PBXBuildFile; fileRef = E762D6D528CC0BBD00A22792 /* t_cose_mac_validate.c */; };
+		E7D3CFBC29EE7A4400F8C764 /* init_keys_psa.c in Sources */ = {isa = PBXBuildFile; fileRef = E7AE886829A402670093B326 /* init_keys_psa.c */; };
+		E7D3CFBD29EE7A4400F8C764 /* t_cose_make_test_messages.c in Sources */ = {isa = PBXBuildFile; fileRef = 0F8B2FE8233C3DD600A22349 /* t_cose_make_test_messages.c */; };
+		E7D3CFBE29EE7A4400F8C764 /* t_cose_mac_compute.c in Sources */ = {isa = PBXBuildFile; fileRef = E762D6D428CC0BBD00A22792 /* t_cose_mac_compute.c */; };
+		E7D3CFBF29EE7A4400F8C764 /* main.c in Sources */ = {isa = PBXBuildFile; fileRef = E7E36E7B226CB8400040613B /* main.c */; };
+		E7D3CFC029EE7A4400F8C764 /* t_cose_signature_sign_main.c in Sources */ = {isa = PBXBuildFile; fileRef = E7F17325293B09E400E5ADF3 /* t_cose_signature_sign_main.c */; };
+		E7D3CFC129EE7A4400F8C764 /* t_cose_signature_verify_main.c in Sources */ = {isa = PBXBuildFile; fileRef = E7F17326293B09E400E5ADF3 /* t_cose_signature_verify_main.c */; };
+		E7D3CFC229EE7A4400F8C764 /* t_cose_encrypt_enc.c in Sources */ = {isa = PBXBuildFile; fileRef = E77108092917EDA900D8ADF4 /* t_cose_encrypt_enc.c */; };
+		E7D3CFC329EE7A4400F8C764 /* run_tests.c in Sources */ = {isa = PBXBuildFile; fileRef = E72FB01C231ADAA8000970FE /* run_tests.c */; };
+		E7D3CFC429EE7A4400F8C764 /* t_cose_signature_verify_eddsa.c in Sources */ = {isa = PBXBuildFile; fileRef = E7F173072928557A00E5ADF3 /* t_cose_signature_verify_eddsa.c */; };
+		E7D3CFC529EE7A4400F8C764 /* t_cose_recipient_dec_keywrap.c in Sources */ = {isa = PBXBuildFile; fileRef = E77108082917EDA900D8ADF4 /* t_cose_recipient_dec_keywrap.c */; };
+		E7D3CFC629EE7A4400F8C764 /* t_cose_compute_validate_mac_test.c in Sources */ = {isa = PBXBuildFile; fileRef = E762D6D928CC0BD700A22792 /* t_cose_compute_validate_mac_test.c */; };
+		E7D3CFC729EE7A4400F8C764 /* hpke.c in Sources */ = {isa = PBXBuildFile; fileRef = E7F17342294967CD00E5ADF3 /* hpke.c */; };
+		E7D3CFC829EE7A4400F8C764 /* t_cose_sign1_sign.c in Sources */ = {isa = PBXBuildFile; fileRef = E7E36E8E226CB9460040613B /* t_cose_sign1_sign.c */; };
+		E7D3CFC929EE7A4400F8C764 /* t_cose_key.c in Sources */ = {isa = PBXBuildFile; fileRef = E7AE885F299FF5FE0093B326 /* t_cose_key.c */; };
+		E7D3CFCB29EE7A4400F8C764 /* libmbedcrypto.a in Frameworks */ = {isa = PBXBuildFile; fileRef = E751F9F027E1F90F00EBA5FA /* libmbedcrypto.a */; };
+		E7D3CFCC29EE7A4400F8C764 /* libqcbor.a in Frameworks */ = {isa = PBXBuildFile; fileRef = E7D3CFA529E1167000F8C764 /* libqcbor.a */; };
+		E7D3CFD229F20DAD00F8C764 /* libqcbor.a in Frameworks */ = {isa = PBXBuildFile; fileRef = E7D3CFA529E1167000F8C764 /* libqcbor.a */; };
+		E7D3CFD329F20DAE00F8C764 /* libqcbor.a in Frameworks */ = {isa = PBXBuildFile; fileRef = E7D3CFA529E1167000F8C764 /* libqcbor.a */; };
+		E7D3CFD429F20DAE00F8C764 /* libqcbor.a in Frameworks */ = {isa = PBXBuildFile; fileRef = E7D3CFA529E1167000F8C764 /* libqcbor.a */; };
 		E7E36E7C226CB8400040613B /* main.c in Sources */ = {isa = PBXBuildFile; fileRef = E7E36E7B226CB8400040613B /* main.c */; };
 		E7E36E90226CB9460040613B /* t_cose_util.c in Sources */ = {isa = PBXBuildFile; fileRef = E7E36E89226CB9460040613B /* t_cose_util.c */; };
 		E7E36E91226CB9460040613B /* t_cose_sign1_verify.c in Sources */ = {isa = PBXBuildFile; fileRef = E7E36E8A226CB9460040613B /* t_cose_sign1_verify.c */; };
@@ -186,6 +220,15 @@
 			runOnlyForDeploymentPostprocessing = 1;
 		};
 		E73CDAC223A7316700D262E0 /* CopyFiles */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = /usr/share/man/man1/;
+			dstSubfolderSpec = 0;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 1;
+		};
+		E7D3CFCD29EE7A4400F8C764 /* CopyFiles */ = {
 			isa = PBXCopyFilesBuildPhase;
 			buildActionMask = 2147483647;
 			dstPath = /usr/share/man/man1/;
@@ -303,7 +346,8 @@
 		E7AE889829AE25BE0093B326 /* t_cose_call_all.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = t_cose_call_all.c; path = tdv/t_cose_call_all.c; sourceTree = "<group>"; };
 		E7AF703428DADF5E00F07637 /* t_cose_param_test.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = t_cose_param_test.h; sourceTree = "<group>"; };
 		E7AF703528DADF5E00F07637 /* t_cose_param_test.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = t_cose_param_test.c; sourceTree = "<group>"; };
-		E7C960A527F7569500FB537C /* libqcbor.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libqcbor.a; path = ../../../../../usr/local/lib/libqcbor.a; sourceTree = "<group>"; };
+		E7D3CFA529E1167000F8C764 /* libqcbor.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libqcbor.a; path = "../../QCBOR/save-restore/libqcbor.a"; sourceTree = "<group>"; };
+		E7D3CFD129EE7A4400F8C764 /* t_cose_psa_qcbor2 */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = t_cose_psa_qcbor2; sourceTree = BUILT_PRODUCTS_DIR; };
 		E7E36E78226CB8400040613B /* t_cose_openssl */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = t_cose_openssl; sourceTree = BUILT_PRODUCTS_DIR; };
 		E7E36E7B226CB8400040613B /* main.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = main.c; sourceTree = "<group>"; };
 		E7E36E89226CB9460040613B /* t_cose_util.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = t_cose_util.c; sourceTree = "<group>"; };
@@ -333,7 +377,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				E7C960A627F7569E00FB537C /* libqcbor.a in Frameworks */,
+				E7D3CFD229F20DAD00F8C764 /* libqcbor.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -342,7 +386,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				E7FECC5328877DFE00420F6F /* libmbedcrypto.a in Frameworks */,
-				E7C960AA27F756A100FB537C /* libqcbor.a in Frameworks */,
+				E7D3CFD329F20DAE00F8C764 /* libqcbor.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -351,7 +395,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				E7F17339293ED70E00E5ADF3 /* libcrypto.a in Frameworks */,
-				E7C960AB27F756A200FB537C /* libqcbor.a in Frameworks */,
+				E7D3CFD429F20DAE00F8C764 /* libqcbor.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -360,7 +404,16 @@
 			buildActionMask = 2147483647;
 			files = (
 				E7C960B527FC97A800FB537C /* libmbedcrypto.a in Frameworks */,
-				E7C960A827F756A000FB537C /* libqcbor.a in Frameworks */,
+				E7D3CFA629E116DF00F8C764 /* libqcbor.a in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		E7D3CFCA29EE7A4400F8C764 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				E7D3CFCB29EE7A4400F8C764 /* libmbedcrypto.a in Frameworks */,
+				E7D3CFCC29EE7A4400F8C764 /* libqcbor.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -369,7 +422,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				E74FFBBA263BAB38003B66FF /* libcrypto.a in Frameworks */,
-				E7C960A727F7569F00FB537C /* libqcbor.a in Frameworks */,
+				E7D3CFA729E1190800F8C764 /* libqcbor.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -586,6 +639,7 @@
 				E73CDAC623A7316700D262E0 /* t_cose_psa */,
 				E73BF6EE23AFFB4100DF5C36 /* PSA examples */,
 				E73BF71C23B07ACF00DF5C36 /* Ossl examples */,
+				E7D3CFD129EE7A4400F8C764 /* t_cose_psa_qcbor2 */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -656,7 +710,7 @@
 		E7F70AB22270D989007CE07F /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				E7C960A527F7569500FB537C /* libqcbor.a */,
+				E7D3CFA529E1167000F8C764 /* libqcbor.a */,
 				E751F9F027E1F90F00EBA5FA /* libmbedcrypto.a */,
 				E74FFBB8263BAB0D003B66FF /* libcrypto.a */,
 			);
@@ -757,6 +811,23 @@
 			productReference = E73CDAC623A7316700D262E0 /* t_cose_psa */;
 			productType = "com.apple.product-type.tool";
 		};
+		E7D3CFA829EE7A4400F8C764 /* t_cose_psa_qcbor2 */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = E7D3CFCE29EE7A4400F8C764 /* Build configuration list for PBXNativeTarget "t_cose_psa_qcbor2" */;
+			buildPhases = (
+				E7D3CFA929EE7A4400F8C764 /* Sources */,
+				E7D3CFCA29EE7A4400F8C764 /* Frameworks */,
+				E7D3CFCD29EE7A4400F8C764 /* CopyFiles */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = t_cose_psa_qcbor2;
+			productName = t_cose;
+			productReference = E7D3CFD129EE7A4400F8C764 /* t_cose_psa_qcbor2 */;
+			productType = "com.apple.product-type.tool";
+		};
 		E7E36E77226CB8400040613B /* t_cose_openssl */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = E7E36E7F226CB8400040613B /* Build configuration list for PBXNativeTarget "t_cose_openssl" */;
@@ -806,6 +877,7 @@
 				E73CDAAC23A7316700D262E0 /* t_cose_psa */,
 				E73BF6D523AFFB4100DF5C36 /* PSA examples */,
 				E73BF70523B07ACF00DF5C36 /* Ossl examples */,
+				E7D3CFA829EE7A4400F8C764 /* t_cose_psa_qcbor2 */,
 			);
 		};
 /* End PBXProject section */
@@ -944,6 +1016,45 @@
 				E7F17343294967CD00E5ADF3 /* hpke.c in Sources */,
 				E73CDABF23A7316700D262E0 /* t_cose_sign1_sign.c in Sources */,
 				E7AE886229A075E40093B326 /* t_cose_key.c in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		E7D3CFA929EE7A4400F8C764 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				E7D3CFAA29EE7A4400F8C764 /* t_cose_sign_sign.c in Sources */,
+				E7D3CFAB29EE7A4400F8C764 /* t_cose_recipient_enc_keywrap.c in Sources */,
+				E7D3CFAC29EE7A4400F8C764 /* t_cose_sign1_verify.c in Sources */,
+				E7D3CFAD29EE7A4400F8C764 /* t_cose_encrypt_dec.c in Sources */,
+				E7D3CFAE29EE7A4400F8C764 /* t_cose_test.c in Sources */,
+				E7D3CFAF29EE7A4400F8C764 /* t_cose_param_test.c in Sources */,
+				E7D3CFB029EE7A4400F8C764 /* t_cose_recipient_dec_hpke.c in Sources */,
+				E7D3CFB129EE7A4400F8C764 /* t_cose_psa_crypto.c in Sources */,
+				E7D3CFB229EE7A4400F8C764 /* t_cose_encrypt_decrypt_test.c in Sources */,
+				E7D3CFB329EE7A4400F8C764 /* t_cose_recipient_enc_hpke.c in Sources */,
+				E7D3CFB429EE7A4400F8C764 /* t_cose_signature_sign_eddsa.c in Sources */,
+				E7D3CFB529EE7A4400F8C764 /* t_cose_util.c in Sources */,
+				E7D3CFB629EE7A4400F8C764 /* t_cose_crypto_test.c in Sources */,
+				E7D3CFB729EE7A4400F8C764 /* t_cose_sign_verify.c in Sources */,
+				E7D3CFB829EE7A4400F8C764 /* t_cose_parameters.c in Sources */,
+				E7D3CFB929EE7A4400F8C764 /* t_cose_sign_verify_test.c in Sources */,
+				E7D3CFBA29EE7A4400F8C764 /* sha256.c in Sources */,
+				E7D3CFBB29EE7A4400F8C764 /* t_cose_mac_validate.c in Sources */,
+				E7D3CFBC29EE7A4400F8C764 /* init_keys_psa.c in Sources */,
+				E7D3CFBD29EE7A4400F8C764 /* t_cose_make_test_messages.c in Sources */,
+				E7D3CFBE29EE7A4400F8C764 /* t_cose_mac_compute.c in Sources */,
+				E7D3CFBF29EE7A4400F8C764 /* main.c in Sources */,
+				E7D3CFC029EE7A4400F8C764 /* t_cose_signature_sign_main.c in Sources */,
+				E7D3CFC129EE7A4400F8C764 /* t_cose_signature_verify_main.c in Sources */,
+				E7D3CFC229EE7A4400F8C764 /* t_cose_encrypt_enc.c in Sources */,
+				E7D3CFC329EE7A4400F8C764 /* run_tests.c in Sources */,
+				E7D3CFC429EE7A4400F8C764 /* t_cose_signature_verify_eddsa.c in Sources */,
+				E7D3CFC529EE7A4400F8C764 /* t_cose_recipient_dec_keywrap.c in Sources */,
+				E7D3CFC629EE7A4400F8C764 /* t_cose_compute_validate_mac_test.c in Sources */,
+				E7D3CFC729EE7A4400F8C764 /* hpke.c in Sources */,
+				E7D3CFC829EE7A4400F8C764 /* t_cose_sign1_sign.c in Sources */,
+				E7D3CFC929EE7A4400F8C764 /* t_cose_key.c in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1108,6 +1219,33 @@
 			};
 			name = Release;
 		};
+		E7D3CFCF29EE7A4400F8C764 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_WARN_ASSIGN_ENUM = YES;
+				CLANG_WARN_IMPLICIT_SIGN_CONVERSION = YES;
+				CLANG_WARN_SUSPICIOUS_IMPLICIT_CONVERSION = YES;
+				CODE_SIGN_STYLE = Automatic;
+				"GCC_PREPROCESSOR_DEFINITIONS[arch=*]" = T_COSE_USE_PSA_CRYPTO;
+				GCC_WARN_SHADOW = YES;
+				GCC_WARN_SIGN_COMPARE = YES;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Debug;
+		};
+		E7D3CFD029EE7A4400F8C764 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_WARN_ASSIGN_ENUM = YES;
+				CLANG_WARN_IMPLICIT_SIGN_CONVERSION = YES;
+				CLANG_WARN_SUSPICIOUS_IMPLICIT_CONVERSION = YES;
+				CODE_SIGN_STYLE = Automatic;
+				GCC_WARN_SHADOW = YES;
+				GCC_WARN_SIGN_COMPARE = YES;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Release;
+		};
 		E7E36E7D226CB8400040613B /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -1247,9 +1385,13 @@
 				);
 				HEADER_SEARCH_PATHS = (
 					inc,
+					../../QCBOR/dev2/inc,
 					/usr/local/include,
 				);
-				LIBRARY_SEARCH_PATHS = /usr/local/lib;
+				LIBRARY_SEARCH_PATHS = (
+					../../QCBOR/dev2,
+					/usr/local/lib,
+				);
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Debug;
@@ -1267,6 +1409,7 @@
 				);
 				HEADER_SEARCH_PATHS = (
 					inc,
+					../../QCBOR/dev2/inc,
 					/usr/local/include,
 				);
 				LIBRARY_SEARCH_PATHS = /usr/local/lib;
@@ -1310,6 +1453,15 @@
 			buildConfigurations = (
 				E73CDAC423A7316700D262E0 /* Debug */,
 				E73CDAC523A7316700D262E0 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		E7D3CFCE29EE7A4400F8C764 /* Build configuration list for PBXNativeTarget "t_cose_psa_qcbor2" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				E7D3CFCF29EE7A4400F8C764 /* Debug */,
+				E7D3CFD029EE7A4400F8C764 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/test/run_tests.c
+++ b/test/run_tests.c
@@ -58,7 +58,6 @@ static test_entry2 s_tests2[] = {
 
 static test_entry s_tests[] = {
 
-    TEST_ENTRY(verify_multi_test),
     TEST_ENTRY(aead_test),
 #ifndef T_COSE_DISABLE_KEYWRAP
     TEST_ENTRY(kw_test),
@@ -85,6 +84,7 @@ static test_entry s_tests[] = {
     TEST_ENTRY(sign_verify_known_good_test),
     TEST_ENTRY(sign_verify_unsupported_test),
     TEST_ENTRY(sign_verify_bad_auxiliary_buffer),
+    TEST_ENTRY(verify_multi_test),
     
 #endif /* T_COSE_DISABLE_SIGN1 */
 

--- a/test/run_tests.c
+++ b/test/run_tests.c
@@ -58,7 +58,7 @@ static test_entry2 s_tests2[] = {
 
 static test_entry s_tests[] = {
 
-
+    TEST_ENTRY(verify_multi_test),
     TEST_ENTRY(aead_test),
 #ifndef T_COSE_DISABLE_KEYWRAP
     TEST_ENTRY(kw_test),

--- a/test/t_cose_param_test.c
+++ b/test/t_cose_param_test.c
@@ -668,7 +668,7 @@ param_test(void)
         /* Encode test */
         if(param_test->unencoded.value_type != NO_ENCODE_TEST) {
             QCBOREncode_Init(&qcbor_encoder, encode_buffer);
-            t_cose_result = t_cose_encode_headers(&qcbor_encoder,
+            t_cose_result = t_cose_headers_encode(&qcbor_encoder,
                                                   &(param_test->unencoded),
                                                   NULL);
 
@@ -698,6 +698,8 @@ param_test(void)
             struct t_cose_parameter *decoded_parameter;
 
             QCBORDecode_Init(&decode_context, param_test->encoded, 0);
+
+            decoded_parameter = NULL;
 
             t_cose_result = t_cose_headers_decode(&decode_context,
                                                   (struct t_cose_header_location){0,0},
@@ -765,7 +767,7 @@ param_test(void)
         }
 
         QCBOREncode_Init(&qcbor_encoder, encode_buffer);
-        t_cose_result = t_cose_encode_headers(&qcbor_encoder,
+        t_cose_result = t_cose_headers_encode(&qcbor_encoder,
                                               param_array,
                                               NULL);
 
@@ -814,7 +816,7 @@ param_test(void)
 
 
     QCBOREncode_Init(&qcbor_encoder, encode_buffer);
-    t_cose_result = t_cose_encode_headers(&qcbor_encoder,
+    t_cose_result = t_cose_headers_encode(&qcbor_encoder,
                                           &param_array[0],
                                           NULL);
 
@@ -864,6 +866,7 @@ param_test(void)
     param_storage.size = sizeof(param_array)/sizeof(struct t_cose_parameter);
     param_storage.storage = param_array;
     param_storage.used = 0;
+    dec = NULL;
 
 
     t_cose_result = t_cose_headers_decode(&decode_context,
@@ -910,7 +913,7 @@ param_test(void)
 
     /* Empty parameters section test */
     QCBOREncode_Init(&qcbor_encoder, encode_buffer);
-    t_cose_result = t_cose_encode_headers(&qcbor_encoder,
+    t_cose_result = t_cose_headers_encode(&qcbor_encoder,
                                           NULL,
                                           NULL);
 
@@ -935,6 +938,8 @@ param_test(void)
     param_storage.used = 0;
     param_storage.storage = param_array;
     struct t_cose_parameter *decoded_parameter;
+
+    decoded_parameter = NULL;
 
     QCBORDecode_Init(&decode_context, encoded_params, 0);
 

--- a/test/t_cose_sign_verify_test.c
+++ b/test/t_cose_sign_verify_test.c
@@ -16,6 +16,9 @@
 #include "init_keys.h"
 #include "t_cose_sign_verify_test.h"
 
+#include "t_cose/t_cose_signature_verify_eddsa.h"
+#include "t_cose/t_cose_signature_verify_main.h"
+
 #include "t_cose_crypto.h" /* Just for t_cose_crypto_sig_size() */
 
 /* These are complete known-good COSE messages for a verification
@@ -985,6 +988,8 @@ Done:
 }
 
 
+
+
 int_fast32_t sign_verify_multi(void)
 {
     enum t_cose_err_t              result;
@@ -1053,7 +1058,7 @@ int_fast32_t sign_verify_multi(void)
         return 2;
     }
 
-    t_cose_sign_verify_init(&verify_ctx, T_COSE_OPT_MESSAGE_TYPE_SIGN | T_COSE_VERIFY_ALL_SIGNATURES);
+    t_cose_sign_verify_init(&verify_ctx, T_COSE_OPT_MESSAGE_TYPE_SIGN | T_COSE_OPT_VERIFY_ALL_SIGNATURES);
 
     t_cose_signature_verify_main_init(&verify1);
     t_cose_signature_verify_main_set_key(&verify1, key_pair1, Q_USEFUL_BUF_FROM_SZ_LITERAL("kid1"));
@@ -1090,3 +1095,160 @@ int_fast32_t sign_verify_multi(void)
 
     return 0;
 }
+
+
+
+static enum t_cose_err_t
+make_triple_signed(struct q_useful_buf buffer,
+                   struct q_useful_buf_c *signed_message)
+{
+    enum t_cose_err_t            result;
+    struct t_cose_sign_sign_ctx  signing_ctx;
+    MakeUsefulBufOnStack(        eddsa_aux_buf, 100);
+
+
+    t_cose_sign_sign_init(&signing_ctx, T_COSE_OPT_MESSAGE_TYPE_SIGN);
+
+    struct t_cose_signature_sign_main  ecdsa_signer;
+    struct t_cose_key                  ecdsa_key;
+    t_cose_signature_sign_main_init(&ecdsa_signer, T_COSE_ALGORITHM_ES256);
+    init_fixed_test_signing_key(T_COSE_ALGORITHM_ES256, &ecdsa_key);
+    t_cose_signature_sign_main_set_signing_key(&ecdsa_signer,
+                                               ecdsa_key,
+                                               Q_USEFUL_BUF_FROM_SZ_LITERAL("ecsda_kid"));
+    t_cose_sign_add_signer(&signing_ctx, t_cose_signature_sign_from_main(&ecdsa_signer));
+
+
+
+    struct t_cose_signature_sign_eddsa eddsa_signer;
+    struct t_cose_key                  eddsa_key;
+    t_cose_signature_sign_eddsa_init(&eddsa_signer);
+    init_fixed_test_signing_key(T_COSE_ALGORITHM_EDDSA, &eddsa_key);
+    t_cose_signature_sign_eddsa_set_signing_key(&eddsa_signer,
+                                               eddsa_key,
+                                               Q_USEFUL_BUF_FROM_SZ_LITERAL("eddsa_kid"));
+    t_cose_signature_sign_eddsa_set_auxiliary_buffer(&eddsa_signer, eddsa_aux_buf);
+    t_cose_sign_add_signer(&signing_ctx, t_cose_signature_sign_from_eddsa(&eddsa_signer));
+
+
+    struct t_cose_signature_sign_main  rsa_signer;
+    struct t_cose_key                  rsa_key;
+    t_cose_signature_sign_main_init(&rsa_signer, T_COSE_ALGORITHM_PS256);
+    init_fixed_test_signing_key(T_COSE_ALGORITHM_PS256, &rsa_key);
+    t_cose_signature_sign_main_set_signing_key(&rsa_signer,
+                                               rsa_key,
+                                               Q_USEFUL_BUF_FROM_SZ_LITERAL("rsa_kid"));
+    t_cose_sign_add_signer(&signing_ctx, t_cose_signature_sign_from_main(&rsa_signer));
+
+    result = t_cose_sign_sign(&signing_ctx,
+                               Q_USEFUL_BUF_FROM_SZ_LITERAL("SAMPLE AAD"),
+                               Q_USEFUL_BUF_FROM_SZ_LITERAL("SAMPLE PAYLOAD"),
+                               buffer, signed_message);
+
+    free_fixed_signing_key(ecdsa_key);
+    free_fixed_signing_key(eddsa_key);
+    free_fixed_signing_key(rsa_key);
+
+    return result;
+}
+
+
+int32_t verify_multi_test(void)
+{
+    enum t_cose_err_t err;
+    MakeUsefulBufOnStack(cose_sign_buf, 700);
+    struct q_useful_buf_c cose_sign;
+    struct t_cose_parameter param_pool[25];
+    Q_USEFUL_BUF_MAKE_STACK_UB(    auxiliary_buffer, 100);
+
+
+    /* This requires Eddsa, RSA and ECDSA. Since PSA doesn't support EdDSA,
+     * this can only run with OpenSSL.
+     */
+    // TODO: check for algorithm support?
+    err = make_triple_signed(cose_sign_buf, &cose_sign);
+
+
+    struct t_cose_sign_verify_ctx  verify_ctx;
+    struct q_useful_buf_c payload;
+
+    t_cose_sign_verify_init(&verify_ctx, T_COSE_OPT_MESSAGE_TYPE_SIGN | T_COSE_OPT_VERIFY_ALL_SIGNATURES);
+
+    struct t_cose_parameter_storage st;
+    T_COSE_PARAM_STORAGE_INIT(st, param_pool);
+    t_cose_sign_add_param_storage(&verify_ctx, &st);
+
+
+    struct t_cose_signature_verify_main verify_ecdsa;
+    struct t_cose_key                   ecdsa_key;
+    init_fixed_test_signing_key(T_COSE_ALGORITHM_ES256, &ecdsa_key);
+    t_cose_signature_verify_main_init(&verify_ecdsa);
+    t_cose_signature_verify_main_set_key(&verify_ecdsa,
+                                         ecdsa_key,
+                                         Q_USEFUL_BUF_FROM_SZ_LITERAL("ecsda_kid"));
+    t_cose_sign_add_verifier(&verify_ctx, &verify_ecdsa);
+
+
+    err = t_cose_sign_verify(&verify_ctx,
+                              cose_sign,
+                              Q_USEFUL_BUF_FROM_SZ_LITERAL("SAMPLE AAD"),
+                             &payload,
+                              NULL);
+
+    /* Not all verifier were configured, but verify all was requested so
+     * decline is expected */
+    if(err != T_COSE_ERR_DECLINE) {
+        return 11;
+    }
+
+
+    struct t_cose_signature_verify_eddsa verify_eddsa;
+    struct t_cose_key                   eddsa_key;
+    init_fixed_test_signing_key(T_COSE_ALGORITHM_EDDSA, &eddsa_key);
+    t_cose_signature_verify_eddsa_init(&verify_eddsa, 0);  // TODO: why does this have option flags and _main_ doesn't
+    t_cose_signature_verify_eddsa_set_key(&verify_eddsa,
+                                         eddsa_key,
+                                         Q_USEFUL_BUF_FROM_SZ_LITERAL("eddsa_kid"));
+    t_cose_signature_verify_eddsa_set_auxiliary_buffer(&verify_eddsa, auxiliary_buffer);
+    t_cose_sign_add_verifier(&verify_ctx, &verify_eddsa);
+
+
+
+    struct t_cose_signature_verify_main verify_rsa;
+    struct t_cose_key                   rsa_key;
+    init_fixed_test_signing_key(T_COSE_ALGORITHM_PS256, &rsa_key);
+    t_cose_signature_verify_main_init(&verify_rsa);
+    t_cose_signature_verify_main_set_key(&verify_rsa,
+                                         rsa_key,
+                                         Q_USEFUL_BUF_FROM_SZ_LITERAL("rsa_kid"));
+    t_cose_sign_add_verifier(&verify_ctx, &verify_rsa);
+
+    err = t_cose_sign_verify(&verify_ctx,
+                              cose_sign,
+                              Q_USEFUL_BUF_FROM_SZ_LITERAL("SAMPLE AAD"),
+                             &payload,
+                              NULL);
+
+    if(err != T_COSE_SUCCESS) {
+        return 4;
+    }
+
+
+    return 0;
+
+
+}
+
+/*
+
+ Conditions:
+ - Require all three to verify and see success
+ - Require all three where one fails
+ - Require one sig and the 3rd one succeeds
+ - Require one sig and none succeed because they all decline
+ - Require one sig and one fails because the data is corrupt/key is wrong
+
+- Use one message signed with ES256, EdDSA and RS2048
+ 
+
+ */

--- a/test/t_cose_sign_verify_test.c
+++ b/test/t_cose_sign_verify_test.c
@@ -1186,7 +1186,7 @@ int32_t verify_multi_test(void)
     t_cose_signature_verify_main_set_key(&verify_ecdsa,
                                          ecdsa_key,
                                          Q_USEFUL_BUF_FROM_SZ_LITERAL("ecsda_kid"));
-    t_cose_sign_add_verifier(&verify_ctx, &verify_ecdsa);
+    t_cose_sign_add_verifier(&verify_ctx, (struct t_cose_signature_verify *)&verify_ecdsa);
 
 
     err = t_cose_sign_verify(&verify_ctx,
@@ -1210,7 +1210,7 @@ int32_t verify_multi_test(void)
                                          eddsa_key,
                                          Q_USEFUL_BUF_FROM_SZ_LITERAL("eddsa_kid"));
     t_cose_signature_verify_eddsa_set_auxiliary_buffer(&verify_eddsa, auxiliary_buffer);
-    t_cose_sign_add_verifier(&verify_ctx, &verify_eddsa);
+    t_cose_sign_add_verifier(&verify_ctx, (struct t_cose_signature_verify *)&verify_eddsa);
 
 
 
@@ -1221,7 +1221,7 @@ int32_t verify_multi_test(void)
     t_cose_signature_verify_main_set_key(&verify_rsa,
                                          rsa_key,
                                          Q_USEFUL_BUF_FROM_SZ_LITERAL("rsa_kid"));
-    t_cose_sign_add_verifier(&verify_ctx, &verify_rsa);
+    t_cose_sign_add_verifier(&verify_ctx, (struct t_cose_signature_verify *)&verify_rsa);
 
     err = t_cose_sign_verify(&verify_ctx,
                               cose_sign,

--- a/test/t_cose_sign_verify_test.h
+++ b/test/t_cose_sign_verify_test.h
@@ -71,4 +71,8 @@ int_fast32_t sign_verify_bad_auxiliary_buffer(void);
 int_fast32_t sign_verify_multi(void);
 
 
+
+int32_t verify_multi_test(void);
+
+
 #endif /* t_cose_sign_verify_test_h */

--- a/test/t_cose_test.c
+++ b/test/t_cose_test.c
@@ -1150,7 +1150,7 @@ foo_decode_cb(void                    *cb_context,
         int64_t n1, n2;
 
         QCBORDecode_EnterMap(cbor_decoder, NULL);
-        QCBORDecode_GetInt64InMapSZ (cbor_decoder, "xxx", &n1);
+        QCBORDecode_GetInt64InMapSZ(cbor_decoder, "xxx", &n1);
         QCBORDecode_GetInt64InMapSZ(cbor_decoder, "yyy", &n2);
         QCBORDecode_ExitMap(cbor_decoder);
         if(QCBORDecode_IsNotWellFormedError(QCBORDecode_GetError(cbor_decoder))) {
@@ -1159,7 +1159,6 @@ foo_decode_cb(void                    *cb_context,
 
         parameter->value.special_decode.value.little_buf[0] = (uint8_t)n1;
         parameter->value.special_decode.value.little_buf[1] = (uint8_t)n2;
-        parameter->value.special_decode.status = SP_DECODED;
         parameter->value_type = T_COSE_PARAMETER_TYPE_SPECIAL;
 
     } else if(parameter->label == 314) {
@@ -1167,15 +1166,10 @@ foo_decode_cb(void                    *cb_context,
         QCBORDecode_GetDouble(cbor_decoder, &dd);
 
         parameter->value.special_decode.value.uint64 = UsefulBufUtil_CopyDoubleToUint64(dd);
-        parameter->value.special_decode.status = SP_DECODED;
         parameter->value_type = T_COSE_PARAMETER_TYPE_SPECIAL;
 
     } else {
-        /* A label we don't understand. */
-        if(parameter->critical) {
-            return T_COSE_ERR_UNKNOWN_CRITICAL_PARAMETER;
-        }
-        parameter->value.special_decode.status = SP_NOT_DECODED;
+        return T_COSE_ERR_DECLINE;
     }
 
     return T_COSE_SUCCESS;
@@ -1192,6 +1186,8 @@ float_encode_cb(const struct t_cose_parameter  *parameter,
 
     return T_COSE_SUCCESS;
 }
+
+
 
 
 static int32_t
@@ -1276,12 +1272,13 @@ make_complex_cose_sign(struct q_useful_buf cose_sign_buf, struct q_useful_buf_c 
     free_fixed_signing_key(sig2_key);
     free_fixed_signing_key(sig3_key);
 
+
     return 0;
 }
 
 
 /* This checks the value for all special headers by having the
- * expected valued hard-coded in.
+ * expected values hard-coded in.
  */
 static int32_t
 match_special(const struct t_cose_parameter *p1)
@@ -1511,7 +1508,7 @@ int_fast32_t sign1_structure_decode_test(void)
                                     &payload,
                                     &decoded_params);
         if(result != T_COSE_SUCCESS) {
-            return -999;
+            return -99;
         }
 
         return_value = check_complex_sign_params(decoded_params);


### PR DESCRIPTION
Clarifications, improved naming and documentation wording improvements in the parameter encoding/decoding API.

Fix bugs in header parameter decoding for multiple signers.

Allow disable of some API usage checks for signing to save object code.

t_cose_parameter_list_append now handles an initial NULL list (just makes code prettier)

Add a test to verify multiple signatures

Bug fixes for verifying multiple signatures

Refactor code for verifying multiple signatures.