### PR TITLE
fix warning in crypto test and in params

### DIFF
--- a/test/t_cose_crypto_test.c
+++ b/test/t_cose_crypto_test.c
@@ -298,6 +298,8 @@ int_fast32_t hkdf_test(void)
                             okm)) {
         return 2;
     }
+#else
+    (void)okm;
 #endif
 
     return 0;


### PR DESCRIPTION
Rearrange parameter decoding a little for smaller code and to get rid of a compiler warning (which was a false positive, but we still don't like warnings).

Warning about unused var in test.