### PR TITLE
Encrypt/decrypt encode/decode works, but not crypto

### DIFF
--- a/crypto_adapters/t_cose_openssl_crypto.c
+++ b/crypto_adapters/t_cose_openssl_crypto.c
@@ -2405,3 +2405,23 @@ t_cose_crypto_import_ec2_pubkey(int32_t               cose_ec_curve_id,
 
     return T_COSE_SUCCESS;
 }
+
+enum t_cose_err_t
+t_cose_crypto_export_ec2_key(struct t_cose_key     pub_key,
+                             int32_t               *curve,
+                             struct q_useful_buf    x_coord_buf,
+                             struct q_useful_buf_c *x_coord,
+                             struct q_useful_buf    y_coord_buf,
+                             struct q_useful_buf_c *y_coord,
+                             bool                  *y_bool)
+{
+    (void)curve;
+    (void)x_coord;
+    (void)x_coord_buf;
+    (void)y_coord_buf;
+    (void)y_coord;
+    (void)y_bool;
+    (void)pub_key;
+
+    return T_COSE_ERR_FAIL;
+}

--- a/crypto_adapters/t_cose_test_crypto.c
+++ b/crypto_adapters/t_cose_test_crypto.c
@@ -683,3 +683,59 @@ t_cose_crypto_hkdf(const int32_t               cose_hash_algorithm_id,
     (void)UsefulBuf_Set(okm_buffer, 'x');
     return T_COSE_SUCCESS;
 }
+
+
+/*
+ * See documentation in t_cose_crypto.h
+ */
+enum t_cose_err_t
+t_cose_crypto_import_ec2_pubkey(int32_t               cose_ec_curve_id,
+                                struct q_useful_buf_c x_coord,
+                                struct q_useful_buf_c y_coord,
+                                bool                  y_bool,
+                                struct t_cose_key    *pub_key)
+{
+    (void)cose_ec_curve_id;
+    (void)x_coord;
+    (void)y_coord;
+    (void)y_bool;
+    (void)pub_key;
+
+    return T_COSE_ERR_FAIL;
+}
+
+
+enum t_cose_err_t
+t_cose_crypto_export_ec2_key(struct t_cose_key     pub_key,
+                             int32_t               *curve,
+                             struct q_useful_buf    x_coord_buf,
+                             struct q_useful_buf_c *x_coord,
+                             struct q_useful_buf    y_coord_buf,
+                             struct q_useful_buf_c *y_coord,
+                             bool                  *y_bool)
+{
+    (void)curve;
+    (void)x_coord;
+    (void)x_coord_buf;
+    (void)y_coord_buf;
+    (void)y_coord;
+    (void)y_bool;
+    (void)pub_key;
+
+    return T_COSE_ERR_FAIL;
+}
+
+enum t_cose_err_t
+t_cose_crypto_ecdh(struct t_cose_key      private_key,
+                   struct t_cose_key      public_key,
+                   struct q_useful_buf    shared_key_buf,
+                   struct q_useful_buf_c *shared_key)
+{
+    (void)private_key;
+    (void)public_key;
+    (void)shared_key_buf;
+    (void)shared_key;
+
+    return T_COSE_ERR_FAIL;
+
+}

--- a/src/t_cose_crypto.h
+++ b/src/t_cose_crypto.h
@@ -1305,6 +1305,16 @@ t_cose_crypto_import_ec2_pubkey(int32_t               curve,
                                 bool                  y_bool,
                                 struct t_cose_key    *pub_key);
 
+
+enum t_cose_err_t
+t_cose_crypto_export_ec2_key(struct t_cose_key     pub_key,
+                             int32_t               *curve,
+                             struct q_useful_buf    x_coord_buf,
+                             struct q_useful_buf_c *x_coord,
+                             struct q_useful_buf    y_coord_buf,
+                             struct q_useful_buf_c *y_coord,
+                             bool                  *y_bool);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/t_cose_crypto.h
+++ b/src/t_cose_crypto.h
@@ -1298,16 +1298,49 @@ t_cose_crypto_hkdf_expand(int32_t                cose_hash_algorithm_id,
 #endif /* WE_NEED_THESE */
 
 
+/* Import a COSE_Key in EC2 format into a key handle.
+ *
+ * \param[in] curve        EC curve from COSE curve registry.
+ * \param[in] x_coord      The X coordinate as a byte string.
+ * \param[in] y_coord      The Y coordinate or NULL.
+ * \param[in] y_bool       The Y sign bit when y_coord is NULL.
+ * \param[out] key_handle  The key handle.
+ *
+ * This doesn't do the actual CBOR decoding, just the import
+ * into a key handle for the crypto library.
+ *
+ * The coordinates are as specified in SECG 1.
+ *
+ * TODO: also support the private key.
+ */
 enum t_cose_err_t
 t_cose_crypto_import_ec2_pubkey(int32_t               curve,
                                 struct q_useful_buf_c x_coord,
                                 struct q_useful_buf_c y_coord,
                                 bool                  y_bool,
-                                struct t_cose_key    *pub_key);
+                                struct t_cose_key    *key_handle);
 
 
+/* Export a key handle into COSE_Key in EC2 format.
+ *
+ * \param[in] key_handle   The key handle.
+ * \param[out] curve        EC curve from COSE curve registry.
+ * \param[out] x_coord_buf  Buffer in which to put X coordinate.
+ * \param[out] x_coord      The X coordinate as a byte string.
+ * \param[out] y_coord_buf  Buffer in which to put Y coordinate.
+ * \param[out] y_coord      The Y coordinate or NULL.
+ * \param[out] y_bool       The Y sign bit when y_coord is NULL.
+ *
+ * This doesn't do the actual CBOR decoding, just the export
+ * from a key handle for the crypto library.
+ *
+ * The coordinates are as specified in SECG 1.
+ *
+ * TODO: also support the private key.
+ * TODO: a way to turn point compression on / off?
+ */
 enum t_cose_err_t
-t_cose_crypto_export_ec2_key(struct t_cose_key     pub_key,
+t_cose_crypto_export_ec2_key(struct t_cose_key      key_handle,
                              int32_t               *curve,
                              struct q_useful_buf    x_coord_buf,
                              struct q_useful_buf_c *x_coord,

--- a/src/t_cose_recipient_dec_esdh.c
+++ b/src/t_cose_recipient_dec_esdh.c
@@ -233,6 +233,9 @@ t_cose_recipient_dec_esdh_cb_private(struct t_cose_recipient_dec *me_x,
         salt = NULL_Q_USEFUL_BUF_C;
     }
 
+    derived_key.ptr = "xxx"; // Fake it to get a full run through even though crypto is right yet
+    derived_key.len = 3;
+
     cose_result = t_cose_crypto_hkdf(kdf_hash_alg,
                                      salt, /* in: salt */
                                      derived_key, /* in: ikm */
@@ -260,6 +263,11 @@ t_cose_recipient_dec_esdh_cb_private(struct t_cose_recipient_dec *me_x,
                         cek_encrypted, /* in: encrypted CEK */
                         cek_buffer, /* in: buffer for CEK */
                         cek); /* out: the CEK*/
+
+    cek->ptr = "xxxxxxxxxxxxxxxx"; // Fake it to get a full run through even though crypto is right yet
+    cek->len = 16;
+    cose_result = 0;
+
 
 Done:
     return cose_result;

--- a/t_cose.xcodeproj/project.pbxproj
+++ b/t_cose.xcodeproj/project.pbxproj
@@ -26,8 +26,6 @@
 		E7088A192A50B88B00F1B2DE /* t_cose_recipient_enc_esdh.c in Sources */ = {isa = PBXBuildFile; fileRef = E7088A102A50B78100F1B2DE /* t_cose_recipient_enc_esdh.c */; };
 		E7088A1A2A50B88C00F1B2DE /* t_cose_recipient_enc_esdh.c in Sources */ = {isa = PBXBuildFile; fileRef = E7088A102A50B78100F1B2DE /* t_cose_recipient_enc_esdh.c */; };
 		E7088A1B2A50B88D00F1B2DE /* t_cose_recipient_enc_esdh.c in Sources */ = {isa = PBXBuildFile; fileRef = E7088A102A50B78100F1B2DE /* t_cose_recipient_enc_esdh.c */; };
-		E7088A1E2A50B89B00F1B2DE /* t_cose_signature_sign_restart.c in Sources */ = {isa = PBXBuildFile; fileRef = E7088A0E2A50B78100F1B2DE /* t_cose_signature_sign_restart.c */; };
-		E7088A1F2A50B89C00F1B2DE /* t_cose_signature_sign_restart.c in Sources */ = {isa = PBXBuildFile; fileRef = E7088A0E2A50B78100F1B2DE /* t_cose_signature_sign_restart.c */; };
 		E721CB9B2362AC2A00C7FD56 /* t_cose_sign_verify_test.c in Sources */ = {isa = PBXBuildFile; fileRef = E721CB9423628D2600C7FD56 /* t_cose_sign_verify_test.c */; };
 		E72BBC722A3C08F40093455E /* t_cose_qcbor_gap.c in Sources */ = {isa = PBXBuildFile; fileRef = E72BBC712A3C08F40093455E /* t_cose_qcbor_gap.c */; };
 		E72BBC732A3C08FE0093455E /* t_cose_qcbor_gap.c in Sources */ = {isa = PBXBuildFile; fileRef = E72BBC712A3C08F40093455E /* t_cose_qcbor_gap.c */; };
@@ -1138,7 +1136,6 @@
 				E7088A162A50B88400F1B2DE /* t_cose_recipient_dec_esdh.c in Sources */,
 				E7AE887C29A4C26F0093B326 /* examples_main.c in Sources */,
 				E7AE888129A4C3C20093B326 /* encryption_examples.c in Sources */,
-				E7088A1E2A50B89B00F1B2DE /* t_cose_signature_sign_restart.c in Sources */,
 				E7AE886929A402670093B326 /* init_keys_psa.c in Sources */,
 				E7AE887829A4C0250093B326 /* print_buf.c in Sources */,
 				E7F1736D29592A4600E5ADF3 /* t_cose_recipient_enc_keywrap.c in Sources */,
@@ -1168,7 +1165,6 @@
 				E7088A1B2A50B88D00F1B2DE /* t_cose_recipient_enc_esdh.c in Sources */,
 				E7FECC4C288754E400420F6F /* t_cose_sign_sign.c in Sources */,
 				E73BF70B23B07ACF00DF5C36 /* t_cose_openssl_crypto.c in Sources */,
-				E7088A1F2A50B89C00F1B2DE /* t_cose_signature_sign_restart.c in Sources */,
 				E78247F0297AAF2D008ED9C8 /* t_cose_encrypt_enc.c in Sources */,
 				E7F17331293B10EC00E5ADF3 /* t_cose_signature_verify_main.c in Sources */,
 				E7F1732E293B10E400E5ADF3 /* t_cose_signature_sign_main.c in Sources */,


### PR DESCRIPTION
A little improvement to esdh encrypt/decrypt. Trying to do small incremental improvements.

This one fixes the header and param encoding for ESDH recipients.

The keys and set up for the crypto is not right yet so it can't round-trip yet. Lots more to do for that.