### PR TITLE
Test improvements for crit params; t_cose 1 compat

### DIFF
--- a/inc/t_cose/t_cose_common.h
+++ b/inc/t_cose/t_cose_common.h
@@ -724,17 +724,17 @@ enum t_cose_err_t {
 /**
  * Functions like t_cose_sign_verify() and t_cose_encrypt_dec() will
  * error out with \ref T_COSE_ERR_UNKNOWN_CRITICAL_PARAMETER if there
- * are any critical header parameters. Since the header parameters for
- * verification, decryption and similar are all standard, don't need
- * to be marked critical and understood by this implementation, this
- * error is not returned.
+ * are any unknown critical header parameters.
  *
- * This option turns off the check for critical parameters for use
- * cases that use them. In that case the caller of t_cose takes
- * responsibility for checking all the parameters decoded to be sure
- * there are no critical parameters that are not understood.
+ * This option turns off the check for critical parameters. if this is
+ * set, the caller of t_cose takes responsibility for checking all the
+ * parameters decoded to be sure there are no critical parameters that
+ * are not understood.
  */
 #define T_COSE_OPT_NO_CRIT_PARAM_CHECK  0x00001000
+#define T_COSE_OPT_UNKNOWN_CRIT_ALLOWED  T_COSE_OPT_NO_CRIT_PARAM_CHECK
+
+
 
 
 /**

--- a/test/t_cose_make_test_messages.c
+++ b/test/t_cose_make_test_messages.c
@@ -162,6 +162,11 @@ encode_protected_parameters(uint32_t            test_message_options,
         QCBOREncode_CloseArray(&cbor_encode_ctx);
     }
 
+    if(test_message_options & T_COSE_TEST_BAD_CRIT_PARAMETER) {
+        QCBOREncode_AddSZStringToMapN(&cbor_encode_ctx,
+                                      T_COSE_HEADER_PARAM_CRIT, "hi");
+    }
+
     if(test_message_options & T_COSE_TEST_EMPTY_CRIT_PARAMETER) {
         QCBOREncode_OpenArrayInMapN(&cbor_encode_ctx, T_COSE_HEADER_PARAM_CRIT);
         QCBOREncode_CloseArray(&cbor_encode_ctx);
@@ -238,11 +243,6 @@ add_unprotected_parameters(uint32_t              test_message_options,
     if(test_message_options & T_COSE_TEST_PARAMETER_LABEL) {
         QCBOREncode_AddBytes(cbor_encode_ctx, kid);
         QCBOREncode_AddBytes(cbor_encode_ctx, kid);
-    }
-
-    if(test_message_options & T_COSE_TEST_BAD_CRIT_PARAMETER) {
-        QCBOREncode_AddSZStringToMapN(cbor_encode_ctx,
-                                      T_COSE_HEADER_PARAM_CRIT, "hi");
     }
 
     if(test_message_options & T_COSE_TEST_EXTRA_PARAMETER) {


### PR DESCRIPTION
Some tests for crit params were re-enabled and fixed.

Fixes compatibility with t_cose 1 for disabling crit param check. This was trivial as it was implemented in t_cose already, just with a different option identifier.

