### PR TITLE
Initialise PSA signing context

### DIFF
--- a/crypto_adapters/t_cose_psa_crypto.c
+++ b/crypto_adapters/t_cose_psa_crypto.c
@@ -306,6 +306,8 @@ t_cose_crypto_sign_restart(bool                   started,
     psa_crypto_context = (struct t_cose_psa_crypto_context *)crypto_context;
 
     if(!started) {
+        psa_crypto_context->operation =
+            psa_sign_hash_interruptible_operation_init();
         psa_result = psa_sign_hash_start(
                             &psa_crypto_context->operation,
                             signing_key_psa,


### PR DESCRIPTION
This PR adds the missing context initialization in the PSA crypto adapter for the restartable case.

The original implementation misses to call `psa_sign_hash_interruptible_operation_init()` on the PSA sign function context. This doesn't cause a problem as long as the context structure is initialised to all 0, or a previous restartable signing with the same context was concluded earlier. However if the signing context of a previously interrupted signing is reused for a new signing operation, `psa_sign_hash_start` returns `PSA_ERROR_BAD_STATE`.