### PR TITLE
Remove mention of short-circuit from MAC code

### DIFF
--- a/inc/t_cose/t_cose_mac_compute.h
+++ b/inc/t_cose/t_cose_mac_compute.h
@@ -111,8 +111,7 @@ t_cose_mac_compute_detached(struct t_cose_mac_calculate_ctx *mac_ctx,
  *
  * Initialize the \ref t_cose_mac_calculate_ctx context. Typically, no
  * \c option_flags are needed and 0 is passed. A \c cose_algorithm_id
- * must always be given. See \ref T_COSE_OPT_SHORT_CIRCUIT_TAG and
- * related for possible option flags.
+ * must always be given.
  *
  * The algorithm ID space is from
  * [COSE (RFC9053)](https://tools.ietf.org/html/rfc9053) and the
@@ -138,11 +137,7 @@ t_cose_mac_compute_init(struct t_cose_mac_calculate_ctx *context,
  * This needs to be called to set the MAC key to use. The \c kid
  * may be omitted by giving \c NULL_Q_USEFUL_BUF_C.
  *
- * If short-circuit signing is used,
- * \ref T_COSE_OPT_SHORT_CIRCUIT_TAG, then this does not need to be
- * called.
- *
- * TODO: remove mention of short circuit; is empty key really OK?
+ * TODO: is empty key really OK?
  */
 static void
 t_cose_mac_set_computing_key(struct t_cose_mac_calculate_ctx *context,

--- a/src/t_cose_crypto.h
+++ b/src/t_cose_crypto.h
@@ -2,7 +2,7 @@
  * t_cose_crypto.h
  *
  * Copyright 2019-2022, Laurence Lundblade
- * Copyright (c) 2020-2022, Arm Limited. All rights reserved.
+ * Copyright (c) 2020-2023, Arm Limited. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *
@@ -804,24 +804,6 @@ static inline size_t t_cose_tag_size(int32_t cose_alg_id)
             return INT32_MAX;
     }
 }
-
-#ifndef T_COSE_DISABLE_SHORT_CIRCUIT_SIGN
-/*
- * Get the COSE Hash algorithm ID from the corresponding
- * COSE HMAC algorithm ID
- */
-static inline int32_t t_cose_hmac_to_hash_alg_id(int32_t cose_hamc_alg_id)
-{
-    switch(cose_hamc_alg_id) {
-        case T_COSE_ALGORITHM_HMAC256:
-            return T_COSE_ALGORITHM_SHA_256;
-
-        default:
-            return INT32_MAX;
-    }
-}
-#endif
-
 
 
 /**

--- a/src/t_cose_util.h
+++ b/src/t_cose_util.h
@@ -228,7 +228,7 @@ create_enc_structure(const char             *context_string,
  *
  */
 struct q_useful_buf_c get_short_circuit_kid(void);
-#endif
+#endif /* !T_COSE_DISABLE_SHORT_CIRCUIT_SIGN */
 
 
 /**


### PR DESCRIPTION
- Short-circuit option is not supported with MAC (it was removed when the Mac0 contribution happened).
Remove residual mentions of it from the code.
- t_cose_hmac_to_hash_alg_id() is unused for the same reason, remove it.
