### PR TITLE
Align MAC related symbols to naming conventions

### DIFF
--- a/inc/t_cose/t_cose_mac_validate.h
+++ b/inc/t_cose/t_cose_mac_validate.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2019, Laurence Lundblade. All rights reserved.
- * Copyright (c) 2020-2022 Arm Limited. All rights reserved.
+ * Copyright (c) 2020-2023 Arm Limited. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -28,12 +28,12 @@ extern "C" {
 #define T_COSE_MAX_TAGS_TO_RETURN 4
 
 /**
- * Context for tag verification.  It is about 24 bytes on a
+ * Context for tag validation.  It is about 24 bytes on a
  * 64-bit machine and 12 bytes on a 32-bit machine.
  */
 struct t_cose_mac_validate_ctx {
     /* Private data structure */
-    struct t_cose_key                verification_key;
+    struct t_cose_key                validation_key;
     int32_t                          option_flags;
     uint64_t                         auTags[T_COSE_MAX_TAGS_TO_RETURN];
     struct t_cose_parameter          __params[T_COSE_NUM_VERIFY_DECODE_HEADERS];
@@ -42,12 +42,12 @@ struct t_cose_mac_validate_ctx {
 
 
 /**
- * \brief Initialize for \c COSE_Mac0 message verification.
+ * \brief Initialize for \c COSE_Mac0 message validation.
  *
  * \param[in,out]  context       The context to initialize.
- * \param[in]      option_flags  Options controlling the verification.
+ * \param[in]      option_flags  Options controlling the validation.
  *
- * This must be called before using the verification context.
+ * This must be called before using the validation context.
  */
 static void
 t_cose_mac_validate_init(struct t_cose_mac_validate_ctx *context,
@@ -55,44 +55,44 @@ t_cose_mac_validate_init(struct t_cose_mac_validate_ctx *context,
 
 
 /**
- * \brief Set key for \c COSE_Mac0 message verification.
+ * \brief Set key for \c COSE_Mac0 message validation.
  *
- * \param[in,out] context      The context of COSE_Mac0 verification
- * \param[in] verify_key       The verification key to use.
+ * \param[in,out] context      The context of COSE_Mac0 validation.
+ * \param[in] validate_key     The validation key to use.
  *
- * Look up by kid parameter and fetch the key for MAC verification.
- * Setup the \ref verify_key structure and fill it in \ref context.
+ * Look up by kid parameter and fetch the key for MAC validation.
+ * Setup the \ref validate_key structure and fill it in \ref context.
  */
 static void
 t_cose_mac_set_validate_key(struct t_cose_mac_validate_ctx *context,
-                            struct t_cose_key               verify_key);
+                            struct t_cose_key               validate_key);
 
 /**
- * \brief Verify a COSE_Mac0
+ * \brief Validate a COSE_Mac0
  *
- * \param[in] context      The context of COSE_Mac0 verification
- * \param[in] cose_mac    Pointer and length of CBOR encoded \c COSE_Mac0
- *                         that is to be verified.
+ * \param[in] context      The context of COSE_Mac0 validation.
+ * \param[in] cose_mac     Pointer and length of CBOR encoded \c COSE_Mac0
+ *                         that is to be validated.
  * \param[out] payload     Pointer and length of the still CBOR encoded
- *                         payload
+ *                         payload.
  *
  * \return This returns one of the error codes defined by \ref t_cose_err_t.
  *
- * Verification involves the following steps.
+ * The validation involves the following steps.
  *
- * The CBOR structure is parsed and verified. It makes sure \c COSE_Mac0
+ * The CBOR structure is parsed and validated. It makes sure \c COSE_Mac0
  * is valid CBOR and that it is tagged as a \c COSE_Mac0.
  *
- * The signing algorithm is pulled out of the protected headers.
+ * The MAC algorithm is pulled out of the protected headers.
  *
  * The kid (key ID) is parsed out of the unprotected headers if it exists.
  *
  * The payload is identified. It doesn't have to be parsed in detail
  * because it is wrapped in a bstr.
  *
- * Finally, the MAC verification is performed if \ref T_COSE_OPT_DECODE_ONLY
- * is not set in option flag. Otherwise, the verification will be skipped.
- * The MAC algorithm to use comes from the signing algorithm in the
+ * Finally, the MAC validation is performed if \ref T_COSE_OPT_DECODE_ONLY
+ * is not set in option flag. Otherwise, the validation will be skipped.
+ * The MAC algorithm to use comes from the algorithm field in the
  * protected headers.
  * If the algorithm is not known or not supported this will error out.
  *
@@ -134,9 +134,9 @@ t_cose_mac_validate_init(struct t_cose_mac_validate_ctx *me,
 
 static inline void
 t_cose_mac_set_validate_key(struct t_cose_mac_validate_ctx *context,
-                            struct t_cose_key               verify_key)
+                            struct t_cose_key               validate_key)
 {
-    context->verification_key = verify_key;
+    context->validation_key = validate_key;
 }
 
 static inline enum t_cose_err_t

--- a/src/t_cose_mac_compute.c
+++ b/src/t_cose_mac_compute.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2018-2023, Laurence Lundblade. All rights reserved.
- * Copyright (c) 2020-2022, Arm Limited. All rights reserved.
+ * Copyright (c) 2020-2023, Arm Limited. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *
@@ -16,7 +16,7 @@
 /**
  * \file t_cose_mac_compute.c
  *
- * \brief This creates t_cose Mac authentication structure without a recipient
+ * \brief This creates t_cose MAC authentication structure without a recipient
  *        structure.
  *        Only HMAC is supported so far.
  */
@@ -138,7 +138,7 @@ t_cose_mac_encode_tag(struct t_cose_mac_calculate_ctx *me,
     Q_USEFUL_BUF_MAKE_STACK_UB(  tbm_first_part_buf,
                                  T_COSE_SIZE_OF_TBM);
     struct t_cose_crypto_hmac    hmac_ctx;
-    struct t_cose_sign_inputs    sign_input;
+    struct t_cose_sign_inputs    mac_input;
 
     /* Check that there are no CBOR encoding errors before proceeding
      * with hashing and tagging. This is not actually necessary as the
@@ -167,11 +167,11 @@ t_cose_mac_encode_tag(struct t_cose_mac_calculate_ctx *me,
      * MAC are the protected parameters, the payload that is
      * getting MACed.
      */
-    sign_input.aad = NULL_Q_USEFUL_BUF_C; // TODO: this won't be NULL when AAD is supported
-    sign_input.payload = maced_payload;
-    sign_input.body_protected = me->protected_parameters;
-    sign_input.sign_protected = NULL_Q_USEFUL_BUF_C; /* Never sign-protected for MAC */
-    return_value = create_tbm(&sign_input,
+    mac_input.aad = NULL_Q_USEFUL_BUF_C; // TODO: this won't be NULL when AAD is supported
+    mac_input.payload = maced_payload;
+    mac_input.body_protected = me->protected_parameters;
+    mac_input.sign_protected = NULL_Q_USEFUL_BUF_C; /* Never sign-protected for MAC */
+    return_value = create_tbm(&mac_input,
                               tbm_first_part_buf,
                               &tbm_first_part);
     if(return_value) {
@@ -184,7 +184,7 @@ t_cose_mac_encode_tag(struct t_cose_mac_calculate_ctx *me,
      * payload, to save a bigger buffer containing the entire ToBeMaced.
      */
     return_value = t_cose_crypto_hmac_compute_setup(&hmac_ctx,
-                                                    me->signing_key,
+                                                    me->mac_key,
                                                     me->cose_algorithm_id);
     if(return_value) {
         goto Done;

--- a/src/t_cose_util.c
+++ b/src/t_cose_util.c
@@ -2,7 +2,7 @@
  *  t_cose_util.c
  *
  * Copyright 2019-2023, Laurence Lundblade
- * Copyright (c) 2020, Arm Limited. All rights reserved.
+ * Copyright (c) 2020-2023, Arm Limited. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *
@@ -115,7 +115,7 @@ hash_alg_id_from_sig_alg_id(int32_t cose_algorithm_id)
 // TODO: try to combine with create_tbs_hash so that no buffer for headers
 // is needed. Make sure it doesn't make sign-only or mac-only object code big
 enum t_cose_err_t
-create_tbm(const struct t_cose_sign_inputs *sign_inputs,
+create_tbm(const struct t_cose_sign_inputs *mac_inputs,
            struct q_useful_buf              tbm_first_part_buf,
            struct q_useful_buf_c           *tbm_first_part)
 {
@@ -128,13 +128,13 @@ create_tbm(const struct t_cose_sign_inputs *sign_inputs,
     /* context */
     QCBOREncode_AddBytes(&cbor_encode_ctx, Q_USEFUL_BUF_FROM_SZ_LITERAL(COSE_MAC_CONTEXT_STRING_MAC0));
     /* body_protected */
-    QCBOREncode_AddBytes(&cbor_encode_ctx, sign_inputs->body_protected);
+    QCBOREncode_AddBytes(&cbor_encode_ctx, mac_inputs->body_protected);
 
     /* external_aad. There is none so an empty bstr */
     QCBOREncode_AddBytes(&cbor_encode_ctx, NULL_Q_USEFUL_BUF_C);
 
     /* The short fake payload. */
-    QCBOREncode_AddBytesLenOnly(&cbor_encode_ctx, sign_inputs->payload);
+    QCBOREncode_AddBytesLenOnly(&cbor_encode_ctx, mac_inputs->payload);
 
     /* Close of the array */
     QCBOREncode_CloseArray(&cbor_encode_ctx);

--- a/src/t_cose_util.h
+++ b/src/t_cose_util.h
@@ -2,7 +2,7 @@
  *  t_cose_util.h
  *
  * Copyright 2019-2023, Laurence Lundblade
- * Copyright (c) 2020-2022, Arm Limited. All rights reserved.
+ * Copyright (c) 2020-2023, Arm Limited. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *
@@ -95,8 +95,9 @@ int32_t hash_alg_id_from_sig_alg_id(int32_t cose_algorithm_id);
 /**
  * \brief Create the ToBeMaced (TBM) structure bytes for COSE.
  *
- * \param[in] tbm_first_part_buf  The buffer to contain the first part
- * \param[in] sign_inputs    The input to be mac'd -- payload, aad, protected headers.
+ * \param[in] mac_inputs          The input to be mac'd -- payload, aad,
+ *                                protected headers.
+ * \param[in]  tbm_first_part_buf The buffer to contain the first part.
  * \param[out] tbm_first_part     Pointer and length of buffer into which
  *                                the resulting TBM is put.
  *
@@ -110,7 +111,7 @@ int32_t hash_alg_id_from_sig_alg_id(int32_t cose_algorithm_id);
  * \retval T_COSE_ERR_HASH_GENERAL_FAIL
  *         In case of some general hash failure.
  */
-enum t_cose_err_t create_tbm(const struct t_cose_sign_inputs *sign_inputs,
+enum t_cose_err_t create_tbm(const struct t_cose_sign_inputs *mac_inputs,
                              struct q_useful_buf              tbm_first_part_buf,
                              struct q_useful_buf_c           *tbm_first_part);
 
@@ -118,7 +119,7 @@ enum t_cose_err_t create_tbm(const struct t_cose_sign_inputs *sign_inputs,
 /**
  * Serialize the to-be-signed (TBS) bytes for COSE.
  *
- * \param[in] sign_inputs               The payload, AAD and header params to hash.
+ * \param[in] sign_inputs           The payload, AAD and header params to hash.
  * \param[in] buffer_for_tbs        Pointer and length of buffer into which
  *                                  the resulting TBS bytes is put.
  * \param[out] tbs                  Pointer and length of the
@@ -154,7 +155,7 @@ enum t_cose_err_t create_tbs(const struct t_cose_sign_inputs *sign_inputs,
  * \return This returns one of the error codes defined by \ref t_cose_err_t.
  * \retval T_COSE_ERR_UNSUPPORTED_HASH
  *         If the hash algorithm is not known.
- * \retval T_COSE_ERR_HASH_BUFFER_SIZE  
+ * \retval T_COSE_ERR_HASH_BUFFER_SIZE
  *         \c buffer_for_tbs is too small.
  * \retval T_COSE_ERR_HASH_GENERAL_FAIL
  *         In case of some general hash failure.
@@ -261,7 +262,7 @@ t_cose_check_list(int32_t cose_algorithm_id, const int32_t *list);
 /**
  * \brief Map a 16-bit integer like an error code to another.
  *
- * \param[in] map   Two-dimentional array that is the mapping.
+ * \param[in] map    Two-dimentional array that is the mapping.
  * \param[in] query  The input to map
  *
  * \returns The output of the mapping.

--- a/test/run_tests.c
+++ b/test/run_tests.c
@@ -2,7 +2,7 @@
  * run_tests.c -- test aggregator and results reporting
  *
  * Copyright (c) 2018-2023, Laurence Lundblade. All rights reserved.
- * Copyright (c) 2022 Arm Limited. All rights reserved.
+ * Copyright (c) 2022-2023, Arm Limited. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *
@@ -70,15 +70,15 @@ static test_entry s_tests[] = {
     TEST_ENTRY(sign_verify_known_good_test),
     TEST_ENTRY(sign_verify_unsupported_test),
     TEST_ENTRY(sign_verify_bad_auxiliary_buffer),
-    
+
 #endif /* T_COSE_DISABLE_SIGN1 */
 
 #ifndef T_COSE_DISABLE_MAC0
     // TODO: should these really be conditional on T_COSE_DISABLE_SIGN_VERIFY_TESTS
     TEST_ENTRY(compute_validate_mac_basic_test),
-    TEST_ENTRY(compute_validate_mac_sig_fail_test),
+    TEST_ENTRY(compute_validate_mac_fail_test),
     TEST_ENTRY(compute_validate_get_size_mac_test),
-    TEST_ENTRY(compute_validate_detached_content_mac_sig_fail_test),
+    TEST_ENTRY(compute_validate_detached_content_mac_fail_test),
     TEST_ENTRY(compute_validate_get_size_detached_content_mac_test),
 #endif /* T_COSE_DISABLE_MAC0 */
 

--- a/test/t_cose_compute_validate_mac_test.h
+++ b/test/t_cose_compute_validate_mac_test.h
@@ -2,7 +2,7 @@
  *  t_cose_compute_validate_mac_test.h
  *
  * Copyright 2019, 2022, Laurence Lundblade
- * Copyright (c) 2022, Arm Limited. All rights reserved.
+ * Copyright (c) 2022-2023, Arm Limited. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *
@@ -31,9 +31,9 @@ int_fast32_t compute_validate_mac_basic_test(void);
 
 
 /*
- * Sign some data, perturb the data and see that sig validation fails.
+ * Compute MAC of some data, perturb the data and see that MAC validation fails.
  */
-int_fast32_t compute_validate_mac_sig_fail_test(void);
+int_fast32_t compute_validate_mac_fail_test(void);
 
 
 /*
@@ -43,9 +43,9 @@ int_fast32_t compute_validate_get_size_mac_test(void);
 
 
 /*
- * Sign some data, perturb the data and see that sig validation fails.
+ * Compute MAC of some data, perturb the data and see that MAC validation fails.
  */
-int_fast32_t compute_validate_detached_content_mac_sig_fail_test(void);
+int_fast32_t compute_validate_detached_content_mac_fail_test(void);
 
 
 /*


### PR DESCRIPTION
Generally, replace the "sign"/"verify" terms with "MAC"/"compute" and "validate".
This PR aims to resolve issue https://github.com/laurencelundblade/t_cose/issues/127.