### PR TITLE
Replace all int_fast32_t with int32_t

### DIFF
--- a/test/t_cose_compute_validate_mac_test.c
+++ b/test/t_cose_compute_validate_mac_test.c
@@ -68,7 +68,7 @@ make_hmac_key(int32_t cose_alg, struct t_cose_key *key)
 /*
  * Compute and validate a test COSE_Mac0 message with the selected MAC algorithm.
  */
-static int_fast32_t compute_validate_basic_test_alg_mac(int32_t cose_alg)
+static int32_t compute_validate_basic_test_alg_mac(int32_t cose_alg)
 {
     struct t_cose_mac_calculate_ctx   mac_ctx;
     struct t_cose_mac_validate_ctx    validate_ctx;
@@ -136,9 +136,9 @@ Done:
 /*
  * Public function, see t_cose_compute_validate_mac_test.h
  */
-int_fast32_t compute_validate_mac_basic_test()
+int32_t compute_validate_mac_basic_test()
 {
-    int_fast32_t return_value;
+    int32_t return_value;
 
     if(t_cose_is_algorithm_supported(T_COSE_ALGORITHM_HMAC256)) {
         return_value  = compute_validate_basic_test_alg_mac(
@@ -171,7 +171,7 @@ int_fast32_t compute_validate_mac_basic_test()
 /*
  * Public function, see t_cose_compute_validate_mac_test.h
  */
-int_fast32_t compute_validate_mac_fail_test()
+int32_t compute_validate_mac_fail_test()
 {
     struct t_cose_mac_calculate_ctx   mac_ctx;
     struct t_cose_mac_validate_ctx    validate_ctx;
@@ -344,7 +344,7 @@ static int size_test(int32_t               cose_algorithm_id,
 /*
  * Public function, see t_cose_compute_validate_mac_test.h
  */
-int_fast32_t compute_validate_get_size_mac_test()
+int32_t compute_validate_get_size_mac_test()
 {
     enum t_cose_err_t return_value;
     struct t_cose_key key;
@@ -404,7 +404,7 @@ int_fast32_t compute_validate_get_size_mac_test()
 /*
  * Public function, see t_cose_compute_validate_mac_test.h
  */
-int_fast32_t compute_validate_detached_content_mac_fail_test()
+int32_t compute_validate_detached_content_mac_fail_test()
 {
     struct t_cose_mac_calculate_ctx   mac_ctx;
     struct t_cose_mac_validate_ctx    validate_ctx;
@@ -570,7 +570,7 @@ static int detached_content_size_test(int32_t               cose_algorithm_id,
 /*
  * Public function, see t_cose_compute_validate_mac_test.h
  */
-int_fast32_t compute_validate_get_size_detached_content_mac_test()
+int32_t compute_validate_get_size_detached_content_mac_test()
 {
     enum t_cose_err_t return_value;
     struct t_cose_key key;

--- a/test/t_cose_compute_validate_mac_test.h
+++ b/test/t_cose_compute_validate_mac_test.h
@@ -27,30 +27,30 @@
  *
  * \return non-zero on failure.
  */
-int_fast32_t compute_validate_mac_basic_test(void);
+int32_t compute_validate_mac_basic_test(void);
 
 
 /*
  * Compute MAC of some data, perturb the data and see that MAC validation fails.
  */
-int_fast32_t compute_validate_mac_fail_test(void);
+int32_t compute_validate_mac_fail_test(void);
 
 
 /*
  * Test the ability to calculate size of a COSE_Mac0.
  */
-int_fast32_t compute_validate_get_size_mac_test(void);
+int32_t compute_validate_get_size_mac_test(void);
 
 
 /*
  * Compute MAC of some data, perturb the data and see that MAC validation fails.
  */
-int_fast32_t compute_validate_detached_content_mac_fail_test(void);
+int32_t compute_validate_detached_content_mac_fail_test(void);
 
 
 /*
  * Test the ability to calculate size of a COSE_Mac0.
  */
-int_fast32_t compute_validate_get_size_detached_content_mac_test(void);
+int32_t compute_validate_get_size_detached_content_mac_test(void);
 
 #endif /* t_cose_compute_validate_mac_test_h */

--- a/test/t_cose_crypto_test.c
+++ b/test/t_cose_crypto_test.c
@@ -43,7 +43,7 @@ static const uint8_t expected_empty_tag[] = {
     0xC9, 0x4A, 0xA9, 0xF3, 0x22, 0x75, 0x73, 0x8C, 0xD5, 0xCC, 0x75, 0x01, 0xA4, 0x80, 0xBC, 0xF5};
 #endif
 
-int_fast32_t aead_test(void)
+int32_t aead_test(void)
 {
     enum t_cose_err_t      err;
     int32_t                cose_algorithm_id;
@@ -61,7 +61,7 @@ int_fast32_t aead_test(void)
                                                   UsefulBuf_FROM_BYTE_ARRAY_LITERAL(test_key_0_128bit),
                                                  &key);
     if(err) {
-        return 1000 + (int_fast32_t)err;
+        return 1000 + (int32_t)err;
     }
 
     /* First the simplest case, no payload, no aad, just the tag */
@@ -73,7 +73,7 @@ int_fast32_t aead_test(void)
                                      ciphertext_buffer,
                                      &ciphertext);
     if(err) {
-        return 2000 + (int_fast32_t)err;
+        return 2000 + (int32_t)err;
     }
 
     /* TODO: proper define to know about test crypto */
@@ -102,7 +102,7 @@ int_fast32_t aead_test(void)
                                      &plaintext);
 
     if(err) {
-        return 3000 + (int_fast32_t)err;
+        return 3000 + (int32_t)err;
     }
 
     if(plaintext.len != 0) {
@@ -119,7 +119,7 @@ int_fast32_t aead_test(void)
                                      ciphertext_buffer,
                                      &ciphertext);
     if(err) {
-        return 4000 + (int_fast32_t)err;
+        return 4000 + (int32_t)err;
     }
 
     err = t_cose_crypto_aead_decrypt(cose_algorithm_id,
@@ -130,7 +130,7 @@ int_fast32_t aead_test(void)
                                      plaintext_buffer,
                                      &plaintext);
     if(err) {
-        return 5000 + (int_fast32_t)err;
+        return 5000 + (int32_t)err;
     }
 
     if(q_useful_buf_compare(Q_USEFUL_BUF_FROM_SZ_LITERAL("plain text"), plaintext)) {
@@ -150,7 +150,7 @@ int_fast32_t aead_test(void)
 
 #ifndef T_COSE_DISABLE_KEYWRAP
 
-int_fast32_t kw_test(void)
+int32_t kw_test(void)
 {
     struct t_cose_key kek;
     /* These are test vectors from RFC 3394 */
@@ -276,7 +276,7 @@ static const uint8_t tc1_okm_bytes[] = {
 };
 #endif
 
-int_fast32_t hkdf_test(void)
+int32_t hkdf_test(void)
 {
     Q_USEFUL_BUF_MAKE_STACK_UB(tc1_okm, 42);
     enum t_cose_err_t          err;
@@ -308,7 +308,7 @@ int_fast32_t hkdf_test(void)
 
 #ifndef T_COSE_USE_B_CON_SHA256 /* test crypto doesn't support ECDH */
 
-int_fast32_t ecdh_test(void)
+int32_t ecdh_test(void)
 {
     enum t_cose_err_t           err;
     struct t_cose_key           public_key;

--- a/test/t_cose_crypto_test.h
+++ b/test/t_cose_crypto_test.h
@@ -14,13 +14,13 @@
 #include <stdint.h>
 
 
-int_fast32_t aead_test(void);
+int32_t aead_test(void);
 
-int_fast32_t kw_test(void);
+int32_t kw_test(void);
 
-int_fast32_t hkdf_test(void);
+int32_t hkdf_test(void);
 
-int_fast32_t ecdh_test(void);
+int32_t ecdh_test(void);
 
 
 

--- a/test/t_cose_param_test.c
+++ b/test/t_cose_param_test.c
@@ -851,7 +851,7 @@ static struct param_test_combo param_combo_tests[] = {
 
 
 
-int_fast32_t
+int32_t
 param_test(void)
 {
     struct t_cose_parameter         param_array[20];
@@ -1067,7 +1067,7 @@ param_test(void)
 
 
 
-int_fast32_t
+int32_t
 common_params_test(void)
 {
     struct t_cose_parameter         param_array[20];

--- a/test/t_cose_param_test.h
+++ b/test/t_cose_param_test.h
@@ -14,8 +14,8 @@
 #include <stdint.h>
 
 
-int_fast32_t param_test(void);
+int32_t param_test(void);
 
-int_fast32_t common_params_test(void);
+int32_t common_params_test(void);
 
 #endif /* t_cose_param_test_h */

--- a/test/t_cose_sign_verify_test.c
+++ b/test/t_cose_sign_verify_test.c
@@ -230,7 +230,7 @@ static struct test_case test_cases[] = {
     { 0 }, /* Sentinel value with an invalid algorithm id */
 };
 
-static int_fast32_t sign_verify_basic_test_alg(int32_t cose_alg)
+static int32_t sign_verify_basic_test_alg(int32_t cose_alg)
 {
     struct t_cose_sign1_sign_ctx   sign_ctx;
     int32_t                        return_value;
@@ -297,9 +297,9 @@ Done:
 /*
  * Public function, see t_cose_sign_verify_test.h
  */
-int_fast32_t sign_verify_basic_test(void)
+int32_t sign_verify_basic_test(void)
 {
-    int_fast32_t return_value;
+    int32_t return_value;
 
     const struct test_case* tc;
     for (tc = test_cases; tc->cose_algorithm_id != 0; tc++) {
@@ -315,7 +315,7 @@ int_fast32_t sign_verify_basic_test(void)
 }
 
 
-static int_fast32_t sig_fail_test(int32_t cose_alg)
+static int32_t sig_fail_test(int32_t cose_alg)
 {
     struct t_cose_sign1_sign_ctx   sign_ctx;
     QCBOREncodeContext             cbor_encode;
@@ -401,9 +401,9 @@ Done:
 /*
  * Public function, see t_cose_sign_verify_test.h
  */
-int_fast32_t sign_verify_sig_fail_test()
+int32_t sign_verify_sig_fail_test()
 {
-    int_fast32_t return_value;
+    int32_t return_value;
     const struct test_case* tc;
     for (tc = test_cases; tc->cose_algorithm_id != 0; tc++) {
         if (t_cose_is_algorithm_supported(tc->cose_algorithm_id)) {
@@ -420,7 +420,7 @@ int_fast32_t sign_verify_sig_fail_test()
 /*
  * Public function, see t_cose_sign_verify_test.h
  */
-int_fast32_t sign_verify_make_cwt_test()
+int32_t sign_verify_make_cwt_test()
 {
     struct t_cose_sign1_sign_ctx   sign_ctx;
     QCBOREncodeContext             cbor_encode;
@@ -558,7 +558,7 @@ Done:
 }
 
 
-static int_fast32_t size_test(int32_t               cose_algorithm_id,
+static int32_t size_test(int32_t               cose_algorithm_id,
                               struct q_useful_buf_c kid)
 {
     struct t_cose_key              key_pair;
@@ -700,9 +700,9 @@ Done:
 /*
  * Public function, see t_cose_sign_verify_test.h
  */
-int_fast32_t sign_verify_get_size_test()
+int32_t sign_verify_get_size_test()
 {
-    int_fast32_t return_value;
+    int32_t return_value;
     const struct test_case* tc;
     for (tc = test_cases; tc->cose_algorithm_id != 0; tc++) {
         if (t_cose_is_algorithm_supported(tc->cose_algorithm_id)) {
@@ -724,7 +724,7 @@ int_fast32_t sign_verify_get_size_test()
 }
 
 
-static int_fast32_t known_good_test(int cose_algorithm_id, struct q_useful_buf_c signed_message)
+static int32_t known_good_test(int cose_algorithm_id, struct q_useful_buf_c signed_message)
 {
     int32_t                        return_value;
     enum t_cose_err_t              result;
@@ -805,9 +805,9 @@ Done2:
     return return_value;
 }
 
-int_fast32_t sign_verify_known_good_test(void)
+int32_t sign_verify_known_good_test(void)
 {
-    int_fast32_t return_value = 0;
+    int32_t return_value = 0;
     const struct test_case* tc;
     for (tc = test_cases; tc->cose_algorithm_id != 0; tc++) {
         if (t_cose_is_algorithm_supported(tc->cose_algorithm_id)) {
@@ -835,7 +835,7 @@ int_fast32_t sign_verify_known_good_test(void)
  * not supported by the current t_cose configuration
  * and crypto adapter.
  */
-static int_fast32_t
+static int32_t
 sign_verify_unsupported_test_alg(int32_t cose_alg,
                                  struct q_useful_buf_c signed_message)
 {
@@ -879,9 +879,9 @@ Done:
     return return_value;
 }
 
-int_fast32_t sign_verify_unsupported_test(void)
+int32_t sign_verify_unsupported_test(void)
 {
-    int_fast32_t return_value;
+    int32_t return_value;
     const struct test_case* tc;
     for (tc = test_cases; tc->cose_algorithm_id != 0; tc++) {
         /* Unlike other tests, this one runs only on unsupported algorithms.
@@ -901,7 +901,7 @@ int_fast32_t sign_verify_unsupported_test(void)
 /*
  * Public function, see t_cose_sign_verify_test.h
  */
-int_fast32_t sign_verify_bad_auxiliary_buffer(void)
+int32_t sign_verify_bad_auxiliary_buffer(void)
 {
     enum t_cose_err_t              result;
     int32_t                        return_value;
@@ -986,7 +986,7 @@ Done:
 
 
 #ifndef T_COSE_DISABLE_COSE_SIGN
-int_fast32_t sign_verify_multi(void)
+int32_t sign_verify_multi(void)
 {
     enum t_cose_err_t              result;
     struct t_cose_key   key_pair1;
@@ -1275,7 +1275,7 @@ int32_t verify_multi_test(void)
         struct t_cose_test_crypto_context crypto_ctx = {0}
 #endif
 
-int_fast32_t restart_test_2_step(void)
+int32_t restart_test_2_step(void)
 {
     QCBOREncodeContext              cbor_encode;
     QCBORError                      qcbor_result;
@@ -1356,7 +1356,7 @@ int_fast32_t restart_test_2_step(void)
     return 0;
 }
 #else
-int_fast32_t restart_test_2_step(void)
+int32_t restart_test_2_step(void)
 {
     return 0;
 }

--- a/test/t_cose_sign_verify_test.h
+++ b/test/t_cose_sign_verify_test.h
@@ -27,49 +27,49 @@
  *
  * \return non-zero on failure.
  */
-int_fast32_t sign_verify_basic_test(void);
+int32_t sign_verify_basic_test(void);
 
 
 /*
  * Sign some data, perturb the data and see that sig validation fails
  */
-int_fast32_t sign_verify_sig_fail_test(void);
+int32_t sign_verify_sig_fail_test(void);
 
 
 /*
  * Make a CWT and compare it to the one in the CWT RFC
  */
-int_fast32_t sign_verify_make_cwt_test(void);
+int32_t sign_verify_make_cwt_test(void);
 
 
 /*
  * Test the ability to calculate size of a COSE_Sign1
  */
-int_fast32_t sign_verify_get_size_test(void);
+int32_t sign_verify_get_size_test(void);
 
 
 /*
  * Test against known good messages.
  */
-int_fast32_t sign_verify_known_good_test(void);
+int32_t sign_verify_known_good_test(void);
 
 
 /*
  * Test the return value when using an unsupported algorithm.
  */
-int_fast32_t sign_verify_unsupported_test(void);
+int32_t sign_verify_unsupported_test(void);
 
 
 /*
  * Test the return value when using a small or no auxiliary buffer.
  */
-int_fast32_t sign_verify_bad_auxiliary_buffer(void);
+int32_t sign_verify_bad_auxiliary_buffer(void);
 
 
 /*
  * Test creation and verification of COSE_Sign with multiple COSE_Signatures
  */
-int_fast32_t sign_verify_multi(void);
+int32_t sign_verify_multi(void);
 
 
 
@@ -79,6 +79,6 @@ int32_t verify_multi_test(void);
 /*
  * Test restartable behaviour
  */
-int_fast32_t restart_test_2_step(void);
+int32_t restart_test_2_step(void);
 
 #endif /* t_cose_sign_verify_test_h */

--- a/test/t_cose_test.c
+++ b/test/t_cose_test.c
@@ -28,7 +28,7 @@ static const struct q_useful_buf_c s_input_payload = {SZ_CONTENT, sizeof(SZ_CONT
 /*
  * Public function, see t_cose_test.h
  */
-int_fast32_t short_circuit_self_test()
+int32_t short_circuit_self_test()
 {
     struct t_cose_sign1_sign_ctx    sign_ctx;
     struct t_cose_sign1_verify_ctx  verify_ctx;
@@ -142,7 +142,7 @@ int_fast32_t short_circuit_self_test()
 /*
  * Public function, see t_cose_test.h
  */
-int_fast32_t short_circuit_self_detached_content_test()
+int32_t short_circuit_self_detached_content_test()
 {
     struct t_cose_sign1_sign_ctx    sign_ctx;
     struct t_cose_sign1_verify_ctx  verify_ctx;
@@ -212,7 +212,7 @@ int_fast32_t short_circuit_self_detached_content_test()
 /*
  * Public function, see t_cose_test.h
  */
-int_fast32_t short_circuit_verify_fail_test()
+int32_t short_circuit_verify_fail_test()
 {
     struct t_cose_sign1_sign_ctx    sign_ctx;
     struct t_cose_sign1_verify_ctx  verify_ctx;
@@ -325,7 +325,7 @@ int_fast32_t short_circuit_verify_fail_test()
  * Public function, see t_cose_test.h
  */
 // TODO: name of this tests isn't right.
-int_fast32_t short_circuit_signing_error_conditions_test()
+int32_t short_circuit_signing_error_conditions_test()
 {
     struct t_cose_sign1_sign_ctx sign_ctx;
     enum t_cose_err_t            result;
@@ -406,7 +406,7 @@ int_fast32_t short_circuit_signing_error_conditions_test()
 /*
  * Public function, see t_cose_test.h
  */
-int_fast32_t short_circuit_make_cwt_test()
+int32_t short_circuit_make_cwt_test()
 {
     struct t_cose_sign1_sign_ctx    sign_ctx;
     struct t_cose_sign1_verify_ctx  verify_ctx;
@@ -542,7 +542,7 @@ int_fast32_t short_circuit_make_cwt_test()
 /*
  * Public function, see t_cose_test.h
  */
-int_fast32_t short_circuit_decode_only_test()
+int32_t short_circuit_decode_only_test()
 {
     struct t_cose_sign1_sign_ctx    sign_ctx;
     struct t_cose_sign1_verify_ctx  verify_ctx;
@@ -679,7 +679,7 @@ static const uint8_t rfc8152_example_2_1[] = {
 /*
  * Public function, see t_cose_test.h
  */
-int_fast32_t cose_example_test()
+int32_t cose_example_test()
 {
     enum t_cose_err_t             result;
     Q_USEFUL_BUF_MAKE_STACK_UB(   signed_cose_buffer, 200);
@@ -782,7 +782,7 @@ static enum t_cose_err_t run_test_sign_and_verify(uint32_t test_mess_options)
 
 
 #ifndef T_COSE_DISABLE_SHORT_CIRCUIT_SIGN
-int_fast32_t all_header_parameters_test()
+int32_t all_header_parameters_test()
 {
     enum t_cose_err_t               result;
     Q_USEFUL_BUF_MAKE_STACK_UB(     signed_cose_buffer, 300);
@@ -910,13 +910,13 @@ static struct test_case bad_parameters_tests_table[] = {
 /*
  * Public function, see t_cose_test.h
  */
-int_fast32_t bad_parameters_test()
+int32_t bad_parameters_test()
 {
     struct test_case *test;
 
     for(test = bad_parameters_tests_table; test->test_option; test++) {
         if(run_test_sign_and_verify(test->test_option) != test->result) {
-            return (int_fast32_t)(test - bad_parameters_tests_table + 1);
+            return (int32_t)(test - bad_parameters_tests_table + 1);
         }
     }
 
@@ -967,7 +967,7 @@ static struct test_case crit_tests_table[] = {
 /*
  * Public function, see t_cose_test.h
  */
-int_fast32_t crit_parameters_test()
+int32_t crit_parameters_test()
 {
     unsigned index;
 
@@ -975,7 +975,7 @@ int_fast32_t crit_parameters_test()
         struct test_case *test = &crit_tests_table[index];
 
         if(run_test_sign_and_verify(test->test_option) != test->result) {
-            return (int_fast32_t)(index * 1000 + 1);
+            return (int32_t)(index * 1000 + 1);
         }
     }
 
@@ -987,7 +987,7 @@ int_fast32_t crit_parameters_test()
 /*
  * Public function, see t_cose_test.h
  */
-int_fast32_t content_type_test()
+int32_t content_type_test()
 {
     struct t_cose_parameters        parameters;
     struct t_cose_sign1_sign_ctx    sign_ctx;
@@ -1473,7 +1473,7 @@ check_complex_sign_params(struct t_cose_parameter *params)
 /*
  * Public function, see t_cose_test.h
  */
-int_fast32_t sign1_structure_decode_test(void)
+int32_t sign1_structure_decode_test(void)
 {
     struct q_useful_buf_c           payload;
     enum t_cose_err_t               result;
@@ -1566,7 +1566,7 @@ extern int hash_test_mode;
 /*
  * Public function, see t_cose_test.h
  */
-int_fast32_t short_circuit_hash_fail_test()
+int32_t short_circuit_hash_fail_test()
 {
     struct t_cose_sign1_sign_ctx sign_ctx;
     enum t_cose_err_t            result;
@@ -1624,7 +1624,7 @@ int_fast32_t short_circuit_hash_fail_test()
 /*
  * Public function, see t_cose_test.h
  */
-int_fast32_t tags_test()
+int32_t tags_test()
 {
     struct t_cose_sign1_sign_ctx    sign_ctx;
     struct t_cose_sign1_verify_ctx  verify_ctx;
@@ -1991,7 +1991,7 @@ int_fast32_t tags_test()
 }
 
 
-int_fast32_t get_size_test()
+int32_t get_size_test()
 {
     struct t_cose_sign1_sign_ctx   sign_ctx;
     QCBOREncodeContext             cbor_encode;
@@ -2097,7 +2097,7 @@ int_fast32_t get_size_test()
 /*
  * Public function, see t_cose_test.h
  */
-int_fast32_t indef_array_and_map_test()
+int32_t indef_array_and_map_test()
 {
     enum t_cose_err_t  return_value;
     #ifdef TODO_CRIT_PARAM_FIXED
@@ -2145,7 +2145,7 @@ int_fast32_t indef_array_and_map_test()
 /*
  * Public function, see t_cose_test.h
  */
-int_fast32_t crypto_context_test()
+int32_t crypto_context_test()
 {
     struct t_cose_sign_sign_ctx         sign_ctx;
     struct t_cose_sign_verify_ctx       verify_ctx;

--- a/test/t_cose_test.h
+++ b/test/t_cose_test.h
@@ -32,7 +32,7 @@
  * short-circuit signatures so no keys or even integration with public
  * key crypto is necessary.
  */
-int_fast32_t short_circuit_self_test(void);
+int32_t short_circuit_self_test(void);
 
 
 /**
@@ -44,7 +44,7 @@ int_fast32_t short_circuit_self_test(void);
  * short-circuit signatures so no keys or even integration with public
  * key crypto is necessary.
  */
-int_fast32_t short_circuit_self_detached_content_test(void);
+int32_t short_circuit_self_detached_content_test(void);
 
 
 /**
@@ -56,7 +56,7 @@ int_fast32_t short_circuit_self_detached_content_test(void);
  * verification fails.  It uses short-circuit signatures so no keys or
  * even integration with public key crypto is necessary.
  */
-int_fast32_t short_circuit_verify_fail_test(void);
+int32_t short_circuit_verify_fail_test(void);
 
 
 /**
@@ -67,12 +67,12 @@ int_fast32_t short_circuit_verify_fail_test(void);
  * It uses short-circuit signatures so no keys or even integration
  * with public key crypto is necessary.
  */
-int_fast32_t short_circuit_signing_error_conditions_test(void);
+int32_t short_circuit_signing_error_conditions_test(void);
 
 
 /* Make a CWT and see that it compares to the sample in the CWT RFC
  */
-int_fast32_t short_circuit_make_cwt_test(void);
+int32_t short_circuit_make_cwt_test(void);
 
 
 /*
@@ -80,7 +80,7 @@ int_fast32_t short_circuit_make_cwt_test(void);
  * headers are returned, but the signature is not
  * verified.
  */
-int_fast32_t short_circuit_decode_only_test(void);
+int32_t short_circuit_decode_only_test(void);
 
 
 /*
@@ -90,36 +90,36 @@ int_fast32_t short_circuit_decode_only_test(void);
 - No algorithm ID parameter
 
  */
-int_fast32_t bad_parameters_test(void);
+int32_t bad_parameters_test(void);
 
 
 /* Test that makes a CWT (CBOR Web Token)
  */
-int_fast32_t cose_example_test(void);
+int32_t cose_example_test(void);
 
 
 /*
  Various tests involving the crit parameter.
  */
-int_fast32_t crit_parameters_test(void);
+int32_t crit_parameters_test(void);
 
 
 /*
  Check that all types of headers are correctly returned.
  */
-int_fast32_t all_header_parameters_test(void);
+int32_t all_header_parameters_test(void);
 
 
 /*
  * Check that setting the content type works
  */
-int_fast32_t content_type_test(void);
+int32_t content_type_test(void);
 
 
 /*
  * Check that setting the content type works
  */
-int_fast32_t sign1_structure_decode_test(void);
+int32_t sign1_structure_decode_test(void);
 
 
 #ifdef T_COSE_ENABLE_HASH_FAIL_TEST
@@ -133,7 +133,7 @@ int_fast32_t sign1_structure_decode_test(void);
  * It works only with the b_con hash bundled and not intended for
  * commercial use (though it is a perfectly fine implementation).
  */
-int_fast32_t short_circuit_hash_fail_test(void);
+int32_t short_circuit_hash_fail_test(void);
 
 #endif /* T_COSE_ENABLE_HASH_FAIL_TEST*/
 
@@ -142,20 +142,20 @@ int_fast32_t short_circuit_hash_fail_test(void);
 /*
  * Test tagging of COSE message
  */
-int_fast32_t tags_test(void);
+int32_t tags_test(void);
 
 
-int_fast32_t get_size_test(void);
+int32_t get_size_test(void);
 
 
 /*
  * Test the decoding of COSE messages that use indefinite length
  * maps and arrays instead of definite length.
  */
-int_fast32_t indef_array_and_map_test(void);
+int32_t indef_array_and_map_test(void);
 
 
-int_fast32_t crypto_context_test(void);
+int32_t crypto_context_test(void);
 
 
 #endif /* t_cose_test_h */


### PR DESCRIPTION
It was a bad idea to start and from a long time ago. Fixing now because some of the GitHub CI no longer thinks they are the same.