### PR TITLE
Pass content encryption alg info to recipient objects

### DIFF
--- a/crypto_adapters/t_cose_openssl_crypto.c
+++ b/crypto_adapters/t_cose_openssl_crypto.c
@@ -2072,11 +2072,11 @@ t_cose_crypto_kw_unwrap(int32_t                 algorithm_id,
  * See documentation in t_cose_crypto.h
  */
 enum t_cose_err_t
-t_cose_crypto_hkdf(int32_t                cose_hash_algorithm_id,
-                   struct q_useful_buf_c  salt,
-                   struct q_useful_buf_c  ikm,
-                   struct q_useful_buf_c  info,
-                   struct q_useful_buf    okm_buffer)
+t_cose_crypto_hkdf(int32_t                     cose_hash_algorithm_id,
+                   const struct q_useful_buf_c salt,
+                   const struct q_useful_buf_c ikm,
+                   const struct q_useful_buf_c info,
+                   struct q_useful_buf         okm_buffer)
 {
     int               ossl_result;
     EVP_PKEY_CTX     *ctx;

--- a/crypto_adapters/t_cose_psa_crypto.c
+++ b/crypto_adapters/t_cose_psa_crypto.c
@@ -1268,11 +1268,11 @@ t_cose_crypto_aead_decrypt(const int32_t          cose_algorithm_id,
  * See documentation in t_cose_crypto.h
  */
 enum t_cose_err_t
-t_cose_crypto_hkdf(int32_t                cose_hash_algorithm_id,
-                   struct q_useful_buf_c  salt,
-                   struct q_useful_buf_c  ikm,
-                   struct q_useful_buf_c  info,
-                   struct q_useful_buf    okm_buffer)
+t_cose_crypto_hkdf(int32_t                     cose_hash_algorithm_id,
+                   const struct q_useful_buf_c salt,
+                   const struct q_useful_buf_c ikm,
+                   const struct q_useful_buf_c info,
+                   struct q_useful_buf         okm_buffer)
 {
     int                       psa_result;
     const mbedtls_md_info_t  *md_info;

--- a/crypto_adapters/t_cose_test_crypto.c
+++ b/crypto_adapters/t_cose_test_crypto.c
@@ -588,11 +588,11 @@ t_cose_crypto_kw_unwrap(int32_t                 cose_algorithm_id,
 
 
 enum t_cose_err_t
-t_cose_crypto_hkdf(int32_t                cose_hash_algorithm_id,
-                   struct q_useful_buf_c  salt,
-                   struct q_useful_buf_c  ikm,
-                   struct q_useful_buf_c  info,
-                   struct q_useful_buf    okm_buffer)
+t_cose_crypto_hkdf(int32_t                     cose_hash_algorithm_id,
+                   const struct q_useful_buf_c salt,
+                   const struct q_useful_buf_c ikm,
+                   const struct q_useful_buf_c info,
+                   struct q_useful_buf         okm_buffer)
 {
     /* This makes a fixed fake output of all x's */
     (void)UsefulBuf_Set(okm_buffer, 'x');

--- a/inc/t_cose/t_cose_common.h
+++ b/inc/t_cose/t_cose_common.h
@@ -778,6 +778,8 @@ struct t_cose_sign_inputs {
 };
 
 
+
+
 /* A COSE algorithm ID and the number of bits for the key. Typically,
  * the number of bits in the key is known from the alg ID, but not
  * always. This structure is typically used to give input for
@@ -785,12 +787,13 @@ struct t_cose_sign_inputs {
  *
  * alg_bits should be size_t to be completely type-consistent,
  * but that would push the size of this structure over an
- * an alignment boundary and double it's size.
+ * an alignment boundary and double its size.
  */
 struct t_cose_alg_and_bits {
     int32_t   cose_alg_id;
-    uint32_t  alg_bits;
+    uint32_t  bits_in_key;
 };
+
 
 
 

--- a/inc/t_cose/t_cose_common.h
+++ b/inc/t_cose/t_cose_common.h
@@ -778,6 +778,21 @@ struct t_cose_sign_inputs {
 };
 
 
+/* A COSE algorithm ID and the number of bits for the key. Typically,
+ * the number of bits in the key is known from the alg ID, but not
+ * always. This structure is typically used to give input for
+ * the construction of COSE_KDF_Context.
+ *
+ * alg_bits should be size_t to be completely type-consistent,
+ * but that would push the size of this structure over an
+ * an alignment boundary and double it's size.
+ */
+struct t_cose_alg_and_bits {
+    int32_t   cose_alg_id;
+    uint32_t  alg_bits;
+};
+
+
 
 /* This is the base class for all implementations
  * of COSE_Signature and COSE_Recipient. It implments what

--- a/inc/t_cose/t_cose_recipient_dec.h
+++ b/inc/t_cose/t_cose_recipient_dec.h
@@ -60,7 +60,7 @@ struct t_cose_recipient_dec;
 typedef enum t_cose_err_t
 t_cose_recipient_dec_cb(struct t_cose_recipient_dec        *context,
                         const struct t_cose_header_location loc,
-                        const struct t_cose_alg_and_bits    cek_alg,
+                        const struct t_cose_alg_and_bits    ce_alg,
                         QCBORDecodeContext                 *cbor_decoder,
                         struct q_useful_buf                 cek_buffer,
                         struct t_cose_parameter_storage    *p_storage,

--- a/inc/t_cose/t_cose_recipient_dec.h
+++ b/inc/t_cose/t_cose_recipient_dec.h
@@ -60,6 +60,7 @@ struct t_cose_recipient_dec;
 typedef enum t_cose_err_t
 t_cose_recipient_dec_cb(struct t_cose_recipient_dec        *context,
                         const struct t_cose_header_location loc,
+                        const struct t_cose_alg_and_bits    cek_alg,
                         QCBORDecodeContext                 *cbor_decoder,
                         struct q_useful_buf                 cek_buffer,
                         struct t_cose_parameter_storage    *p_storage,

--- a/inc/t_cose/t_cose_recipient_dec_hpke.h
+++ b/inc/t_cose/t_cose_recipient_dec_hpke.h
@@ -71,6 +71,7 @@ t_cose_recipient_dec_hpke_set_skr(struct t_cose_recipient_dec_hpke *context,
 enum t_cose_err_t
 t_cose_recipient_dec_hpke_cb_private(struct t_cose_recipient_dec *me_x,
                                      const struct t_cose_header_location loc,
+                                     const struct t_cose_alg_and_bits ce_alg,
                                      QCBORDecodeContext *cbor_decoder,
                                      struct q_useful_buf cek_buffer,
                                      struct t_cose_parameter_storage *p_storage,

--- a/inc/t_cose/t_cose_recipient_dec_keywrap.h
+++ b/inc/t_cose/t_cose_recipient_dec_keywrap.h
@@ -71,6 +71,7 @@ t_cose_recipient_dec_keywrap_set_kek(struct t_cose_recipient_dec_keywrap *contex
 enum t_cose_err_t
 t_cose_recipient_dec_keywrap_cb_private(struct t_cose_recipient_dec        *me_x,
                                         const struct t_cose_header_location loc,
+                                        const struct t_cose_alg_and_bits    cek_alg,
                                         QCBORDecodeContext                 *cbor_decoder,
                                         struct q_useful_buf                 cek_buffer,
                                         struct t_cose_parameter_storage    *p_storage,

--- a/inc/t_cose/t_cose_recipient_dec_keywrap.h
+++ b/inc/t_cose/t_cose_recipient_dec_keywrap.h
@@ -71,7 +71,7 @@ t_cose_recipient_dec_keywrap_set_kek(struct t_cose_recipient_dec_keywrap *contex
 enum t_cose_err_t
 t_cose_recipient_dec_keywrap_cb_private(struct t_cose_recipient_dec        *me_x,
                                         const struct t_cose_header_location loc,
-                                        const struct t_cose_alg_and_bits    cek_alg,
+                                        const struct t_cose_alg_and_bits    ce_alg,
                                         QCBORDecodeContext                 *cbor_decoder,
                                         struct q_useful_buf                 cek_buffer,
                                         struct t_cose_parameter_storage    *p_storage,

--- a/inc/t_cose/t_cose_recipient_enc.h
+++ b/inc/t_cose/t_cose_recipient_enc.h
@@ -45,7 +45,7 @@ struct t_cose_recipient_enc;
 typedef enum t_cose_err_t
 t_cose_create_recipient_cb(struct t_cose_recipient_enc     *context,
                            struct q_useful_buf_c            cek,
-                           const struct t_cose_alg_and_bits cek_alg,
+                           const struct t_cose_alg_and_bits ce_alg,
                            QCBOREncodeContext              *cbor_encoder);
 
 

--- a/inc/t_cose/t_cose_recipient_enc.h
+++ b/inc/t_cose/t_cose_recipient_enc.h
@@ -43,9 +43,10 @@ struct t_cose_recipient_enc;
  * \retval Error messages otherwise.
  */
 typedef enum t_cose_err_t
-t_cose_create_recipient_cb(struct t_cose_recipient_enc  *context,
-                           struct q_useful_buf_c         cek,
-                           QCBOREncodeContext           *cbor_encoder);
+t_cose_create_recipient_cb(struct t_cose_recipient_enc     *context,
+                           struct q_useful_buf_c            cek,
+                           const struct t_cose_alg_and_bits cek_alg,
+                           QCBOREncodeContext              *cbor_encoder);
 
 
 /**

--- a/inc/t_cose/t_cose_recipient_enc_hpke.h
+++ b/inc/t_cose/t_cose_recipient_enc_hpke.h
@@ -79,6 +79,7 @@ t_cose_recipient_enc_hpke_set_key(struct t_cose_recipient_enc_hpke *context,
 enum t_cose_err_t
 t_cose_recipient_create_hpke_cb_private(struct t_cose_recipient_enc  *me_x,
                                         struct q_useful_buf_c         cek,
+                                        struct t_cose_alg_and_bits    ce,
                                         QCBOREncodeContext           *cbor_encoder);
 
 

--- a/inc/t_cose/t_cose_recipient_enc_keywrap.h
+++ b/inc/t_cose/t_cose_recipient_enc_keywrap.h
@@ -16,6 +16,7 @@
 #include <stdbool.h>
 #include <stdlib.h>
 #include "t_cose_parameters.h"
+#include "t_cose/t_cose_common.h"
 #include "t_cose/t_cose_key.h"
 #include "t_cose/t_cose_recipient_enc.h"
 
@@ -116,9 +117,10 @@ t_cose_recipient_enc_add_params(struct t_cose_recipient_enc_keywrap *context,
 
 /* Private function referenced by inline implementation. */
 enum t_cose_err_t
-t_cose_recipient_create_keywrap_cb_private(struct t_cose_recipient_enc  *me_x,
-                                           struct q_useful_buf_c         plaintext,
-                                           QCBOREncodeContext           *cbor_encoder);
+t_cose_recipient_create_keywrap_cb_private(struct t_cose_recipient_enc     *me_x,
+                                           struct q_useful_buf_c            plaintext,
+                                           const struct t_cose_alg_and_bits cek_alg,
+                                           QCBOREncodeContext              *cbor_encoder);
 
 
 static inline void

--- a/inc/t_cose/t_cose_recipient_enc_keywrap.h
+++ b/inc/t_cose/t_cose_recipient_enc_keywrap.h
@@ -119,7 +119,7 @@ t_cose_recipient_enc_add_params(struct t_cose_recipient_enc_keywrap *context,
 enum t_cose_err_t
 t_cose_recipient_create_keywrap_cb_private(struct t_cose_recipient_enc     *me_x,
                                            struct q_useful_buf_c            plaintext,
-                                           const struct t_cose_alg_and_bits cek_alg,
+                                           const struct t_cose_alg_and_bits ce_alg,
                                            QCBOREncodeContext              *cbor_encoder);
 
 

--- a/src/t_cose_crypto.h
+++ b/src/t_cose_crypto.h
@@ -1172,11 +1172,11 @@ t_cose_crypto_free_symmetric_key(struct t_cose_key key);
  * See RFC 5869 for a detailed description.
  */
 enum t_cose_err_t
-t_cose_crypto_hkdf(int32_t                cose_hash_algorithm_id,
-                   struct q_useful_buf_c  salt,
-                   struct q_useful_buf_c  ikm,
-                   struct q_useful_buf_c  info,
-                   struct q_useful_buf    okm_buffer);
+t_cose_crypto_hkdf(int32_t                     cose_hash_algorithm_id,
+                   const struct q_useful_buf_c salt,
+                   const struct q_useful_buf_c ikm,
+                   const struct q_useful_buf_c info,
+                   struct q_useful_buf         okm_buffer);
 
 
 

--- a/src/t_cose_encrypt_enc.c
+++ b/src/t_cose_encrypt_enc.c
@@ -38,21 +38,20 @@ t_cose_encrypt_enc_detached(struct t_cose_encrypt_enc *me,
     QCBOREncodeContext           cbor_encoder;
     unsigned                     message_type;
     struct q_useful_buf_c        nonce;
-    struct q_useful_buf_c        cek_bytes;
     struct t_cose_parameter      params[2]; /* 1 for Alg ID plus 1 for IV */
     struct q_useful_buf_c        body_prot_headers;
     struct q_useful_buf_c        enc_structure;
+    struct t_cose_alg_and_bits   ce_alg;
     Q_USEFUL_BUF_MAKE_STACK_UB(  cek_buffer, T_COSE_MAX_SYMMETRIC_KEY_LENGTH);
+    struct q_useful_buf_c        cek_bytes;
+    struct t_cose_key            cek_handle;
     Q_USEFUL_BUF_MAKE_STACK_UB(  nonce_buffer, T_COSE_MAX_SYMMETRIC_KEY_LENGTH);
     Q_USEFUL_BUF_MAKE_STACK_UB(  enc_struct_buffer, T_COSE_ENCRYPT_STRUCT_DEFAULT_SIZE);
-    struct t_cose_key            cek_handle;
     const char                  *enc_struct_string;
     struct q_useful_buf          encrypt_buffer;
     struct q_useful_buf_c        encrypt_output;
     bool                         is_cose_encrypt0;
     struct t_cose_recipient_enc *recipient;
-    struct t_cose_alg_and_bits   cek_alg;
-    uint32_t                     bits_in_key;
 
 
     /* ---- Figure out the COSE message type ---- */
@@ -65,17 +64,19 @@ t_cose_encrypt_enc_detached(struct t_cose_encrypt_enc *me,
         default: return T_COSE_ERR_FAIL; // TODO: better error code
     }
 
+
     /* ---- Algorithm ID, IV and parameter list ---- */
     /* Determine algorithm parameters */
-    bits_in_key = bits_in_crypto_alg(me->payload_cose_algorithm_id);
-    if(bits_in_key == UINT32_MAX) {
+    ce_alg.cose_alg_id = me->payload_cose_algorithm_id;
+    ce_alg.bits_in_key = bits_in_crypto_alg(ce_alg.cose_alg_id);
+    if(ce_alg.bits_in_key == UINT32_MAX) {
         // TODO: this may not be the full error check for unsupported.
         return T_COSE_ERR_UNSUPPORTED_CIPHER_ALG;
     }
-    params[0] = t_cose_param_make_alg_id(me->payload_cose_algorithm_id);
+    params[0] = t_cose_param_make_alg_id(ce_alg.cose_alg_id);
 
     /* Generate random nonce (aka iv) */
-    return_value = t_cose_crypto_get_random(nonce_buffer, bits_in_key / 8, &nonce);
+    return_value = t_cose_crypto_get_random(nonce_buffer, ce_alg.bits_in_key  / 8, &nonce);
     params[1] = t_cose_param_make_iv(nonce);
 
     params[0].next = &params[1];
@@ -136,12 +137,12 @@ t_cose_encrypt_enc_detached(struct t_cose_encrypt_enc *me,
          * conveyed to the recipient by some key distribution method in
          * a COSE_Recipient). */
         return_value = t_cose_crypto_get_random(cek_buffer,
-                                                bits_in_key / 8,
+                                                ce_alg.bits_in_key  / 8,
                                                 &cek_bytes);
         if (return_value != T_COSE_SUCCESS) {
             goto Done;
         }
-        return_value = t_cose_crypto_make_symmetric_key_handle(me->payload_cose_algorithm_id, /* in: alg id */
+        return_value = t_cose_crypto_make_symmetric_key_handle(ce_alg.cose_alg_id, /* in: alg id */
                                                                cek_bytes, /* in: key bytes */
                                                               &cek_handle); /* out: key handle */
     }
@@ -167,7 +168,7 @@ t_cose_encrypt_enc_detached(struct t_cose_encrypt_enc *me,
 
     // TODO: support AE (in addition to AEAD) algorithms
     return_value =
-        t_cose_crypto_aead_encrypt(me->payload_cose_algorithm_id, /* in: AEAD algorithm ID */
+        t_cose_crypto_aead_encrypt(ce_alg.cose_alg_id, /* in: AEAD algorithm ID */
                                    cek_handle,     /* in: content encryption key handle */
                                    nonce,          /* in: nonce / IV */
                                    enc_structure,  /* in: additional data to authenticate */
@@ -196,17 +197,13 @@ t_cose_encrypt_enc_detached(struct t_cose_encrypt_enc *me,
             recipient != NULL;
             recipient = recipient->next_in_list) {
 
-            cek_alg.cose_alg_id = me->payload_cose_algorithm_id;
-            cek_alg.alg_bits    = bits_in_key;
-
-
             /* Array holding the COSE_Recipients */
             QCBOREncode_OpenArray(&cbor_encoder);
 
             /* This does the public-key crypto and outputs a COSE_Recipient */
             return_value = recipient->creat_cb(recipient,
                                                cek_bytes,
-                                               cek_alg,
+                                               ce_alg,
                                               &cbor_encoder);
             if(return_value) {
                 goto Done;

--- a/src/t_cose_recipient_dec_hpke.c
+++ b/src/t_cose_recipient_dec_hpke.c
@@ -63,7 +63,7 @@ hpke_sender_info_decode_cb(void                    *cb_context,
 enum t_cose_err_t
 t_cose_recipient_dec_hpke_cb_private(struct t_cose_recipient_dec *me_x,
                                      const struct t_cose_header_location loc,
-                                     struct t_cose_alg_and_bits      cek_alg,
+                                     struct t_cose_alg_and_bits      ce_alg,
                                      QCBORDecodeContext *cbor_decoder,
                                      struct q_useful_buf cek_buffer,
                                      struct t_cose_parameter_storage *p_storage,
@@ -84,7 +84,7 @@ t_cose_recipient_dec_hpke_cb_private(struct t_cose_recipient_dec *me_x,
 
     me = (struct t_cose_recipient_dec_hpke *)me_x;
 
-    (void)cek_alg; /* TODO: Still up for debate whether COSE-HPKE does COSE_KDF_Context or not. */
+    (void)ce_alg; /* TODO: Still up for debate whether COSE-HPKE does COSE_KDF_Context or not. */
 
     /* One recipient */
     QCBORDecode_EnterArray(cbor_decoder, NULL);

--- a/src/t_cose_recipient_dec_hpke.c
+++ b/src/t_cose_recipient_dec_hpke.c
@@ -63,6 +63,7 @@ hpke_sender_info_decode_cb(void                    *cb_context,
 enum t_cose_err_t
 t_cose_recipient_dec_hpke_cb_private(struct t_cose_recipient_dec *me_x,
                                      const struct t_cose_header_location loc,
+                                     struct t_cose_alg_and_bits      cek_alg,
                                      QCBORDecodeContext *cbor_decoder,
                                      struct q_useful_buf cek_buffer,
                                      struct t_cose_parameter_storage *p_storage,
@@ -82,6 +83,8 @@ t_cose_recipient_dec_hpke_cb_private(struct t_cose_recipient_dec *me_x,
     struct q_useful_buf_c enc_struct;
 
     me = (struct t_cose_recipient_dec_hpke *)me_x;
+
+    (void)cek_alg; /* TODO: Still up for debate whether COSE-HPKE does COSE_KDF_Context or not. */
 
     /* One recipient */
     QCBORDecode_EnterArray(cbor_decoder, NULL);

--- a/src/t_cose_recipient_dec_keywrap.c
+++ b/src/t_cose_recipient_dec_keywrap.c
@@ -23,6 +23,7 @@
 enum t_cose_err_t
 t_cose_recipient_dec_keywrap_cb_private(struct t_cose_recipient_dec *me_x,
                                         const struct t_cose_header_location loc,
+                                        const struct t_cose_alg_and_bits cek_alg,
                                         QCBORDecodeContext *cbor_decoder,
                                         struct q_useful_buf cek_buffer,
                                         struct t_cose_parameter_storage *p_storage,
@@ -36,6 +37,8 @@ t_cose_recipient_dec_keywrap_cb_private(struct t_cose_recipient_dec *me_x,
     QCBORError             cbor_error;
 
     struct t_cose_recipient_dec_keywrap *me = (struct t_cose_recipient_dec_keywrap *)me_x;
+
+    (void)cek_alg; /* No COSE_KDF_Context is built for key wrap. */
 
     /* ---- The array of three that is a COSE_Recipient ---- */
     QCBORDecode_EnterArray(cbor_decoder, NULL);

--- a/src/t_cose_recipient_dec_keywrap.c
+++ b/src/t_cose_recipient_dec_keywrap.c
@@ -23,7 +23,7 @@
 enum t_cose_err_t
 t_cose_recipient_dec_keywrap_cb_private(struct t_cose_recipient_dec *me_x,
                                         const struct t_cose_header_location loc,
-                                        const struct t_cose_alg_and_bits cek_alg,
+                                        const struct t_cose_alg_and_bits ce_alg,
                                         QCBORDecodeContext *cbor_decoder,
                                         struct q_useful_buf cek_buffer,
                                         struct t_cose_parameter_storage *p_storage,
@@ -38,7 +38,7 @@ t_cose_recipient_dec_keywrap_cb_private(struct t_cose_recipient_dec *me_x,
 
     struct t_cose_recipient_dec_keywrap *me = (struct t_cose_recipient_dec_keywrap *)me_x;
 
-    (void)cek_alg; /* No COSE_KDF_Context is built for key wrap. */
+    (void)ce_alg; /* No COSE_KDF_Context is built for key wrap. */
 
     /* ---- The array of three that is a COSE_Recipient ---- */
     QCBORDecode_EnterArray(cbor_decoder, NULL);

--- a/src/t_cose_recipient_enc_hpke.c
+++ b/src/t_cose_recipient_enc_hpke.c
@@ -89,6 +89,7 @@ t_cose_crypto_hpke_encrypt(struct t_cose_crypto_hpke_suite_t  suite,
 enum t_cose_err_t
 t_cose_recipient_create_hpke_cb_private(struct t_cose_recipient_enc  *me_x,
                                         struct q_useful_buf_c         cek,
+                                        struct t_cose_alg_and_bits    cek_alg,
                                         QCBOREncodeContext           *cbor_encoder)
 {
     struct q_useful_buf_c  proteced_params;
@@ -107,6 +108,8 @@ t_cose_recipient_create_hpke_cb_private(struct t_cose_recipient_enc  *me_x,
     struct t_cose_recipient_enc_hpke *context;
 
     context = (struct t_cose_recipient_enc_hpke *)me_x;
+
+    (void)cek_alg; /* TODO: Still up for debate whether COSE-HPKE does COSE_KDF_Context or not. */
 
     /* Create ephemeral key */
     return_value = t_cose_crypto_generate_key(&ephemeral_key,

--- a/src/t_cose_recipient_enc_hpke.c
+++ b/src/t_cose_recipient_enc_hpke.c
@@ -89,7 +89,7 @@ t_cose_crypto_hpke_encrypt(struct t_cose_crypto_hpke_suite_t  suite,
 enum t_cose_err_t
 t_cose_recipient_create_hpke_cb_private(struct t_cose_recipient_enc  *me_x,
                                         struct q_useful_buf_c         cek,
-                                        struct t_cose_alg_and_bits    cek_alg,
+                                        struct t_cose_alg_and_bits    ce_alg,
                                         QCBOREncodeContext           *cbor_encoder)
 {
     struct q_useful_buf_c  proteced_params;
@@ -109,7 +109,7 @@ t_cose_recipient_create_hpke_cb_private(struct t_cose_recipient_enc  *me_x,
 
     context = (struct t_cose_recipient_enc_hpke *)me_x;
 
-    (void)cek_alg; /* TODO: Still up for debate whether COSE-HPKE does COSE_KDF_Context or not. */
+    (void)ce_alg; /* TODO: Still up for debate whether COSE-HPKE does COSE_KDF_Context or not. */
 
     /* Create ephemeral key */
     return_value = t_cose_crypto_generate_key(&ephemeral_key,

--- a/src/t_cose_recipient_enc_keywrap.c
+++ b/src/t_cose_recipient_enc_keywrap.c
@@ -23,7 +23,7 @@
 enum t_cose_err_t
 t_cose_recipient_create_keywrap_cb_private(struct t_cose_recipient_enc  *me_x,
                                            const struct q_useful_buf_c   plaintext,
-                                           const struct t_cose_alg_and_bits cek_alg,
+                                           const struct t_cose_alg_and_bits ce_alg,
                                            QCBOREncodeContext           *cbor_encoder)
 {
     struct t_cose_recipient_enc_keywrap *me;
@@ -34,7 +34,7 @@ t_cose_recipient_create_keywrap_cb_private(struct t_cose_recipient_enc  *me_x,
     struct q_useful_buf_c                encrypted_cek_result;
     struct q_useful_buf_c                protected_params_not;
 
-    (void)cek_alg; /* No COSE_KDF_Context is built for key wrap. */
+    (void)ce_alg; /* No COSE_KDF_Context is built for key wrap. */
 
     me = (struct t_cose_recipient_enc_keywrap *) me_x;
 

--- a/src/t_cose_recipient_enc_keywrap.c
+++ b/src/t_cose_recipient_enc_keywrap.c
@@ -19,9 +19,11 @@
 
 #ifndef T_COSE_DISABLE_KEYWRAP
 
+
 enum t_cose_err_t
 t_cose_recipient_create_keywrap_cb_private(struct t_cose_recipient_enc  *me_x,
                                            const struct q_useful_buf_c   plaintext,
+                                           const struct t_cose_alg_and_bits cek_alg,
                                            QCBOREncodeContext           *cbor_encoder)
 {
     struct t_cose_recipient_enc_keywrap *me;
@@ -31,6 +33,8 @@ t_cose_recipient_create_keywrap_cb_private(struct t_cose_recipient_enc  *me_x,
     struct q_useful_buf                  encrypted_cek_destiation;
     struct q_useful_buf_c                encrypted_cek_result;
     struct q_useful_buf_c                protected_params_not;
+
+    (void)cek_alg; /* No COSE_KDF_Context is built for key wrap. */
 
     me = (struct t_cose_recipient_enc_keywrap *) me_x;
 

--- a/src/t_cose_util.c
+++ b/src/t_cose_util.c
@@ -111,6 +111,31 @@ hash_alg_id_from_sig_alg_id(int32_t cose_algorithm_id)
 }
 
 
+/**
+ * \brief Returns the key length (in bits) of a given encryption algo.
+ *
+ * @param cose_algorithm_id  Crypto algorithm.
+ *
+ * Returns the key length (in bits) or UINT_MAX in case of an
+ * unknown algorithm id.
+ */
+uint32_t
+bits_in_crypto_alg(int32_t cose_algorithm_id)
+{
+    switch(cose_algorithm_id) {
+        case T_COSE_ALGORITHM_AES128CCM_16_128:
+        case T_COSE_ALGORITHM_A128KW:
+        case T_COSE_ALGORITHM_A128GCM: return 128;
+        case T_COSE_ALGORITHM_A192KW:
+        case T_COSE_ALGORITHM_A192GCM: return 192;
+        case T_COSE_ALGORITHM_AES256CCM_16_128:
+        case T_COSE_ALGORITHM_A256KW:
+        case T_COSE_ALGORITHM_A256GCM: return 256;
+        default: return UINT32_MAX;
+    }
+}
+
+
 #ifndef T_COSE_DISABLE_MAC0
 // TODO: try to combine with create_tbs_hash so that no buffer for headers
 // is needed. Make sure it doesn't make sign-only or mac-only object code big

--- a/src/t_cose_util.h
+++ b/src/t_cose_util.h
@@ -92,6 +92,20 @@ extern "C" {
  */
 int32_t hash_alg_id_from_sig_alg_id(int32_t cose_algorithm_id);
 
+
+/**
+ * \brief Returns the key length (in bits) of a given encryption algo.
+ *
+ * @param cose_algorithm_id  Crypto algorithm.
+ *
+ * Returns the key length (in bits) or UINT_MAX in case of an
+ * unknown algorithm id.
+ */
+uint32_t
+bits_in_crypto_alg(int32_t cose_algorithm_id);
+
+
+
 /**
  * \brief Create the ToBeMaced (TBM) structure bytes for COSE.
  *


### PR DESCRIPTION
This is so COSE_KDF_Context can be implemented in a better way.

This also makes the [in] arguments to t_cose_crypto_hkdf const. Nothing critical, just good hygiene.