### PR TITLE
Fix: Add missing goto from PSA crypto adapter

### DIFF
--- a/crypto_adapters/t_cose_psa_crypto.c
+++ b/crypto_adapters/t_cose_psa_crypto.c
@@ -301,6 +301,7 @@ t_cose_crypto_sign_restart(bool                   started,
 
     if(!crypto_context) {
         return_value = T_COSE_ERR_FAIL;
+        goto Done;
     }
     psa_crypto_context = (struct t_cose_psa_crypto_context *)crypto_context;
 


### PR DESCRIPTION
This trivial fix adds the missing goto in the PSA crypto adapter so that t_cose_crypto_sign_restart bails out when the passed crypto context is NULL.