### PR TITLE
Fix QCBOR version check

### DIFF
--- a/inc/t_cose/t_cose_common.h
+++ b/inc/t_cose/t_cose_common.h
@@ -1,7 +1,7 @@
 /*
  * t_cose_common.h
  *
- * Copyright 2019-2022, Laurence Lundblade
+ * Copyright 2019-2024, Laurence Lundblade
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *
@@ -59,6 +59,14 @@ extern "C" {
  */
 
 
+/**
+ * Semantic versioning for t_cose x.y.z. Note that these were not defined
+ * for some releases of t_cose 1.x so !defined(T_COSE_VERSION_MAJOR)
+ * indicates t_cose 1.x.
+ */
+#define T_COSE_VERSION_MAJOR 1
+#define T_COSE_VERSION_MINOR 1
+#define T_COSE_VERSION_PATCH 2
 
 
 /**

--- a/src/t_cose_sign1_sign.c
+++ b/src/t_cose_sign1_sign.c
@@ -1,7 +1,7 @@
 /*
  * t_cose_sign1_sign.c
  *
- * Copyright (c) 2018-2021, Laurence Lundblade. All rights reserved.
+ * Copyright (c) 2018-2024, Laurence Lundblade. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *
@@ -15,10 +15,12 @@
 #include "t_cose_util.h"
 #include "t_cose_short_circuit.h"
 
-#ifndef QCBOR_1_1
-// The OpenBytes API we use was only added in 1.1.
+
+#if !(defined(QCBOR_1_1) || QCBOR_VERSION_MAJOR >= 2 || (QCBOR_VERSION_MAJOR == 1 && QCBOR_VERSION_MINOR >= 1))
+/* The OpenBytes API we use was only added in 1.1. */
 #error t_cose requires QCBOR 1.1 or greater
 #endif
+
 
 /**
  * \file t_cose_sign1_sign.c


### PR DESCRIPTION
Fixes check for the correct version of QCBOR so it works for all versions of QCBOR

Add semantic version numbering for t_cose 1.x