### PR TITLE
Remove kid from crypto adaptor layer

### DIFF
--- a/crypto_adapters/t_cose_openssl_crypto.c
+++ b/crypto_adapters/t_cose_openssl_crypto.c
@@ -858,7 +858,6 @@ Done2:
 enum t_cose_err_t
 t_cose_crypto_verify(const int32_t                cose_algorithm_id,
                      const struct t_cose_key      verification_key,
-                     const struct q_useful_buf_c  kid,
                      void                        *crypto_context,
                      const struct q_useful_buf_c  hash_to_verify,
                      const struct q_useful_buf_c  cose_signature)
@@ -879,10 +878,6 @@ t_cose_crypto_verify(const int32_t                cose_algorithm_id,
      * whether an RSA or ECDSA signature is used
      */
     struct q_useful_buf_c  openssl_signature;
-
-    /* This implementation doesn't use any key store with the ability
-     * to look up a key based on kid. */
-    (void)kid;
 
     (void)crypto_context; /* This crypto adaptor doesn't use this */
 
@@ -1271,7 +1266,6 @@ Done:
  */
 enum t_cose_err_t
 t_cose_crypto_verify_eddsa(struct t_cose_key     verification_key,
-                           struct q_useful_buf_c kid,
                            void                 *crypto_context,
                            struct q_useful_buf_c tbs,
                            struct q_useful_buf_c signature)
@@ -1280,10 +1274,6 @@ t_cose_crypto_verify_eddsa(struct t_cose_key     verification_key,
     int               ossl_result;
     EVP_MD_CTX       *verify_context = NULL;
     EVP_PKEY         *verification_key_evp;
-
-    /* This implementation doesn't use any key store with the ability
-     * to look up a key based on kid. */
-    (void)kid;
 
     (void)crypto_context; /* This crypto adaptor doesn't use this */
 

--- a/crypto_adapters/t_cose_psa_crypto.c
+++ b/crypto_adapters/t_cose_psa_crypto.c
@@ -180,7 +180,6 @@ psa_status_to_t_cose_error_signing(psa_status_t err)
 enum t_cose_err_t
 t_cose_crypto_verify(int32_t               cose_algorithm_id,
                      struct t_cose_key     verification_key,
-                     struct q_useful_buf_c kid,
                      void                 *crypto_context,
                      struct q_useful_buf_c hash_to_verify,
                      struct q_useful_buf_c signature)
@@ -190,12 +189,7 @@ t_cose_crypto_verify(int32_t               cose_algorithm_id,
     enum t_cose_err_t     return_value;
     psa_key_handle_t      verification_key_psa;
 
-    /* This implementation does no look up keys by kid in the key
-     * store */
-    ARG_UNUSED(kid);
-
     (void)crypto_context; /* This crypto-adapter doesn't use this */
-
 
     /* Convert to PSA algorithm ID scheme */
     psa_alg_id = cose_alg_id_to_psa_alg_id(cose_algorithm_id);
@@ -643,13 +637,11 @@ t_cose_crypto_sign_eddsa(struct t_cose_key      signing_key,
 
 enum t_cose_err_t
 t_cose_crypto_verify_eddsa(struct t_cose_key     verification_key,
-                           struct q_useful_buf_c kid,
                            void                 *crypto_context,
                            struct q_useful_buf_c tbs,
                            struct q_useful_buf_c signature)
 {
     (void)verification_key;
-    (void)kid;
     (void)crypto_context;
     (void)tbs;
     (void)signature;

--- a/crypto_adapters/t_cose_test_crypto.c
+++ b/crypto_adapters/t_cose_test_crypto.c
@@ -176,7 +176,6 @@ Done:
 enum t_cose_err_t
 t_cose_crypto_verify(int32_t                cose_algorithm_id,
                      struct t_cose_key      verification_key,
-                     struct q_useful_buf_c  kid,
                      void                  *crypto_context,
                      struct q_useful_buf_c  hash_to_verify,
                      struct q_useful_buf_c  signature)
@@ -186,7 +185,6 @@ t_cose_crypto_verify(int32_t                cose_algorithm_id,
     struct t_cose_test_crypto_context *cc = (struct t_cose_test_crypto_context *)crypto_context;
 
     (void)verification_key;
-    (void)kid;
 
     /* This is used for testing the crypto context */
     if(cc != NULL && cc->test_error != T_COSE_SUCCESS) {
@@ -349,13 +347,11 @@ t_cose_crypto_sign_eddsa(struct t_cose_key      signing_key,
  */
 enum t_cose_err_t
 t_cose_crypto_verify_eddsa(struct t_cose_key     verification_key,
-                           struct q_useful_buf_c kid,
                            void                 *crypto_context,
                            struct q_useful_buf_c tbs,
                            struct q_useful_buf_c signature)
 {
     (void)verification_key;
-    (void)kid;
     (void)crypto_context;
     (void)tbs;
     (void)signature;

--- a/src/t_cose_crypto.h
+++ b/src/t_cose_crypto.h
@@ -281,17 +281,12 @@ t_cose_crypto_sign(int32_t                cose_algorithm_id,
  *                              locally (\c \#define) if the needed one
  *                              hasn't been registered.
  * \param[in] verification_key  The verification key to use.
- * \param[in] kid               The COSE kid (key ID) or \c NULL_Q_USEFUL_BUF_C.
  * \param[in] crypto_context       Pointer to adaptor-specific context. May be NULL.
  * \param[in] hash_to_verify    The hash of the data that is to be verified.
  * \param[in] signature         The COSE-format signature.
  *
  * This verifies that the \c signature passed in was over the \c
  * hash_to_verify passed in.
- *
- * The public key used to verify the signature is selected by the \c
- * kid if it is not \c NULL_Q_USEFUL_BUF_C or the \c key_select if it
- * is.
  *
  * The key selected must be, or include, a public key of the correct
  * type for \c cose_algorithm_id.
@@ -305,9 +300,6 @@ t_cose_crypto_sign(int32_t                cose_algorithm_id,
  *         Signature verification failed. For example, the
  *         cryptographic operations completed successfully but hash
  *         wasn't as expected.
- * \retval T_COSE_ERR_UNKNOWN_KEY
- *         The key identified by \c key_select or a \c kid was
- *         not found.
  * \retval T_COSE_ERR_WRONG_TYPE_OF_KEY
  *         The key was found, but it was the wrong type
  *         for the operation.
@@ -325,7 +317,6 @@ t_cose_crypto_sign(int32_t                cose_algorithm_id,
 enum t_cose_err_t
 t_cose_crypto_verify(int32_t               cose_algorithm_id,
                      struct t_cose_key     verification_key,
-                     struct q_useful_buf_c kid,
                      void                  *crypto_context,
                      struct q_useful_buf_c hash_to_verify,
                      struct q_useful_buf_c signature);
@@ -396,7 +387,6 @@ t_cose_crypto_sign_eddsa(struct t_cose_key      signing_key,
  * an incrementally computed hash.
  *
  * \param[in] verification_key  The verification key to use.
- * \param[in] kid               The COSE kid (key ID) or \c NULL_Q_USEFUL_BUF_C.
  * \param[in] tbs               The data to be verified.
  * \param[in] signature         The COSE-format signature.
  *
@@ -409,9 +399,6 @@ t_cose_crypto_sign_eddsa(struct t_cose_key      signing_key,
  *         Signature verification failed. For example, the
  *         cryptographic operations completed successfully but hash
  *         wasn't as expected.
- * \retval T_COSE_ERR_UNKNOWN_KEY
- *         The key identified by \c key_select or a \c kid was
- *         not found.
  * \retval T_COSE_ERR_WRONG_TYPE_OF_KEY
  *         The key was found, but it was the wrong type
  *         for the operation.
@@ -428,7 +415,6 @@ t_cose_crypto_sign_eddsa(struct t_cose_key      signing_key,
  */
 enum t_cose_err_t
 t_cose_crypto_verify_eddsa(struct t_cose_key     verification_key,
-                           struct q_useful_buf_c kid,
                            void                  *crypto_context,
                            struct q_useful_buf_c tbs,
                            struct q_useful_buf_c signature);

--- a/src/t_cose_signature_verify_eddsa.c
+++ b/src/t_cose_signature_verify_eddsa.c
@@ -91,7 +91,6 @@ t_cose_signature_verify1_eddsa_cb(struct t_cose_signature_verify *me_x,
     }
 
     return_value = t_cose_crypto_verify_eddsa(me->verification_key,
-                                              kid,
                                               NULL,
                                               tbs,
                                               signature);

--- a/src/t_cose_signature_verify_main.c
+++ b/src/t_cose_signature_verify_main.c
@@ -91,6 +91,8 @@ t_cose_signature_verify1_main_cb(struct t_cose_signature_verify   *me_x,
     Q_USEFUL_BUF_MAKE_STACK_UB(  tbs_hash_buffer, T_COSE_CRYPTO_MAX_HASH_SIZE);
     struct q_useful_buf_c        tbs_hash;
 
+    (void)kid;
+
     /* --- Get the parameters values needed --- */
     cose_algorithm_id = t_cose_param_find_alg_id(parameter_list, true);
     if(cose_algorithm_id == T_COSE_ALGORITHM_NONE) {
@@ -131,7 +133,6 @@ t_cose_signature_verify1_main_cb(struct t_cose_signature_verify   *me_x,
     /* -- Verify the signature -- */
     return_value = t_cose_crypto_verify(cose_algorithm_id,
                                         me->verification_key,
-                                        kid,
                                         me->crypto_context,
                                         tbs_hash,
                                         signature);


### PR DESCRIPTION
kid was never used in the signature verification crypto adaptor and this saves object code and simplifies a little.

This can be remove because there is now the opportunity to do kid look up in t_cose_signature implementations. This is a much more appropriate place to do kid processing.