### PR TITLE
Reporting of tests that didn't do any testing

### DIFF
--- a/src/t_cose_mac_validate.c
+++ b/src/t_cose_mac_validate.c
@@ -258,7 +258,7 @@ t_cose_mac_validate_private(struct t_cose_mac_validate_ctx *me,
     }
 
     /* --- Check for critical parameters --- */
-    if(!(context->option_flags & T_COSE_OPT_NO_CRIT_PARAM_CHECK)) {
+    if(!(me->option_flags & T_COSE_OPT_NO_CRIT_PARAM_CHECK)) {
         return_value = t_cose_params_check(decoded_params);
     }
 

--- a/test/run_tests.c
+++ b/test/run_tests.c
@@ -215,6 +215,13 @@ int RunTestsTCose(const char    *szTestNames[],
         }
 
         int32_t nTestResult = (int32_t)(t->test_fun)();
+
+        if(nTestResult == INT32_MIN) {
+            /* INT32_MIN means tests didn't do any testing. It is typically
+             * returned when the algorithms needed for a test aren't
+             * available when checked by t_cose_is_algorithm_supported(). */
+            continue;
+        }
         nTestsRun++;
         if(pfOutput) {
             (*pfOutput)(t->szTestName, poutCtx, 0);

--- a/test/t_cose_crypto_test.c
+++ b/test/t_cose_crypto_test.c
@@ -172,7 +172,7 @@ int_fast32_t kw_test(void)
          * this dynamically. The below tests will correctly link
          * on 2.28, but will fail to run so this exception is needed.
          */
-        return 0;
+        return INT32_MIN; /* Means no testing was actually done */
     }
 
     e = t_cose_crypto_make_symmetric_key_handle(T_COSE_ALGORITHM_A128GCM,

--- a/test/t_cose_sign_verify_test.c
+++ b/test/t_cose_sign_verify_test.c
@@ -922,7 +922,7 @@ int_fast32_t sign_verify_bad_auxiliary_buffer(void)
      * meaning less if we don't support it.
      */
     if (!t_cose_is_algorithm_supported(T_COSE_ALGORITHM_EDDSA)) {
-        return 0;
+        return INT32_MIN; /* Means no testing was actually done */
     }
 
     result = init_fixed_test_signing_key(T_COSE_ALGORITHM_EDDSA, &key_pair);
@@ -1008,7 +1008,7 @@ int_fast32_t sign_verify_multi(void)
 
     if (!t_cose_is_algorithm_supported(T_COSE_ALGORITHM_ES512)) {
         /* T_COSE_ALGORITHM_ES512 is required for this test */
-        return 0;
+        return INT32_MIN; /* Means no testing was actually done */
     }
 
     result = init_fixed_test_signing_key(T_COSE_ALGORITHM_ES256, &key_pair1);
@@ -1165,7 +1165,7 @@ int32_t verify_multi_test(void)
         !t_cose_is_algorithm_supported(T_COSE_ALGORITHM_EDDSA) ||
         !t_cose_is_algorithm_supported(T_COSE_ALGORITHM_PS256)) {
         /* T_COSE_ALGORITHM_ES512 is required for this test */
-        return 0;
+        return INT32_MIN; /* Means no testing was actually done */
     }
     /* This requires Eddsa, RSA and ECDSA. Since PSA doesn't support EdDSA,
      * this can only run with OpenSSL.

--- a/test/t_cose_test.c
+++ b/test/t_cose_test.c
@@ -2152,7 +2152,7 @@ int_fast32_t crypto_context_test()
      * crypto context behavior tested here.
      */
     if(!t_cose_is_algorithm_supported(T_COSE_ALGORITHM_SHORT_CIRCUIT_256)) {
-        return 0;
+        return INT32_MIN; /* Means no testing was actually done */
     }
     init_fixed_test_signing_key(T_COSE_ALGORITHM_SHORT_CIRCUIT_256, &key_pair);
 


### PR DESCRIPTION
Some tests require a particular algorithm to run. These can now return INT32_MIN as an error code to indicate they didn't run even though they were actually called.

This return code can be used for other reasons too. This should eventually make the #ifdefs in run_tests.c fewer.
