### PR TITLE
Introduce x_DISABLE_COSE_SIGN option

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,11 @@ an introduction to t_cose 2.0 before the merge to master.
 ![t_cose](https://github.com/laurencelundblade/t_cose/blob/master/t-cose-logo.png?raw=true)
 
 
-*t_cose* implements enough of COSE to support [CBOR Web Token, RFC 8392](https://tools.ietf.org/html/rfc8392)  
-and [Entity Attestation Token (EAT)](https://tools.ietf.org/html/draft-ietf-rats-eat-01). 
-This is the COSE_Sign1 part of [COSE, RFC 9052](https://tools.ietf.org/html/rfc9052). 
+*t_cose* implements enough of COSE to support [CBOR Web Token, RFC 8392](https://tools.ietf.org/html/rfc8392)
+and [Entity Attestation Token (EAT)](https://tools.ietf.org/html/draft-ietf-rats-eat-01).
+This is the COSE_Sign1 part of [COSE, RFC 9052](https://tools.ietf.org/html/rfc9052).
 
-**Implemented in C with minimal dependency** – There are three main 
+**Implemented in C with minimal dependency** – There are three main
 dependencies: 1) [QCBOR](https://github.com/laurencelundblade/QCBOR),
 2) A cryptographic library for ECDSA and SHA-2, 3) C99, <stdint.h>,
 <stddef.h>, <stdbool.h> and <string.h>.  It is  highly
@@ -19,9 +19,9 @@ some minor configuration for the cryptographic library, no #ifdefs or
 compiler options need to be set for it to run correctly.
 
 **Crypto Library Integration Layer** – Works with different cryptographic
-libraries via a simple integration layer. The integration layer is kept small and simple, 
-just enough for the use cases, so that integration is simpler. Integration layers for 
-the OpenSSL and ARM Mbed TLS (PSA Cryptography API) cryptographic libraries 
+libraries via a simple integration layer. The integration layer is kept small and simple,
+just enough for the use cases, so that integration is simpler. Integration layers for
+the OpenSSL and ARM Mbed TLS (PSA Cryptography API) cryptographic libraries
 are included.
 
 **Secure coding style** – Uses a construct called UsefulBuf / q_useful_buf as a
@@ -41,12 +41,12 @@ useful for embedded implementations that have to run in small fixed memory.
 ## Code Status
 
 Status for t_cose 2.0 is very roughly this. COSE_Sign1 is working
-except for decoding of protected parameters. COSE_Sign works for 
+except for decoding of protected parameters. COSE_Sign works for
 a single signature.  COSE_Mac0 is generally working. COSE_Encrypt
 and COSE_Encrypt0 are somewhat working. The HPKE here is disabled
-and is a early IETF proposal. 
+and is a early IETF proposal.
 
-There is still lots of work to do on COSE_Sign, clean up on 
+There is still lots of work to do on COSE_Sign, clean up on
 COSE_Mac0 and some re design is exected for COSE_Encrypt.
 
 RSA and Eddsa integration from main is still to be done.
@@ -153,7 +153,7 @@ If this doesn't work or you have Mbed TLS elsewhere edit the makefile.
 The specific things that Makefile.psa does is:
     * Links the crypto_adapters/t_cose_psa_crypto.o into libt_cose.a
     * Links test/test/t_cose_make_psa_test_key.o into the test binary
-    * `#define T_COSE_USE_PSA_CRYPTO`   
+    * `#define T_COSE_USE_PSA_CRYPTO`
 
 This crypto adapter is small and simple. The adapter allocates no
 memory and as far as I know it internally allocates no memory. It is a
@@ -279,23 +279,25 @@ into.
 
 ## Memory Usage
 
-### Code 
+### Code
 
 Here are code sizes on 64-bit x86 optimized for size
 
-     |                           | smallest | largest |  
+     |                           | smallest | largest |
      |---------------------------|----------|---------|
      | signing only              |     1500 |    2300 |
      | verification only         |     2500 |    3300 |
      | common to sign and verify |     (500)|    (800)|
      | combined                  |     3500 |    4800 |
-     
+
 Things that make the code smaller:
 * PSA / Mbed crypto takes less code to interface with than OpenSSL
 * gcc is usually smaller than llvm because stack guards are off by default
 * Use only 256-bit crypto with the T_COSE_DISABLE_ESXXX options
-* Disable short-circut sig debug faclity T_COSE_DISABLE_SHORT_CIRCUIT_SIGN
+* Disable short-circut sig debug facility T_COSE_DISABLE_SHORT_CIRCUIT_SIGN
 * Disable the content type header T_COSE_DISABLE_CONTENT_TYPE
+* Disable COSE_Sign structure support with T_COSE_DISABLE_COSE_SIGN
+  (use only COSE_Sign1 signature structures if adequate).
 
 #### Change in code size with spiffy decode
 
@@ -357,13 +359,13 @@ implementation of ECDSA might not use malloc, as the keys are small
 enough.
 
 ### Mixed code style
-QCBOR uses camelCase and t_cose follows 
+QCBOR uses camelCase and t_cose follows
 [Arm's coding guidelines](https://git.trustedfirmware.org/TF-M/trusted-firmware-m.git/tree/docs/contributing/coding_guide.rst)
 resulting in code with mixed styles. For better or worse, an Arm-style version of UsefulBuf
 is created and used and so there is a duplicate of UsefulBuf. The two are identical. They
 just have different names.
 
-## Limitations 
+## Limitations
 
 * Most inputs and outputs must be in a continguous buffer. One
   exception to this is that CBOR payloads being signed can be

--- a/crypto_adapters/t_cose_psa_crypto.c
+++ b/crypto_adapters/t_cose_psa_crypto.c
@@ -110,7 +110,6 @@ bool t_cose_crypto_is_algorithm_supported(int32_t cose_algorithm_id)
 }
 
 
-#ifndef T_COSE_DISABLE_SIGN1
 
 /**
  * \brief Map a COSE signing algorithm ID to a PSA signing algorithm ID
@@ -304,10 +303,8 @@ enum t_cose_err_t t_cose_crypto_sig_size(int32_t           cose_algorithm_id,
 Done:
     return return_value;
 }
-#endif /* !T_COSE_DISABLE_SIGN1 */
 
 
-#if !defined(T_COSE_DISABLE_SIGN1)
 /**
  * \brief Convert COSE hash algorithm ID to a PSA hash algorithm ID
  *
@@ -424,7 +421,6 @@ t_cose_crypto_hash_finish(struct t_cose_crypto_hash *hash_ctx,
 Done:
     return psa_status_to_t_cose_error_hash(hash_ctx->status);
 }
-#endif /* !T_COSE_DISABLE_SIGN1 */
 
 
 /**

--- a/inc/t_cose/t_cose_common.h
+++ b/inc/t_cose/t_cose_common.h
@@ -2,7 +2,7 @@
  * t_cose_common.h
  *
  * Copyright 2019-2023, Laurence Lundblade
- * Copyright (c) 2020-2022, Arm Limited. All rights reserved.
+ * Copyright (c) 2020-2023, Arm Limited. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *
@@ -25,7 +25,7 @@ extern "C" {
 
 /*
  * API Design Overview
- * 
+ *
  * t_cose is made up of a collection of objects (in the
  * object-oriented programming sense) that correspond to the main
  * objects defined in CDDL by the COSE standard (RFC 9052). These
@@ -82,7 +82,7 @@ extern "C" {
  * checked by actually designing and implementing it). These are not
  * needed for COSE_Mac0.
  *
- * 
+ *
  * COSE_Message
  *
  * t_cose_message_create() and t_cose_message_decode handle
@@ -157,8 +157,8 @@ extern "C" {
  * database look ups, use of certificates, counter signatures
  * and such, all without changing the source or even object
  * code of the core t_cose library.
- * 
- * COSE_Key 
+ *
+ * COSE_Key
  *
  * Some formats of COSE_recipient have parameters that are in the
  * COSE_key format. It would be useful to have some library code to
@@ -167,7 +167,7 @@ extern "C" {
  */
 
 
-  
+
 /**
  * \file t_cose_common.h
  *
@@ -591,6 +591,9 @@ enum t_cose_err_t {
 
     /** The HMAC did not successfully verify.  */
     T_COSE_ERR_HMAC_VERIFY = 80,
+
+    /** General unsupported operation failure. */
+    T_COSE_ERR_UNSUPPORTED = 81,
 };
 
 
@@ -659,7 +662,7 @@ enum t_cose_err_t {
  */
 #define T_COSE_OPT_OMIT_CBOR_TAG 0x00000400
 
-  
+
 /**
  * When verifying or signing a COSE message, cryptographic operations
  * like verification and decryption will not be performed. Keys needed

--- a/src/t_cose_sign_sign.c
+++ b/src/t_cose_sign_sign.c
@@ -2,6 +2,7 @@
  * t_cose_sign_sign.c
  *
  * Copyright (c) 2018-2023, Laurence Lundblade. All rights reserved.
+ * Copyright (c) 2023, Arm Limited. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *
@@ -145,6 +146,7 @@ t_cose_sign_encode_finish(struct t_cose_sign_sign_ctx *me,
     signer = me->signers;
 
     if(T_COSE_OPT_IS_SIGN(me->option_flags)) {
+#ifndef T_COSE_DISABLE_COSE_SIGN
         /* --- One or more COSE_Signatures for COSE_Sign --- */
 
         /* Output the arrray of signers, each of which is an array of
@@ -160,6 +162,9 @@ t_cose_sign_encode_finish(struct t_cose_sign_sign_ctx *me,
             signer = (struct t_cose_signature_sign *)signer->rs.next;
         }
         QCBOREncode_CloseArray(cbor_encoder);
+#else
+        return_value = T_COSE_ERR_UNSUPPORTED;
+#endif /* !T_COSE_DISABLE_COSE_SIGN */
 
     } else {
         /* --- Single signature for COSE_Sign1 --- */

--- a/src/t_cose_sign_verify.c
+++ b/src/t_cose_sign_verify.c
@@ -2,6 +2,7 @@
  * t_cose_sign_verify.c
  *
  * Copyright 2019-2023, Laurence Lundblade
+ * Copyright (c) 2023, Arm Limited. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *
@@ -138,6 +139,7 @@ is_soft_verify_error(enum t_cose_err_t error)
 }
 
 
+#ifndef T_COSE_DISABLE_COSE_SIGN
 #ifdef QCBOR_FOR_T_COSE_2
 
 /* Return the number of parameters in a linked list of parameters. */
@@ -386,58 +388,6 @@ verify_one_signature(struct t_cose_sign_verify_ctx       *me,
 
 #endif /* QCBOR_FOR_T_COSE_2 */
 
-
-
-/* Run all the verifiers against the a COSE_Sign1 signature (not a COSE_Signature).
- *
- * Called once. Expect it will be inlined. Separate function for
- * code readability.
- */
-static enum t_cose_err_t
-call_sign1_verifiers(struct t_cose_sign_verify_ctx   *me,
-                     const struct t_cose_parameter   *body_params_list,
-                     const struct t_cose_sign_inputs *sign_inputs,
-                     const struct q_useful_buf_c      signature)
-{
-    enum t_cose_err_t               return_value;
-    struct t_cose_signature_verify *verifier;
-
-    return_value = T_COSE_ERR_NO_VERIFIERS;
-
-    for(verifier = me->verifiers;
-        verifier != NULL;
-        verifier = (struct t_cose_signature_verify *)(verifier)->rs.next) {
-
-        /* Call the verifier to attempt a verification. It will
-         * compute the tbs and try to run the crypto (unless
-         * T_COSE_OPT_DECODE_ONLY is set). Note also that the only
-         * reason that the verifier is called even when
-         * T_COSE_OPT_DECODE_ONLY is set here for a COSE_Sign1 is
-         * so the aux buffer size can be computed for EdDSA.
-         */
-        return_value =
-            verifier->verify1_cb(verifier,         /* in/out: me pointer for this verifier */
-                                 me->option_flags, /* in: option flags from top-level caller */
-                                 sign_inputs,      /* in: everything covered by signing */
-                                 body_params_list, /* in: linked list of header params from body */
-                                 signature);       /* in: the signature */
-        if(return_value == T_COSE_SUCCESS) {
-            break;
-        }
-        if(!is_soft_verify_error(return_value)) {
-            /* Decode error or a signature verification failure or such. */
-            break;
-        }
-
-        /* Algorithm or kid didn't match or verifier
-         * declined for some other reason. Continue trying other verifiers.
-         */
-    }
-
-    return return_value;
-}
-
-
 /*
  *
  * @param[in,out] decode_parameters param list to append newly decoded params to
@@ -510,6 +460,58 @@ process_cose_signatures(struct t_cose_sign_verify_ctx *me,
                 /* decline. Continue to try other COSE_Signatures. */
             }
         }
+    }
+
+    return return_value;
+}
+#endif /* !T_COSE_DISABLE_COSE_SIGN */
+
+
+
+/* Run all the verifiers against the a COSE_Sign1 signature (not a COSE_Signature).
+ *
+ * Called once. Expect it will be inlined. Separate function for
+ * code readability.
+ */
+static enum t_cose_err_t
+call_sign1_verifiers(struct t_cose_sign_verify_ctx   *me,
+                     const struct t_cose_parameter   *body_params_list,
+                     const struct t_cose_sign_inputs *sign_inputs,
+                     const struct q_useful_buf_c      signature)
+{
+    enum t_cose_err_t               return_value;
+    struct t_cose_signature_verify *verifier;
+
+    return_value = T_COSE_ERR_NO_VERIFIERS;
+
+    for(verifier = me->verifiers;
+        verifier != NULL;
+        verifier = (struct t_cose_signature_verify *)(verifier)->rs.next) {
+
+        /* Call the verifier to attempt a verification. It will
+         * compute the tbs and try to run the crypto (unless
+         * T_COSE_OPT_DECODE_ONLY is set). Note also that the only
+         * reason that the verifier is called even when
+         * T_COSE_OPT_DECODE_ONLY is set here for a COSE_Sign1 is
+         * so the aux buffer size can be computed for EdDSA.
+         */
+        return_value =
+            verifier->verify1_cb(verifier,         /* in/out: me pointer for this verifier */
+                                 me->option_flags, /* in: option flags from top-level caller */
+                                 sign_inputs,      /* in: everything covered by signing */
+                                 body_params_list, /* in: linked list of header params from body */
+                                 signature);       /* in: the signature */
+        if(return_value == T_COSE_SUCCESS) {
+            break;
+        }
+        if(!is_soft_verify_error(return_value)) {
+            /* Decode error or a signature verification failure or such. */
+            break;
+        }
+
+        /* Algorithm or kid didn't match or verifier
+         * declined for some other reason. Continue trying other verifiers.
+         */
     }
 
     return return_value;
@@ -605,6 +607,8 @@ t_cose_sign_verify_private(struct t_cose_sign_verify_ctx  *me,
                                             signature);
 
     } else {
+
+#ifndef T_COSE_DISABLE_COSE_SIGN
         /* --- The array of COSE_Signatures --- */
         QCBORDecode_EnterArray(&cbor_decoder, NULL);
 
@@ -614,6 +618,9 @@ t_cose_sign_verify_private(struct t_cose_sign_verify_ctx  *me,
                                                &decoded_params);
 
         QCBORDecode_ExitArray(&cbor_decoder);
+#else
+        return_value = T_COSE_ERR_UNSUPPORTED;
+#endif /* !T_COSE_DISABLE_COSE_SIGN */
     }
 
 

--- a/src/t_cose_signature_sign_eddsa.c
+++ b/src/t_cose_signature_sign_eddsa.c
@@ -2,6 +2,8 @@
  * t_cose_signature_sign_eddsa.c
  *
  * Copyright (c) 2022, Laurence Lundblade. All rights reserved.
+ * Copyright (c) 2023, Arm Limited. All rights reserved.
+ *
  * Created by Laurence Lundblade on 11/15/22.
  *
  * SPDX-License-Identifier: BSD-3-Clause
@@ -108,6 +110,7 @@ t_cose_signature_sign_eddsa_cb(struct t_cose_signature_sign  *me_x,
                                struct t_cose_sign_inputs     *sign_inputs,
                                QCBOREncodeContext            *qcbor_encoder)
 {
+#ifndef T_COSE_DISABLE_COSE_SIGN
     struct t_cose_signature_sign_eddsa *me =
                                      (struct t_cose_signature_sign_eddsa *)me_x;
     enum t_cose_err_t           return_value;
@@ -128,6 +131,15 @@ t_cose_signature_sign_eddsa_cb(struct t_cose_signature_sign  *me_x,
     QCBOREncode_CloseArray(qcbor_encoder);
 
     return return_value;
+
+#else /* !T_COSE_DISABLE_COSE_SIGN */
+
+    (void)me_x;
+    (void)sign_inputs;
+    (void)qcbor_encoder;
+
+    return T_COSE_ERR_UNSUPPORTED;
+#endif /* !T_COSE_DISABLE_COSE_SIGN */
 }
 
 
@@ -140,4 +152,3 @@ t_cose_signature_sign_eddsa_init(struct t_cose_signature_sign_eddsa *me)
     me->s.sign1_cb   = t_cose_signature_sign1_eddsa_cb;
     me->s.headers_cb = t_cose_signature_sign_headers_eddsa_cb;
 }
-

--- a/src/t_cose_signature_sign_main.c
+++ b/src/t_cose_signature_sign_main.c
@@ -2,6 +2,8 @@
  * t_cose_signature_sign_main.c
  *
  * Copyright (c) 2023, Laurence Lundblade. All rights reserved.
+ * Copyright (c) 2023, Arm Limited. All rights reserved.
+ *
  * Created by Laurence Lundblade on 5/23/22.
  *
  * SPDX-License-Identifier: BSD-3-Clause
@@ -104,6 +106,7 @@ t_cose_signature_sign_main_cb(struct t_cose_signature_sign  *me_x,
                               struct t_cose_sign_inputs     *sign_inputs,
                               QCBOREncodeContext            *qcbor_encoder)
 {
+#ifndef T_COSE_DISABLE_COSE_SIGN
     struct t_cose_signature_sign_main *me =
                                      (struct t_cose_signature_sign_main *)me_x;
     enum t_cose_err_t         return_value;
@@ -128,6 +131,15 @@ t_cose_signature_sign_main_cb(struct t_cose_signature_sign  *me_x,
     QCBOREncode_CloseArray(qcbor_encoder);
 
     return return_value;
+
+#else /* !T_COSE_DISABLE_COSE_SIGN */
+
+    (void)me_x;
+    (void)sign_inputs;
+    (void)qcbor_encoder;
+
+    return T_COSE_ERR_UNSUPPORTED;
+#endif /* !T_COSE_DISABLE_COSE_SIGN */
 }
 
 

--- a/src/t_cose_signature_verify_eddsa.c
+++ b/src/t_cose_signature_verify_eddsa.c
@@ -2,6 +2,7 @@
  * t_cose_signature_verify_eddsa.c
  *
  * Copyright (c) 2023, Laurence Lundblade. All rights reserved.
+ * Copyright (c) 2023, Arm Limited. All rights reserved.
  * Created by Laurence Lundblade on 11/19/22.
  *
  * SPDX-License-Identifier: BSD-3-Clause
@@ -122,6 +123,7 @@ t_cose_signature_verify_eddsa_cb(struct t_cose_signature_verify  *me_x,
                                  QCBORDecodeContext             *cbor_decoder,
                                  struct t_cose_parameter       **decoded_params)
 {
+#ifndef T_COSE_DISABLE_COSE_SIGN
     const struct t_cose_signature_verify_eddsa *me =
                             (const struct t_cose_signature_verify_eddsa *)me_x;
     QCBORError             qcbor_error;
@@ -167,6 +169,19 @@ t_cose_signature_verify_eddsa_cb(struct t_cose_signature_verify  *me_x,
                                                      signature);
 Done:
     return return_value;
+
+#else /* !T_COSE_DISABLE_COSE_SIGN */
+
+    (void)me_x;
+    (void)option_flags;
+    (void)loc;
+    (void)sign_inputs;
+    (void)param_storage;
+    (void)cbor_decoder;
+    (void)decoded_params;
+
+    return T_COSE_ERR_UNSUPPORTED;
+#endif /* !T_COSE_DISABLE_COSE_SIGN */
 }
 
 

--- a/src/t_cose_signature_verify_main.c
+++ b/src/t_cose_signature_verify_main.c
@@ -2,6 +2,7 @@
  * t_cose_signature_verify_main.c
  *
  * Copyright (c) 2022-2023, Laurence Lundblade. All rights reserved.
+ * Copyright (c) 2023, Arm Limited. All rights reserved.
  * Created by Laurence Lundblade on 7/19/22.
  *
  * SPDX-License-Identifier: BSD-3-Clause
@@ -142,7 +143,6 @@ Done:
 
 
 
-
 /**
  * \brief "Main" verifier of t_cose_signature_verify_cb.
  *
@@ -185,6 +185,7 @@ t_cose_signature_verify_main_cb(struct t_cose_signature_verify  *me_x,
                                 QCBORDecodeContext              *cbor_decoder,
                                 struct t_cose_parameter        **decoded_params)
 {
+#ifndef T_COSE_DISABLE_COSE_SIGN
     const struct t_cose_signature_verify_main *me =
                             (const struct t_cose_signature_verify_main *)me_x;
     QCBORError             qcbor_error;
@@ -233,6 +234,19 @@ t_cose_signature_verify_main_cb(struct t_cose_signature_verify  *me_x,
 
 Done:
     return return_value;
+
+#else /* !T_COSE_DISABLE_COSE_SIGN */
+
+    (void)me_x;
+    (void)option_flags;
+    (void)loc;
+    (void)sign_inputs;
+    (void)param_storage;
+    (void)cbor_decoder;
+    (void)decoded_params;
+
+    return T_COSE_ERR_UNSUPPORTED;
+#endif /* !T_COSE_DISABLE_COSE_SIGN */
 }
 
 

--- a/test/run_tests.c
+++ b/test/run_tests.c
@@ -50,14 +50,11 @@ static test_entry s_tests[] = {
 #endif
     TEST_ENTRY(hkdf_test),
 
-#ifndef T_COSE_DISABLE_SIGN1
     TEST_ENTRY(sign1_structure_decode_test),
-#endif /* T_COSE_DISABLE_SIGN1 */
 
     TEST_ENTRY(crypto_context_test),
 
 #ifndef T_COSE_DISABLE_SIGN_VERIFY_TESTS
-#ifndef T_COSE_DISABLE_SIGN1
     /* Many tests can be run without a crypto library integration and
      * provide good test coverage of everything but the signing and
      * verification. These tests can't be run with signing and
@@ -70,13 +67,13 @@ static test_entry s_tests[] = {
     TEST_ENTRY(sign_verify_known_good_test),
     TEST_ENTRY(sign_verify_unsupported_test),
     TEST_ENTRY(sign_verify_bad_auxiliary_buffer),
-    TEST_ENTRY(verify_multi_test),
 
-#endif /* T_COSE_DISABLE_SIGN1 */
+#ifndef T_COSE_DISABLE_COSE_SIGN
+    TEST_ENTRY(verify_multi_test),
+    TEST_ENTRY(sign_verify_multi),
+#endif /* !T_COSE_DISABLE_COSE_SIGN */
 
     // TODO: should these really be conditional on T_COSE_DISABLE_SIGN_VERIFY_TESTS
-
-    TEST_ENTRY(sign_verify_multi),
 
 #endif /* T_COSE_DISABLE_SIGN_VERIFY_TESTS */
 
@@ -87,7 +84,6 @@ static test_entry s_tests[] = {
     TEST_ENTRY(compute_validate_get_size_detached_content_mac_test),
 
 #ifndef T_COSE_DISABLE_SHORT_CIRCUIT_SIGN
-#ifndef T_COSE_DISABLE_SIGN1
     /* These tests can't run if short-circuit signatures are disabled.
      * The most critical ones are replicated in the group of tests
      * that require a real crypto library. Typically short-circuit
@@ -117,7 +113,6 @@ static test_entry s_tests[] = {
 #ifdef T_COSE_ENABLE_HASH_FAIL_TEST
     TEST_ENTRY(short_circuit_hash_fail_test),
 #endif /* T_COSE_DISABLE_HASH_FAIL_TEST */
-#endif /* T_COSE_DISABLE_SIGN1 */
 #endif /* T_COSE_DISABLE_SHORT_CIRCUIT_SIGN */
 
     TEST_ENTRY(param_test),

--- a/test/t_cose_sign_verify_test.c
+++ b/test/t_cose_sign_verify_test.c
@@ -2,7 +2,7 @@
  *  t_cose_sign_verify_test.c
  *
  * Copyright 2019-2022, Laurence Lundblade
- * Copyright (c) 2022, Arm Limited. All rights reserved.
+ * Copyright (c) 2022-2023, Arm Limited. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *
@@ -313,10 +313,8 @@ int_fast32_t sign_verify_basic_test(void)
     return 0;
 }
 
-/*
- * Public function, see t_cose_sign_verify_test.h
- */
-int_fast32_t sig_fail_test(int32_t cose_alg)
+
+static int_fast32_t sig_fail_test(int32_t cose_alg)
 {
     struct t_cose_sign1_sign_ctx   sign_ctx;
     QCBOREncodeContext             cbor_encode;
@@ -986,7 +984,7 @@ Done:
 
 
 
-
+#ifndef T_COSE_DISABLE_COSE_SIGN
 int_fast32_t sign_verify_multi(void)
 {
     enum t_cose_err_t              result;
@@ -1095,7 +1093,6 @@ int_fast32_t sign_verify_multi(void)
 }
 
 
-
 static enum t_cose_err_t
 make_triple_signed(struct q_useful_buf buffer,
                    struct q_useful_buf_c *signed_message)
@@ -1190,10 +1187,9 @@ int32_t verify_multi_test(void)
     init_fixed_test_signing_key(T_COSE_ALGORITHM_ES256, &ecdsa_key);
     t_cose_signature_verify_main_init(&verify_ecdsa);
     t_cose_signature_verify_main_set_key(&verify_ecdsa,
-                                         ecdsa_key,
-                                         Q_USEFUL_BUF_FROM_SZ_LITERAL("ecsda_kid"));
+                                          ecdsa_key,
+                                          Q_USEFUL_BUF_FROM_SZ_LITERAL("ecsda_kid"));
     t_cose_sign_add_verifier(&verify_ctx, (struct t_cose_signature_verify *)&verify_ecdsa);
-
 
     err = t_cose_sign_verify(&verify_ctx,
                               cose_sign,
@@ -1215,18 +1211,15 @@ int32_t verify_multi_test(void)
 #endif /* QCBOR_FOR_T_COSE_2 */
 
 
-
-
     struct t_cose_signature_verify_eddsa verify_eddsa;
     struct t_cose_key                   eddsa_key;
     init_fixed_test_signing_key(T_COSE_ALGORITHM_EDDSA, &eddsa_key);
     t_cose_signature_verify_eddsa_init(&verify_eddsa, 0);  // TODO: why does this have option flags and _main_ doesn't
     t_cose_signature_verify_eddsa_set_key(&verify_eddsa,
-                                         eddsa_key,
-                                         Q_USEFUL_BUF_FROM_SZ_LITERAL("eddsa_kid"));
+                                           eddsa_key,
+                                           Q_USEFUL_BUF_FROM_SZ_LITERAL("eddsa_kid"));
     t_cose_signature_verify_eddsa_set_auxiliary_buffer(&verify_eddsa, auxiliary_buffer);
     t_cose_sign_add_verifier(&verify_ctx, (struct t_cose_signature_verify *)&verify_eddsa);
-
 
 
     struct t_cose_signature_verify_main verify_rsa;
@@ -1234,8 +1227,8 @@ int32_t verify_multi_test(void)
     init_fixed_test_signing_key(T_COSE_ALGORITHM_PS256, &rsa_key);
     t_cose_signature_verify_main_init(&verify_rsa);
     t_cose_signature_verify_main_set_key(&verify_rsa,
-                                         rsa_key,
-                                         Q_USEFUL_BUF_FROM_SZ_LITERAL("rsa_kid"));
+                                          rsa_key,
+                                          Q_USEFUL_BUF_FROM_SZ_LITERAL("rsa_kid"));
     t_cose_sign_add_verifier(&verify_ctx, (struct t_cose_signature_verify *)&verify_rsa);
 
     err = t_cose_sign_verify(&verify_ctx,
@@ -1256,9 +1249,9 @@ int32_t verify_multi_test(void)
 #endif /* QCBOR_FOR_T_COSE_2 */
 
     return 0;
-
-
 }
+#endif /* !T_COSE_DISABLE_COSE_SIGN */
+
 
 /*
 
@@ -1270,6 +1263,6 @@ int32_t verify_multi_test(void)
  - Require one sig and one fails because the data is corrupt/key is wrong
 
 - Use one message signed with ES256, EdDSA and RS2048
- 
+
 
  */


### PR DESCRIPTION
-- RFC --
Introduce the T_COSE_DISABLE_SIGN option and replace T_COSE_DISABLE_SIGN1 with it.
The tests that use multiple signatures can also be disabled with this option.
COSE_Sign1 structure support is always enabled.

Related issue: #111 

Note:
  The tests are currently failing, but it is expected since this PR and #211 are connected and
  this one is still in progress.