### PR TITLE
Tag number processing update for QCBOR v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,19 @@
-This is the DEV BRANCH for t_cose 2.0. It is an ALPHA quality release. The major 
-features are in place. Test and documentation are not complete.  There may be 
-minor changes.
+This is the DEV BRANCH for t_cose 2.0. It is an ALPHA quality
+release. The major features are in place. Test and documentation are
+not complete.  There will be changes.
 
-COMPATIBILITY NOTE: t_cose 2.0 supports the same sign and verify APIs that t_cose 1.x 
-does, but it is recommended that t_cose 2.0 users move to the new APIs for better efficiency
-and code size. Specifically, users should move from t_cose_sign1_xxxx to t_cose_sign_xxx.
-The t_cose_sign_xxx APIs in 2.0 support both COSE_Sign and COSE_Sign1.  A select
-few users that are very concerned about code size and that do not need any t_cose 2.x
-features may choose to stay with t_cose 1.x as overall it a smaller implementation
-of COSE_Sign1.
+COMPATIBILITY NOTE: v2.0 is backwards compatible with v1.x, but there
+are new APIs in v2.0 for signing and verification. The v2.0 APIs
+support both COSE_Sign and COSE_Sign1 and support multiple
+signatures. The v2.0 API are named "t_cose_sign_xxx" and the
+old ones, which support only COSE_Sign1, are named "t_cose_sign1_xxx".
+If you are using this v2.0 t_cose library, it is
+better to use the v2.0 API, t_cose_sign_xxx because it uses
+less memory and links in less code. This is because in v2.0
+the old APIs are supported by a compatibility layer.
+
+However, some use cases may want to continue with v1.x. It is smaller
+over all. But note that it only supports COSE_Sign1.
 
 ![t_cose](https://github.com/laurencelundblade/t_cose/blob/master/t-cose-logo.png?raw=true)
 

--- a/examples/encryption_examples.c
+++ b/examples/encryption_examples.c
@@ -91,12 +91,12 @@ encrypt0_example(void)
     t_cose_encrypt_set_cek(&enc_context, cek);
 
     err = t_cose_encrypt_enc_detached(&enc_context,
-                              Q_USEFUL_BUF_FROM_SZ_LITERAL("This is a real plaintext."),
-                                      NULL_Q_USEFUL_BUF_C,
-                              encrypted_payload_buf,
-                             cose_message_buf,
-                             &encrypted_payload,
-                             &encrypted_cose_message);
+                                       Q_USEFUL_BUF_FROM_SZ_LITERAL("This is a real plaintext."),
+                                          NULL_Q_USEFUL_BUF_C,
+                                       encrypted_payload_buf,
+                                       cose_message_buf,
+                                      &encrypted_payload,
+                                      &encrypted_cose_message);
     if(err != T_COSE_SUCCESS) {
         goto Done;
     }
@@ -112,12 +112,13 @@ encrypt0_example(void)
     t_cose_encrypt_dec_set_cek(&dec_ctx, cek);
 
     err = t_cose_encrypt_dec_detached_msg(&dec_ctx,
-                                      encrypted_cose_message,
-                                      NULL_Q_USEFUL_BUF_C,
-                                      encrypted_payload,
-                                      decrypted_payload_buf,
-                                     &decrypted_cose_message,
-                                      NULL, NULL);
+                                           encrypted_cose_message,
+                                           NULL_Q_USEFUL_BUF_C,
+                                           encrypted_payload,
+                                           decrypted_payload_buf,
+                                          &decrypted_cose_message,
+                                           NULL,
+                                           NULL);
 
     if (err != T_COSE_SUCCESS) {
         printf("\nDecryption failed %d!\n", err);
@@ -236,12 +237,13 @@ key_wrap_example(void)
     t_cose_encrypt_dec_add_recipient(&dec_context, (struct t_cose_recipient_dec *)&kw_unwrap_recipient);
 
     err = t_cose_encrypt_dec_detached_msg(&dec_context,
-                              encrypted_cose_message, /* ciphertext */
-                                      NULL_Q_USEFUL_BUF_C,
-                              encrypted_payload,
-                              decrypted_payload_buf,
-                             &decrypted_payload,
-                                      NULL, NULL);
+                                           encrypted_cose_message, /* ciphertext */
+                                           NULL_Q_USEFUL_BUF_C,
+                                           encrypted_payload,
+                                           decrypted_payload_buf,
+                                          &decrypted_payload,
+                                           NULL,
+                                           NULL);
     if(err) {
         goto Done;
     }
@@ -350,11 +352,11 @@ esdh_example(void)
                                      (struct t_cose_recipient_dec *)&dec_recipient);
 
     result = t_cose_encrypt_dec_msg(&dec_ctx,
-                                cose_encrypted_message,
-                                NULL_Q_USEFUL_BUF_C, /* in/unused: AAD */
-                                decrypted_buffer,
-                                &decrypted_payload,
-                                &params,
+                                     cose_encrypted_message,
+                                     NULL_Q_USEFUL_BUF_C, /* in/unused: AAD */
+                                     decrypted_buffer,
+                                    &decrypted_payload,
+                                    &params,
                                     NULL);
     if(result != T_COSE_SUCCESS) {
         goto Done;

--- a/examples/encryption_examples.c
+++ b/examples/encryption_examples.c
@@ -2,7 +2,7 @@
  * encryption_examples.c
  *
  * Copyright (c) 2022, Arm Limited. All rights reserved.
- * Copyright 2023, Laurence Lundblade
+ * Copyright 2025, Laurence Lundblade
  *
  * Created by Laurence Lundblade on 2/6/23 from previous files.
  *
@@ -111,13 +111,13 @@ encrypt0_example(void)
 
     t_cose_encrypt_dec_set_cek(&dec_ctx, cek);
 
-    err = t_cose_encrypt_dec_detached(&dec_ctx,
+    err = t_cose_encrypt_dec_detached_msg(&dec_ctx,
                                       encrypted_cose_message,
                                       NULL_Q_USEFUL_BUF_C,
                                       encrypted_payload,
                                       decrypted_payload_buf,
                                      &decrypted_cose_message,
-                                      NULL);
+                                      NULL, NULL);
 
     if (err != T_COSE_SUCCESS) {
         printf("\nDecryption failed %d!\n", err);
@@ -235,13 +235,13 @@ key_wrap_example(void)
 
     t_cose_encrypt_dec_add_recipient(&dec_context, (struct t_cose_recipient_dec *)&kw_unwrap_recipient);
 
-    err = t_cose_encrypt_dec_detached(&dec_context,
+    err = t_cose_encrypt_dec_detached_msg(&dec_context,
                               encrypted_cose_message, /* ciphertext */
                                       NULL_Q_USEFUL_BUF_C,
                               encrypted_payload,
                               decrypted_payload_buf,
                              &decrypted_payload,
-                                      NULL);
+                                      NULL, NULL);
     if(err) {
         goto Done;
     }
@@ -349,12 +349,13 @@ esdh_example(void)
     t_cose_encrypt_dec_add_recipient(&dec_ctx,
                                      (struct t_cose_recipient_dec *)&dec_recipient);
 
-    result = t_cose_encrypt_dec(&dec_ctx,
+    result = t_cose_encrypt_dec_msg(&dec_ctx,
                                 cose_encrypted_message,
                                 NULL_Q_USEFUL_BUF_C, /* in/unused: AAD */
                                 decrypted_buffer,
                                 &decrypted_payload,
-                                &params);
+                                &params,
+                                    NULL);
     if(result != T_COSE_SUCCESS) {
         goto Done;
     }

--- a/examples/signing_examples.c
+++ b/examples/signing_examples.c
@@ -243,7 +243,7 @@ int32_t one_step_sign_example(void)
      * to put them.
      */
     return_value =
-        t_cose_sign_verify(/* In: The context set up with signing key */
+        t_cose_sign_verify_msg(/* In: The context set up with signing key */
                            &verify_ctx,
 
                            /* In: The signed and coded COSE message to verify */
@@ -257,7 +257,9 @@ int32_t one_step_sign_example(void)
 
                            /* Out: linked list of header parameters.
                             * Not requested in this case. */
-                           NULL);
+                           NULL,
+
+                               NULL);
 
     printf("Verification complete: %d (%s)\n",
            return_value, return_value ? "fail" : "success");
@@ -463,7 +465,7 @@ int32_t one_step_multi_sign_detached_example(void)
      * to put them.
      */
     return_value =
-        t_cose_sign_verify_detached(/* In: The verification context. */
+        t_cose_sign_verify_detached_msg(/* In: The verification context. */
                                     &verify_ctx,
 
                                     /* In: The signed and encoded COSE
@@ -479,7 +481,9 @@ int32_t one_step_multi_sign_detached_example(void)
                                     /* Out: linked list of header
                                      * parameters.  Not requested in
                                      * this case. */
-                                    NULL);
+                                    NULL,
+
+                                        NULL);
 
     printf("Verification complete: %d (%s)\n",
            return_value, return_value ? "fail" : "success");
@@ -721,7 +725,7 @@ int32_t two_step_sign_example(void)
      * to put them.
      */
     return_value =
-        t_cose_sign_verify(/* In: The context set up with signing key */
+        t_cose_sign_verify_msg(/* In: The context set up with signing key */
                            &verify_ctx,
 
                            /* In: The signed and coded COSE message to verify */
@@ -735,7 +739,9 @@ int32_t two_step_sign_example(void)
 
                            /* Out: linked list of header parameters.
                             * Not requested in this case. */
-                           NULL);
+                           NULL,
+
+                               NULL);
 
     printf("Verification complete: %d (%s)\n",
            return_value, return_value ? "fail" : "success");

--- a/examples/signing_examples.c
+++ b/examples/signing_examples.c
@@ -1,7 +1,7 @@
 /*
  * signing_examples.c
  *
- * Copyright 2019-2023, Laurence Lundblade
+ * Copyright 2019-2025, Laurence Lundblade
  *
  * Created by Laurence Lundblade on 2/20/23 from previous files.
  *
@@ -726,21 +726,22 @@ int32_t two_step_sign_example(void)
      */
     return_value =
         t_cose_sign_verify_msg(/* In: The context set up with signing key */
-                           &verify_ctx,
+                              &verify_ctx,
 
-                           /* In: The signed and coded COSE message to verify */
-                           signed_cose,
+                               /* In: The signed and coded COSE message to verify */
+                               signed_cose,
 
-                           /* In: Externally Supplied Data (none here) */
-                           NULL_Q_USEFUL_BUF_C,
+                               /* In: Externally Supplied Data (none here) */
+                               NULL_Q_USEFUL_BUF_C,
 
-                           /* Out: Pointer and length of verify payload */
-                           &payload,
+                               /* Out: Pointer and length of verify payload */
+                              &payload,
 
-                           /* Out: linked list of header parameters.
-                            * Not requested in this case. */
-                           NULL,
+                               /* Out: linked list of header parameters.
+                                * Not requested in this case. */
+                               NULL,
 
+                               /* Out: unprocessed tags. Not requested here. */
                                NULL);
 
     printf("Verification complete: %d (%s)\n",

--- a/examples/signing_examples.c
+++ b/examples/signing_examples.c
@@ -244,21 +244,23 @@ int32_t one_step_sign_example(void)
      */
     return_value =
         t_cose_sign_verify_msg(/* In: The context set up with signing key */
-                           &verify_ctx,
+                                &verify_ctx,
 
-                           /* In: The signed and coded COSE message to verify */
-                           signed_cose,
+                               /* In: The signed and coded COSE message to verify */
+                               signed_cose,
 
-                           /* In: Externally Supplied Data (none here) */
-                           NULL_Q_USEFUL_BUF_C,
+                               /* In: Externally Supplied Data (none here) */
+                               NULL_Q_USEFUL_BUF_C,
 
-                           /* Out: Pointer and length of verify payload */
-                           &returned_payload,
+                               /* Out: Pointer and length of verify payload */
+                               &returned_payload,
 
-                           /* Out: linked list of header parameters.
-                            * Not requested in this case. */
-                           NULL,
+                               /* Out: linked list of header parameters.
+                                * Not requested in this case. */
+                               NULL,
 
+                               /* Out: preceding tag numbers.
+                                * Not requested in this case. */
                                NULL);
 
     printf("Verification complete: %d (%s)\n",
@@ -466,23 +468,25 @@ int32_t one_step_multi_sign_detached_example(void)
      */
     return_value =
         t_cose_sign_verify_detached_msg(/* In: The verification context. */
-                                    &verify_ctx,
+                                        &verify_ctx,
 
-                                    /* In: The signed and encoded COSE
-                                     * message to verify. */
-                                    signed_cose,
+                                        /* In: The signed and encoded COSE
+                                         * message to verify. */
+                                        signed_cose,
 
-                                    /* In: Externally Supplied AAD */
-                                    aad,
+                                        /* In: Externally Supplied AAD */
+                                        aad,
 
-                                    /* in: The detachd payload to verify */
-                                    payload,
+                                        /* in: The detachd payload to verify */
+                                        payload,
 
-                                    /* Out: linked list of header
-                                     * parameters.  Not requested in
-                                     * this case. */
-                                    NULL,
+                                        /* Out: linked list of header
+                                         * parameters.  Not requested in
+                                         * this case. */
+                                        NULL,
 
+                                        /* Out: preceding tag numbers. Not
+                                         * requested in this case. */
                                         NULL);
 
     printf("Verification complete: %d (%s)\n",

--- a/inc/t_cose/t_cose_common.h
+++ b/inc/t_cose/t_cose_common.h
@@ -1,7 +1,7 @@
 /*
  * t_cose_common.h
  *
- * Copyright 2019-2023, Laurence Lundblade
+ * Copyright 2019-2025, Laurence Lundblade
  * Copyright (c) 2020-2023, Arm Limited. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
@@ -162,7 +162,7 @@ extern "C" {
  * Some formats of COSE_recipient have parameters that are in the
  * COSE_key format. It would be useful to have some library code to
  * handle these, in particular to encode and decode from the key data
- * structure used by the cr *ypto library (OpenSSL, PSA, …).
+ * structure used by the crypto library (OpenSSL, PSA, …).
  */
 
 
@@ -215,6 +215,10 @@ extern "C" {
 #define T_COSE_VERSION_PATCH 0
 
 
+/* The early versions of QCBOR 1.0 didn't define QCBOR_MAJOR_VERSION */
+#ifndef QCBOR_MAJOR_VERSION
+#define QCBOR_MAJOR_VERSION 1
+#endif
 
 
 /* Definition of algorithm IDs is moved to t_cose_standard_constants.h */
@@ -639,6 +643,11 @@ enum t_cose_err_t {
 
     /** An initialization vector (IV) is empty, wrong type or such. */
     T_COSE_ERR_BAD_IV = 92,
+
+    /** Failure decoding a COSE message */
+    T_COSE_ERR_MESSAGE_FORMAT = 93,
+
+    T_COSE_ERR_UNPROCESSED_TAG_NUMBERS = 94
 
 };
 

--- a/inc/t_cose/t_cose_encrypt_dec.h
+++ b/inc/t_cose/t_cose_encrypt_dec.h
@@ -2,7 +2,7 @@
  * t_cose_encrypt_dec.h
  *
  * Copyright (c) 2022, Arm Limited. All rights reserved.
- * Copyright (c) 2023, Laurence Lundblade. All rights reserved.
+ * Copyright (c) 2025, Laurence Lundblade. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *
@@ -100,8 +100,6 @@ struct t_cose_encrypt_dec_ctx {
     struct t_cose_parameter_storage   params;
     struct t_cose_parameter           __params[T_COSE_NUM_DECODE_HEADERS];
     struct t_cose_parameter_storage  *p_storage;
-
-    uint64_t                         unprocessed_tag_nums[T_COSE_MAX_TAGS_TO_RETURN];
 
     struct q_useful_buf           extern_enc_struct_buffer;
 };
@@ -244,8 +242,7 @@ t_cose_decrypt_set_enc_struct_buffer(struct t_cose_encrypt_dec_ctx *context,
  * \brief Decryption of a \c COSE_Encrypt0 or \c COSE_Encrypt structure.
  *
  * \param[in,out] context       The t_cose_encrypt_dec_ctx context.
- * \param[in] message           The COSE message (a COSE_Encrypt0
- *                              or COSE_Encrypt).
+ * \param[in] cbor_decoder           Context from which COSE message is decoded.
  * \param[in] ext_sup_data               Externally supplied data or \ref NULL_Q_USEFUL_BUF.
  * \param[in] plaintext_buffer  A buffer for plaintext.
  * \param[out] plaintext        Place to return pointer and length of
@@ -263,6 +260,14 @@ t_cose_decrypt_set_enc_struct_buffer(struct t_cose_encrypt_dec_ctx *context,
  * COSE_Recipient processers that have been set up with decryption
  * keys.
  *
+ * If \c context was set up with XXX_UNSPECIFIED, this expects
+ * one tag number to indicate COSE_Encrypt vs COSE_Encryptt0.
+ * Other wise the context must have been set up to indicate
+ * COSE_Encrypt or COSE_Encrypt0 and no tag numbers
+ * are expected.  That is, the caller should have consumed
+ * any tag numbers before calling this. See t_cose_encrypt_dec_message()
+ * which does more tag number processing.
+ *
  * Each \ref struct t_cose_recipient_dec is invoked on each \c
  * COSE_Recipient until one successfully decrypts the content
  * encryption key. Only one success is necessary. Each
@@ -277,7 +282,7 @@ t_cose_decrypt_set_enc_struct_buffer(struct t_cose_encrypt_dec_ctx *context,
 // TODO: support a decode-only mode
 static enum t_cose_err_t
 t_cose_encrypt_dec(struct t_cose_encrypt_dec_ctx *context,
-                   struct q_useful_buf_c          message,
+                   QCBORDecodeContext            *cbor_decoder,
                    struct q_useful_buf_c          ext_sup_data,
                    struct q_useful_buf            plaintext_buffer,
                    struct q_useful_buf_c         *plaintext,
@@ -296,6 +301,8 @@ t_cose_encrypt_dec(struct t_cose_encrypt_dec_ctx *context,
  * \param[out] plaintext     Place to return pointer and length of the plaintext.
  * \param[out] returned_parameters  Place to return linked list of header parameters.
  *
+ * tag_numbers are used only with QCBOR v1. TODO: put in a semi-private layer so that is not exposed to the public
+ *
  * \return This returns one of the error codes defined by \ref t_cose_err_t.
  *
  * Note: If the ciphertext is integrated into the COSE_Encrypt0 or
@@ -304,36 +311,49 @@ t_cose_encrypt_dec(struct t_cose_encrypt_dec_ctx *context,
  */
 enum t_cose_err_t
 t_cose_encrypt_dec_detached(struct t_cose_encrypt_dec_ctx *context,
-                            struct q_useful_buf_c          message,
+                            QCBORDecodeContext            *cbor_decoder,
                             struct q_useful_buf_c          ext_sup_data,
                             struct q_useful_buf_c          detached_ciphertext,
                             struct q_useful_buf            plaintext_buffer,
                             struct q_useful_buf_c         *plaintext,
-                            struct t_cose_parameter      **returned_parameters);
+                            struct t_cose_parameter      **returned_parameters,
+                            uint64_t                       tag_numbers[T_COSE_MAX_TAGS_TO_RETURN]);
 
 
 
-/**
- * \brief Return unprocessed tags from most recent decryption.
+
+/*
+
+ * This is the same as t_cose_encrypt_dec() except for two
+ * things.
  *
- * \param[in] context   The t_cose decryption context.
- * \param[in] n         Index of the tag to return.
+ * First takes the COSE message to decrypt as a buffer of bytes.
  *
- * \return  The tag value or \ref CBOR_TAG_INVALID64 if there is no tag
- *          at the index or the index is too large.
+ * Second, this will process any tag numbers that preceed the
+ * COSE message and make them available via t_cose_encrypt_dec_nth_tag().
  *
- * The 0th tag is the one for which the COSE message is the content. Loop
- * from 0 up until \ref CBOR_TAG_INVALID64 is returned. The maximum
- * is \ref T_COSE_MAX_TAGS_TO_RETURN.
- *
- * It will be necessary to call this for a general implementation
- * of a CWT since sometimes the CWT tag is required. This is also
- * useful for recursive processing of nested COSE signing, mac
- * and encryption.
+ * TODO: how does this work with the options?
  */
-static inline uint64_t
-t_cose_encrypt_dec_nth_tag(const struct t_cose_encrypt_dec_ctx *context,
-                           size_t                               n);
+enum t_cose_err_t
+t_cose_encrypt_dec_msg(struct t_cose_encrypt_dec_ctx *context,
+                       struct q_useful_buf_c          cose_message,
+                       struct q_useful_buf_c          ext_sup_data,
+                       struct q_useful_buf            plaintext_buffer,
+                       struct q_useful_buf_c         *plaintext,
+                       struct t_cose_parameter      **returned_parameters,
+                       uint64_t                       tag_numbers[T_COSE_MAX_TAGS_TO_RETURN]);
+
+
+enum t_cose_err_t
+t_cose_encrypt_dec_detached_msg(struct t_cose_encrypt_dec_ctx *context,
+                                struct q_useful_buf_c          cose_message,
+                                struct q_useful_buf_c          ext_sup_data,
+                                struct q_useful_buf_c          detached_ciphertext,
+                                struct q_useful_buf            plaintext_buffer,
+                                struct q_useful_buf_c         *plaintext,
+                                struct t_cose_parameter      **returned_parameters,
+                                uint64_t                       tag_numbers[T_COSE_MAX_TAGS_TO_RETURN]);
+
 
 
 /* ------------------------------------------------------------------------
@@ -387,31 +407,26 @@ t_cose_decrypt_set_enc_struct_buffer(struct t_cose_encrypt_dec_ctx *context,
 
 static inline enum t_cose_err_t
 t_cose_encrypt_dec(struct t_cose_encrypt_dec_ctx *me,
-                   struct q_useful_buf_c          message,
+                   QCBORDecodeContext            *cbor_decoder,
                    struct q_useful_buf_c          ext_sup_data,
                    struct q_useful_buf            plaintext_buffer,
                    struct q_useful_buf_c         *plaintext,
                    struct t_cose_parameter      **returned_parameters)
 {
     return t_cose_encrypt_dec_detached(me,
-                                       message,
+                                       cbor_decoder,
                                        ext_sup_data,
                                        NULL_Q_USEFUL_BUF_C,
                                        plaintext_buffer,
                                        plaintext,
-                                       returned_parameters);
+                                       returned_parameters,
+                                       NULL);
 }
 
 
-static inline uint64_t
-t_cose_encrypt_dec_nth_tag(const struct t_cose_encrypt_dec_ctx *me,
-                           size_t                               n)
-{
-    if(n > T_COSE_MAX_TAGS_TO_RETURN) {
-        return CBOR_TAG_INVALID64;
-    }
-    return me->unprocessed_tag_nums[n];
-}
+
+
+
 
 #ifdef __cplusplus
 }

--- a/inc/t_cose/t_cose_encrypt_dec.h
+++ b/inc/t_cose/t_cose_encrypt_dec.h
@@ -242,7 +242,7 @@ t_cose_decrypt_set_enc_struct_buffer(struct t_cose_encrypt_dec_ctx *context,
  * \brief Decryption of a \c COSE_Encrypt0 or \c COSE_Encrypt structure.
  *
  * \param[in,out] context       The t_cose_encrypt_dec_ctx context.
- * \param[in] cbor_decoder           Context from which COSE message is decoded.
+ * \param[in] cbor_decoder    Source of the input COSE message to decrypt.
  * \param[in] ext_sup_data               Externally supplied data or \ref NULL_Q_USEFUL_BUF.
  * \param[in] plaintext_buffer  A buffer for plaintext.
  * \param[out] plaintext        Place to return pointer and length of
@@ -293,8 +293,7 @@ t_cose_encrypt_dec(struct t_cose_encrypt_dec_ctx *context,
  * \brief Decrypt a \c COSE_Encrypt0 or \c COSE_Encrypt with detached cipher text.
  *
  * \param[in,out] context               The t_cose_encrypt_dec_ctx context.
- * \param[in] message                      The COSE message (a COSE_Encrypt0
- *                                      or COSE_Encrypt).
+ * \param[in] cbor_decoder    Source of the input COSE message to decrypt.
  * \param[in] ext_sup_data               Externally supplied data or \ref NULL_Q_USEFUL_BUF.
  * \param[in] detached_ciphertext  The detached ciphertext.
  * \param[in] plaintext_buffer                A buffer for plaintext.

--- a/inc/t_cose/t_cose_mac_validate.h
+++ b/inc/t_cose/t_cose_mac_validate.h
@@ -241,7 +241,7 @@ t_cose_mac_validate_detached_msg(struct t_cose_mac_validate_ctx *context,
  * Private and inline implementations of public functions defined above.
  * ------------------------------------------------------------------------ */
 
-
+/** @private  Semi-private function. See t_cose_mac_validate.c */
 enum t_cose_err_t
 t_cose_mac_validate_private(struct t_cose_mac_validate_ctx *me,
                             QCBORDecodeContext             *cbor_decoder,
@@ -249,8 +249,9 @@ t_cose_mac_validate_private(struct t_cose_mac_validate_ctx *me,
                             bool                            payload_is_detached,
                             struct q_useful_buf_c          *payload,
                             struct t_cose_parameter       **return_params,
-                            uint64_t                       returned_tag_numbers[T_COSE_MAX_TAGS_TO_RETURN]);
+                            uint64_t                        tag_numbers[T_COSE_MAX_TAGS_TO_RETURN]);
 
+/** @private  Semi-private function. See t_cose_mac_validate.c */
 enum t_cose_err_t
 t_cose_mac_validate_msg_private(struct t_cose_mac_validate_ctx *context,
                                 struct q_useful_buf_c           cose_message,

--- a/inc/t_cose/t_cose_mac_validate.h
+++ b/inc/t_cose/t_cose_mac_validate.h
@@ -123,7 +123,7 @@ t_cose_mac_set_special_param_decoder(struct t_cose_mac_validate_ctx *context,
  *
  * \return This returns one of the error codes defined by \ref t_cose_err_t.
  *
- * This is the base method forMAC validation It links the least object code. See t_cose_mac_validate_message() for
+ * This is the base method forMAC validation. It links the least object code. See t_cose_mac_validate_message() for
  * a method that takes the message from a buffer and does
  * more tag number processing.
  *
@@ -199,17 +199,18 @@ t_cose_mac_validate_detached(struct t_cose_mac_validate_ctx *context,
  *                            CBOR encoded payload.
  * \param[out] return_params  Place to return decoded parameters.
  *                            May be \c NULL.
+ * \param[out] tag_numbers Place to return preceding tag numbers or NULL.
  *
  * \return This returns one of the error codes defined by \ref t_cose_err_t.
  *
  * This is a wrapper around t_cose_mac_validate().
  *
- * This creates an instance of the CBOR decoder and initializes it with
+ * Internally, this creates an instance of the CBOR decoder and initializes it with
  * the COSE message.
  *
  * This does the following tag number processing.
  *
- * All tag numbers preceding the message are consumed. The same as t_cose_mac_validate()
+ * All tag numbers preceding the message are consumed. The same as t_cose_mac_validate(),
  * the initialization options T_COSE_OPT_MESSAGE_TYPE_MAC0 and XXXX
  * are used. Any tag numbers not used in determing the message type
  * based on the initialization options are returned in \c tag_numbers
@@ -244,27 +245,6 @@ t_cose_mac_validate_detached_msg(struct t_cose_mac_validate_ctx *context,
  * ------------------------------------------------------------------------ */
 
 
-/**
- * \brief Semi-private function to validate a COSE_Mac0 message.
- *
- * \param[in] context   The context of COSE_Mac0 validation.
- * \param[in] cose_mac  Pointer and length of CBOR encoded \c COSE_Mac0
- *                      that is to be validated.
- * \param[in] ext_sup_data       The Additional Authenticated Data or
- *                      \c NULL_Q_USEFUL_BUF_C.
- * \param[in] payload_is_detached  If \c true, indicates the \c payload
- *                                 is detached.
- * \param[out] payload             Pointer and length of the still CBOR
- *                                 encoded payload.
- * \param[out] return_params       Place to return decoded parameters.
- *                                 May be \c NULL.
- *
- * \return This returns one of the error codes defined by \ref t_cose_err_t.
- *
- * It is a semi-private function internal to the implementation which means its
- * interface isn't guaranteed so it should not be called directly. Call
- * t_cose_mac_validate() or t_cose_mac_validate_detached() instead of this.
- */
 enum t_cose_err_t
 t_cose_mac_validate_private(struct t_cose_mac_validate_ctx *me,
                             QCBORDecodeContext             *decode_context,

--- a/inc/t_cose/t_cose_mac_validate.h
+++ b/inc/t_cose/t_cose_mac_validate.h
@@ -1,7 +1,7 @@
 /*
  * t_cose_mac_validate.h
  *
- * Copyright (c) 2019, Laurence Lundblade. All rights reserved.
+ * Copyright (c) 2019, 2025, Laurence Lundblade. All rights reserved.
  * Copyright (c) 2020-2023 Arm Limited. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
@@ -21,23 +21,15 @@
 extern "C" {
 #endif
 
-/**
- * The maximum number of unprocessed tags that can be returned by
- * t_cose_sign1_get_nth_tag(). The CWT
- * tag is an example of the tags that might returned. The COSE tags
- * that are processed, don't count here.
- */
-#define T_COSE_MAX_TAGS_TO_RETURN 4
 
 /**
- * Context for tag validation.  It is about 24 bytes on a
- * 64-bit machine and 12 bytes on a 32-bit machine.
+ * Context for tag validation.  It is about 360 bytes on a
+ * 64-bit machine.
  */
 struct t_cose_mac_validate_ctx {
     /* Private data structure */
     struct t_cose_key                validation_key;
     uint32_t                         option_flags;
-    uint64_t                         unprocessed_tag_nums[T_COSE_MAX_TAGS_TO_RETURN];
     struct t_cose_parameter          __params[T_COSE_NUM_DECODE_HEADERS];
     struct t_cose_parameter_storage  parameter_storage;
     struct t_cose_parameter_storage *p_storage;
@@ -123,20 +115,29 @@ t_cose_mac_set_special_param_decoder(struct t_cose_mac_validate_ctx *context,
  * \brief Validate a \c COSE_Mac0 message.
  *
  * \param[in] context         The context of COSE_Mac0 validation.
- * \param[in] cose_mac        Pointer and length of CBOR encoded \c COSE_Mac0
- *                            that is to be validated.
+ * \param[in] decode_context        Source of the input message to validate.
  * \param[in] ext_sup_data    Externally supplied data or \c NULL_Q_USEFUL_BUF_C.
- * \param[out] payload        Pointer and length of the still
- *                            CBOR encoded payload.
+ * \param[out] payload        Pointer and length of the payload.
  * \param[out] return_params  Place to return decoded parameters.
  *                            May be \c NULL.
  *
  * \return This returns one of the error codes defined by \ref t_cose_err_t.
  *
- * The validation involves the following steps.
+ * This is the base method forMAC validation It links the least object code. See t_cose_mac_validate_message() for
+ * a method that takes the message from a buffer and does
+ * more tag number processing.
  *
- * The CBOR structure is parsed and validated. It makes sure \c COSE_Mac0
- * is valid CBOR and that it is tagged as a \c COSE_Mac0.
+ * The COSE message to be validated is decoded from the given QCBOR
+ * decode context.
+ *
+ * If the validation context is configured
+ * with T_COSE_OPT_MESSAGE_TYPE_MAC0 in \c option,
+ * then this will error out if  any tag numbers are present.
+ * If configured with T_COSE_OPT_MESSAGE_TYPE_UNSPECIFIED
+ * one tag number identifying the type of COSE Mac message
+ * must be present. As this currently only supports COSE_Mac0,
+ * this will error out if the tag number is other than that
+ * for COSE_Mac0.
  *
  * The MAC algorithm is pulled out of the protected header.
  *
@@ -157,45 +158,85 @@ t_cose_mac_set_special_param_decoder(struct t_cose_mac_validate_ctx *context,
  */
 static enum t_cose_err_t
 t_cose_mac_validate(struct t_cose_mac_validate_ctx *context,
-                    struct q_useful_buf_c           cose_mac,
+                    QCBORDecodeContext             *decode_context,
                     struct q_useful_buf_c           ext_sup_data,
                     struct q_useful_buf_c          *payload,
                     struct t_cose_parameter       **return_params);
 
-/*
- * This is the same as t_cose_mac_validate(), but the payload is detached.
- * See t_cose_mac_compute_detached() for more details in t_cose_mac_compute.h
+
+/**
+ * \brief Validate a \c COSE_Mac0 message with detached payload.
+ *
+ * \param[in] context         The context of COSE_Mac0 validation.
+ * \param[in] decode_context        Source of the input message to validate.
+ * \param[in] ext_sup_data    Externally supplied data or \c NULL_Q_USEFUL_BUF_C.
+ * \param[in] detached_payload        Pointer and length of the payload.
+ * \param[out] return_params  Place to return decoded parameters.
+ *                            May be \c NULL.
+ *
+ * \return This returns one of the error codes defined by \ref t_cose_err_t.
+ *
+ * This is the same as t_cose_mac_validate() except the payload is detached.
+ * The payload is not in the COSE message. It is external and thus supplied
+ * for validation as an input parameter.
  */
 static enum t_cose_err_t
 t_cose_mac_validate_detached(struct t_cose_mac_validate_ctx *context,
-                             struct q_useful_buf_c           cose_mac,
+                             QCBORDecodeContext             *decode_context,
                              struct q_useful_buf_c           ext_sup_data,
                              struct q_useful_buf_c           detached_payload,
                              struct t_cose_parameter       **return_params);
 
 
 /**
- * \brief Return unprocessed tags from most recent MAC validate.
+ * \brief Validate a \c COSE_Mac0 message.
  *
- * \param[in] context   The t_cose mac validation context.
- * \param[in] n         Index of the tag to return.
+ * \param[in] context         The context of COSE_Mac0 validation.
+ * \param[in] cose_mac        Pointer and length of CBOR encoded \c COSE_Mac0
+ *                            that is to be validated.
+ * \param[in] ext_sup_data    Externally supplied data or \c NULL_Q_USEFUL_BUF_C.
+ * \param[out] payload        Pointer and length of the still
+ *                            CBOR encoded payload.
+ * \param[out] return_params  Place to return decoded parameters.
+ *                            May be \c NULL.
  *
- * \return  The tag value or \ref CBOR_TAG_INVALID64 if there is no tag
- *          at the index or the index is too large.
+ * \return This returns one of the error codes defined by \ref t_cose_err_t.
  *
- * The 0th tag is the one for which the COSE message is the content. Loop
- * from 0 up until \ref CBOR_TAG_INVALID64 is returned. The maximum
- * is \ref T_COSE_MAX_TAGS_TO_RETURN.
+ * This is a wrapper around t_cose_mac_validate().
  *
- * It will be necessary to call this for a general implementation
- * of a CWT since sometimes the CWT tag is required. This is also
- * useful for recursive processing of nested COSE signing, mac
- * and encryption.
+ * This creates an instance of the CBOR decoder and initializes it with
+ * the COSE message.
+ *
+ * This does the following tag number processing.
+ *
+ * All tag numbers preceding the message are consumed. The same as t_cose_mac_validate()
+ * the initialization options T_COSE_OPT_MESSAGE_TYPE_MAC0 and XXXX
+ * are used. Any tag numbers not used in determing the message type
+ * based on the initialization options are returned in \c tag_numbers
+ * so they can be checked. Generally tag numbers are not optional and
+ * should not be ignored. If
+ * tag numbers are present in the input and \c tag_numbers is NULL, an
+ * error occurs.
  */
-static inline uint64_t
-t_cose_mac_validate_nth_tag(const struct t_cose_mac_validate_ctx *context,
-                            size_t                                n);
+static enum t_cose_err_t
+t_cose_mac_validate_msg(struct t_cose_mac_validate_ctx *context,
+                        struct q_useful_buf_c           cose_message,
+                        struct q_useful_buf_c           ext_sup_data,
+                        struct q_useful_buf_c          *payload,
+                        struct t_cose_parameter       **return_params,
+                        uint64_t                        tag_numbers[T_COSE_MAX_TAGS_TO_RETURN]);
 
+
+static enum t_cose_err_t
+t_cose_mac_validate_detached_msg(struct t_cose_mac_validate_ctx *context,
+                                 struct q_useful_buf_c           cose_message,
+                                 struct q_useful_buf_c           ext_sup_data,
+                                 struct q_useful_buf_c          detached_payload,
+                                 struct t_cose_parameter       **return_params,
+                                 uint64_t                        tag_numbers[T_COSE_MAX_TAGS_TO_RETURN]);
+
+
+// TODO: should there be t_cose_mac_validate__detached_msg()?
 
 
 /* ------------------------------------------------------------------------
@@ -225,12 +266,22 @@ t_cose_mac_validate_nth_tag(const struct t_cose_mac_validate_ctx *context,
  * t_cose_mac_validate() or t_cose_mac_validate_detached() instead of this.
  */
 enum t_cose_err_t
-t_cose_mac_validate_private(struct t_cose_mac_validate_ctx *context,
-                            struct q_useful_buf_c           cose_mac,
+t_cose_mac_validate_private(struct t_cose_mac_validate_ctx *me,
+                            QCBORDecodeContext             *decode_context,
                             struct q_useful_buf_c           ext_sup_data,
                             bool                            payload_is_detached,
                             struct q_useful_buf_c          *payload,
-                            struct t_cose_parameter       **return_params);
+                            struct t_cose_parameter       **return_params,
+                            uint64_t                       returned_tag_numbers[T_COSE_MAX_TAGS_TO_RETURN]);
+
+enum t_cose_err_t
+t_cose_mac_validate_msg_private(struct t_cose_mac_validate_ctx *context,
+                                    struct q_useful_buf_c           cose_message,
+                                    struct q_useful_buf_c           ext_sup_data,
+                                    bool                            payload_is_detached,
+                                    struct q_useful_buf_c          *payload,
+                                    struct t_cose_parameter       **return_params,
+                                    uint64_t                        tag_numbers[T_COSE_MAX_TAGS_TO_RETURN]);
 
 
 static inline void
@@ -267,48 +318,72 @@ t_cose_mac_set_special_param_decoder(struct t_cose_mac_validate_ctx *me,
     me->special_param_decode_ctx = decode_ctx;
 }
 
-
 static inline enum t_cose_err_t
 t_cose_mac_validate(struct t_cose_mac_validate_ctx *me,
-                    struct q_useful_buf_c           cose_mac,
+                    QCBORDecodeContext             *decode_context,
                     struct q_useful_buf_c           ext_sup_data,
                     struct q_useful_buf_c          *payload,
                     struct t_cose_parameter       **return_params)
 {
     return t_cose_mac_validate_private(me,
-                                       cose_mac,
+                                       decode_context,
                                        ext_sup_data,
                                        false,
                                        payload,
-                                       return_params);
+                                       return_params,
+                                       NULL);
 }
-
 
 static inline enum t_cose_err_t
 t_cose_mac_validate_detached(struct t_cose_mac_validate_ctx *me,
-                             struct q_useful_buf_c           cose_mac,
+                             QCBORDecodeContext             *decode_context,
                              struct q_useful_buf_c           ext_sup_data,
                              struct q_useful_buf_c           detached_payload,
                              struct t_cose_parameter       **return_params)
 {
     return t_cose_mac_validate_private(me,
-                                       cose_mac,
+                                       decode_context,
                                        ext_sup_data,
                                        true,
-                                      &detached_payload,
-                                       return_params);
+                                       &detached_payload,
+                                       return_params,
+                                       NULL);
 }
 
-
-static inline uint64_t
-t_cose_mac_validate_nth_tag(const struct t_cose_mac_validate_ctx *me,
-                            size_t                                n)
+static inline enum t_cose_err_t
+t_cose_mac_validate_msg(struct t_cose_mac_validate_ctx *me,
+                        struct q_useful_buf_c           cose_message,
+                        struct q_useful_buf_c           ext_sup_data,
+                        struct q_useful_buf_c          *payload,
+                        struct t_cose_parameter       **return_params,
+                        uint64_t                        tag_numbers[T_COSE_MAX_TAGS_TO_RETURN])
 {
-    if(n > T_COSE_MAX_TAGS_TO_RETURN) {
-        return CBOR_TAG_INVALID64;
-    }
-    return me->unprocessed_tag_nums[n];
+    return t_cose_mac_validate_msg_private(me,
+                                           cose_message,
+                                           ext_sup_data,
+                                           false,
+                                           payload,
+                                           return_params,
+                                           tag_numbers);
 }
+
+static inline enum t_cose_err_t
+t_cose_mac_validate_detached_msg(struct t_cose_mac_validate_ctx *me,
+                                 struct q_useful_buf_c           cose_message,
+                                 struct q_useful_buf_c           ext_sup_data,
+                                 struct q_useful_buf_c          detached_payload,
+                                 struct t_cose_parameter       **return_params,
+                                 uint64_t                        tag_numbers[T_COSE_MAX_TAGS_TO_RETURN])
+{
+    return t_cose_mac_validate_msg_private(me,
+                                           cose_message,
+                                           ext_sup_data,
+                                           true,
+                                           &detached_payload,
+                                           return_params,
+                                           tag_numbers);
+}
+
 
 
 #ifdef __cplusplus

--- a/inc/t_cose/t_cose_sign1_verify.h
+++ b/inc/t_cose/t_cose_sign1_verify.h
@@ -80,6 +80,8 @@ struct t_cose_sign1_verify_ctx {
     struct t_cose_signature_verify_eddsa eddsa_verifier;
 
     uint32_t                             option_flags;
+
+    uint64_t                             tag_numbers[T_COSE_MAX_TAGS_TO_RETURN];
 };
 
 
@@ -316,7 +318,7 @@ t_cose_sign1_verify_aad(struct t_cose_sign1_verify_ctx *context,
  */
 static inline enum t_cose_err_t
 t_cose_sign1_verify_detached(struct t_cose_sign1_verify_ctx *context,
-                             struct q_useful_buf_c           cose_sign1,
+                             struct q_useful_buf_c           cose_message,
                              struct q_useful_buf_c           ext_sup_data,
                              struct q_useful_buf_c           detached_payload,
                              struct t_cose_parameters       *parameters);
@@ -351,51 +353,34 @@ t_cose_sign1_get_nth_tag(const struct t_cose_sign1_verify_ctx *context,
  * Inline implementations of public functions defined above.
  */
 
+enum t_cose_err_t
+t_cose_sign1_private_verify_main(struct t_cose_sign1_verify_ctx *me,
+                                 struct q_useful_buf_c           cose_message,
+                                 struct q_useful_buf_c           ext_sup_data,
+                                 bool                            payload_is_detached,
+                                 struct q_useful_buf_c          *payload,
+                                 struct t_cose_parameters       *parameters);
+
 
 static inline enum t_cose_err_t
 t_cose_sign1_verify_aad(struct t_cose_sign1_verify_ctx *me,
-                        struct q_useful_buf_c           cose_sign1,
+                        struct q_useful_buf_c           cose_message,
                         struct q_useful_buf_c           ext_sup_data,
                         struct q_useful_buf_c          *payload,
                         struct t_cose_parameters       *parameters)
 {
-     enum t_cose_err_t           return_value;
-     struct t_cose_parameter *decoded_params;
-
-     return_value = t_cose_sign_verify(&(me->me2),
-                                       cose_sign1,
-                                       ext_sup_data,
-                                       payload,
-                                      &decoded_params);
-     if(parameters != NULL) {
-         t_cose_params_common(decoded_params, parameters);
-     }
-
-     return return_value;
+     return t_cose_sign1_private_verify_main(me, cose_message, ext_sup_data, false, payload, parameters);
 }
 
 
 static inline enum t_cose_err_t
 t_cose_sign1_verify_detached(struct t_cose_sign1_verify_ctx *me,
-                             struct q_useful_buf_c           cose_sign1,
+                             struct q_useful_buf_c           cose_message,
                              struct q_useful_buf_c           ext_sup_data,
                              struct q_useful_buf_c           detached_payload,
                              struct t_cose_parameters       *parameters)
 {
-    enum t_cose_err_t        return_value;
-    struct t_cose_parameter *decoded_params;
-
-    return_value = t_cose_sign_verify_detached(&(me->me2),
-                                               cose_sign1,
-                                               ext_sup_data,
-                                               detached_payload,
-                                              &decoded_params);
-
-    if(parameters != NULL) {
-        return_value = t_cose_params_common(decoded_params, parameters);
-    }
-
-    return return_value;
+    return t_cose_sign1_private_verify_main(me, cose_message, ext_sup_data, true, &detached_payload, parameters);
 }
 
 
@@ -418,9 +403,22 @@ t_cose_sign1_verify_auxiliary_buffer_size(struct t_cose_sign1_verify_ctx *me)
 
 static inline uint64_t
 t_cose_sign1_get_nth_tag(const struct t_cose_sign1_verify_ctx *me,
-                         size_t                                n)
+                         const size_t                          tag_index)
 {
-    return t_cose_sign_verify_nth_tag(&(me->me2), n);
+    // TODO: make this not inline ??
+
+    size_t tag_num_count;
+
+    for(tag_num_count = 0; tag_num_count < T_COSE_MAX_TAGS_TO_RETURN; tag_num_count++) {
+        if(me->tag_numbers[tag_num_count] == CBOR_TAG_INVALID64) {
+            break;
+        }
+    }
+    if(tag_index >= tag_num_count) {
+        return CBOR_TAG_INVALID64;
+    }
+
+    return me->tag_numbers[(tag_num_count - 1) - tag_index];
 }
 
 

--- a/inc/t_cose/t_cose_sign_verify.h
+++ b/inc/t_cose/t_cose_sign_verify.h
@@ -1,7 +1,7 @@
 /*
  * t_cose_sign_verify.h
  *
- * Copyright 2019-2023, Laurence Lundblade
+ * Copyright 2019-2025, Laurence Lundblade
  *
  * SPDX-License-Identifier: BSD-3-Clause
  * Created by Laurence Lundblade on 7/17/22.
@@ -53,7 +53,6 @@ extern "C" {
 
 
 
-
 /**
  * Context for signature verification.
  */
@@ -61,6 +60,7 @@ struct t_cose_sign_verify_ctx {
     /* Private data structure */
     struct t_cose_signature_verify   *verifiers;
     uint32_t                          option_flags;
+    bool                              v1_compatible;
     struct t_cose_parameter_storage   params;
     struct t_cose_parameter           __params[T_COSE_NUM_DECODE_HEADERS];
     struct t_cose_parameter_storage  *p_storage;

--- a/inc/t_cose/t_cose_sign_verify.h
+++ b/inc/t_cose/t_cose_sign_verify.h
@@ -83,8 +83,6 @@ struct t_cose_sign_verify_ctx {
  * to indicate which COSE message type is expected. If
  * \ref T_COSE_OPT_MESSAGE_TYPE_UNSPECIFIED is given, then there must
  * be a tag number in the input encoded CBOR to indicate which.
- *
- * TODO: describe (and implement) selection of COSE_Sign1 vs COSE_Sign.
  */
 static void
 t_cose_sign_verify_init(struct t_cose_sign_verify_ctx *context,

--- a/inc/t_cose/t_cose_sign_verify.h
+++ b/inc/t_cose/t_cose_sign_verify.h
@@ -197,7 +197,7 @@ t_cose_sign_set_special_param_decoder(struct t_cose_sign_verify_ctx  *context,
  * \brief Verify a COSE_Sign1 or COSE_Sign.
  *
  * \param[in,out] context   The t_cose signature verification context.
- * \param[in] decode_context      Decode context from which the COSE message will be decoded.
+ * \param[in] cbor_decoder    Source of the input COSE message to verify..
  * \param[in] ext_sup_data  Externally supplied data or \c NULL_Q_USEFUL_BUF_C.
  * \param[out] payload      Pointer and length of the payload that is returned.
  *                          Must not be \c NULL.
@@ -252,7 +252,7 @@ t_cose_sign_set_special_param_decoder(struct t_cose_sign_verify_ctx  *context,
  */
 static enum t_cose_err_t
 t_cose_sign_verify(struct t_cose_sign_verify_ctx *context,
-                   QCBORDecodeContext            *decode_context,
+                   QCBORDecodeContext            *cbor_decoder,
                    struct q_useful_buf_c          ext_sup_data,
                    struct q_useful_buf_c         *payload,
                    struct t_cose_parameter      **parameters);
@@ -263,7 +263,7 @@ t_cose_sign_verify(struct t_cose_sign_verify_ctx *context,
 */
 static enum t_cose_err_t
 t_cose_sign_verify_detached(struct t_cose_sign_verify_ctx *context,
-                            QCBORDecodeContext            *decode_context,
+                            QCBORDecodeContext            *cbor_decoder,
                             struct q_useful_buf_c          ext_sup_data,
                             struct q_useful_buf_c          detached_payload,
                             struct t_cose_parameter      **parameters);
@@ -353,13 +353,13 @@ t_cose_sign_verify_msg_private(struct t_cose_sign_verify_ctx *me,
 
 static inline enum t_cose_err_t
 t_cose_sign_verify(struct t_cose_sign_verify_ctx *me,
-                   QCBORDecodeContext            *decoder,
+                   QCBORDecodeContext            *cbor_decoder,
                    struct q_useful_buf_c          ext_sup_data,
                    struct q_useful_buf_c         *payload,
                    struct t_cose_parameter      **parameters)
 {
     return t_cose_sign_verify_private(me,
-                                      decoder,
+                                      cbor_decoder,
                                       ext_sup_data,
                                       false,
                                       payload,
@@ -370,13 +370,13 @@ t_cose_sign_verify(struct t_cose_sign_verify_ctx *me,
 
 static inline enum t_cose_err_t
 t_cose_sign_verify_detached(struct t_cose_sign_verify_ctx *me,
-                            QCBORDecodeContext            *decoder,
+                            QCBORDecodeContext            *cbor_decoder,
                             struct q_useful_buf_c          ext_sup_data,
                             struct q_useful_buf_c          detached_payload,
                             struct t_cose_parameter      **parameters)
 {
     return t_cose_sign_verify_private(me,
-                                      decoder,
+                                      cbor_decoder,
                                       ext_sup_data,
                                       true,
                                       &detached_payload,

--- a/inc/t_cose/t_cose_sign_verify.h
+++ b/inc/t_cose/t_cose_sign_verify.h
@@ -78,6 +78,12 @@ struct t_cose_sign_verify_ctx {
  *
  * This must be called before using the verification context.
  *
+ * \c option_flags may include \ref T_COSE_OPT_MESSAGE_TYPE_UNSPECIFIED,
+ * \ref T_COSE_OPT_MESSAGE_TYPE_SIGN1 or \ref T_COSE_OPT_MESSAGE_TYPE_SIGN
+ * to indicate which COSE message type is expected. If
+ * \ref T_COSE_OPT_MESSAGE_TYPE_UNSPECIFIED is given, then there must
+ * be a tag number in the input encoded CBOR to indicate which.
+ *
  * TODO: describe (and implement) selection of COSE_Sign1 vs COSE_Sign.
  */
 static void
@@ -208,13 +214,6 @@ t_cose_sign_set_special_param_decoder(struct t_cose_sign_verify_ctx  *context,
  * See t_cose_sign_add_verifier() for discussion on where the
  * verification key comes from, algorithms, formats and handling of
  * multiple signatures and multiple verifiers.
- *
- * If no option was given to t_cose_sign_verify_init() to indicate whether to process COSE_Sign
- * or COSE_SIgn1, this expects there to be one tag number in the input
- * to indicate which. If an option is given to indicate the message type
- * this expects no tag numbers in the input. See t_cose_sign_verify_message()
- * which does more tag processing.
- * TODO: can this be implemented with QCBOR v1?
  *
  * Verification involves the following steps.
  *

--- a/src/t_cose_encrypt_dec.c
+++ b/src/t_cose_encrypt_dec.c
@@ -128,16 +128,15 @@ decrypt_one_recipient(struct t_cose_encrypt_dec_ctx      *me,
 /*
  * Public Function. See t_cose_encrypt_dec.h
  */
-/* The main decryption implementation */
 enum t_cose_err_t
-t_cose_encrypt_dec_detached(struct t_cose_encrypt_dec_ctx* me,
-                            QCBORDecodeContext            *cbor_decoder,
-                            const struct q_useful_buf_c    ext_sup_data,
-                            const struct q_useful_buf_c    detached_ciphertext,
-                            struct q_useful_buf            plaintext_buffer,
-                            struct q_useful_buf_c         *plaintext,
-                            struct t_cose_parameter      **returned_parameters,
-                            uint64_t                       tag_numbers[T_COSE_MAX_TAGS_TO_RETURN])
+t_cose_encrypt_dec_main_private(struct t_cose_encrypt_dec_ctx* me,
+                                QCBORDecodeContext            *cbor_decoder,
+                                const struct q_useful_buf_c    ext_sup_data,
+                                const struct q_useful_buf_c    detached_ciphertext,
+                                struct q_useful_buf            plaintext_buffer,
+                                struct q_useful_buf_c         *plaintext,
+                                struct t_cose_parameter      **returned_parameters,
+                                uint64_t                       tag_numbers[T_COSE_MAX_TAGS_TO_RETURN])
 {
     enum t_cose_err_t              return_value;
     QCBORItem                      array_item;
@@ -441,7 +440,7 @@ Done:
  * Public Function. See t_cose_encrypt_dec.h
  */
 enum t_cose_err_t
-t_cose_encrypt_dec_msg(struct t_cose_encrypt_dec_ctx  *me,
+t_cose_encrypt_dec_msg(struct t_cose_encrypt_dec_ctx *me,
                        const struct q_useful_buf_c    cose_message,
                        const struct q_useful_buf_c    ext_sup_data,
                        struct q_useful_buf            plaintext_buffer,
@@ -466,19 +465,24 @@ t_cose_encrypt_dec_msg(struct t_cose_encrypt_dec_ctx  *me,
     /* QCBORv1 tag number processing is in t_cose_encrypt_dec() */
 #endif /* QCBOR_VERSION_MAJOR >= 2 */
 
-    error = t_cose_encrypt_dec(me,
-                              &cbor_decoder,
-                               ext_sup_data,
-                               plaintext_buffer,
-                               plaintext,
-                               returned_parameters);
+    error = t_cose_encrypt_dec_main_private(me,
+                                           &cbor_decoder,
+                                            ext_sup_data,
+                                            NULL_Q_USEFUL_BUF_C,
+                                            plaintext_buffer,
+                                            plaintext,
+                                            returned_parameters,
+                                            returned_tag_numbers);
 
-     me->option_flags = save_option_flags;
+    me->option_flags = save_option_flags;
 
     return error;
 }
 
 
+/*
+ * Public Function. See t_cose_encrypt_dec.h
+ */
 enum t_cose_err_t
 t_cose_encrypt_dec_detached_msg(struct t_cose_encrypt_dec_ctx *me,
                                 struct q_useful_buf_c          cose_message,
@@ -506,14 +510,14 @@ t_cose_encrypt_dec_detached_msg(struct t_cose_encrypt_dec_ctx *me,
     /* QCBORv1 tag number processing is in t_cose_encrypt_dec_detached() */
 #endif /* QCBOR_VERSION_MAJOR >= 2 */
 
-    error = t_cose_encrypt_dec_detached(me,
-                                       &cbor_decoder,
-                                        ext_sup_data,
-                                        detached_ciphertext,
-                                        plaintext_buffer,
-                                        plaintext,
-                                        returned_parameters,
-                                        returned_tag_numbers);
+    error = t_cose_encrypt_dec_main_private(me,
+                                           &cbor_decoder,
+                                            ext_sup_data,
+                                            detached_ciphertext,
+                                            plaintext_buffer,
+                                            plaintext,
+                                            returned_parameters,
+                                            returned_tag_numbers);
 
     me->option_flags = saved_option_flags;
 

--- a/src/t_cose_encrypt_dec.c
+++ b/src/t_cose_encrypt_dec.c
@@ -126,19 +126,20 @@ decrypt_one_recipient(struct t_cose_encrypt_dec_ctx      *me,
 
 
 /*
- * Pubilc Function. See t_cose_encrypt_dec.h
+ * Public Function. See t_cose_encrypt_dec.h
  */
+/* The MAIN implementation of decryption */
 enum t_cose_err_t
 t_cose_encrypt_dec_detached(struct t_cose_encrypt_dec_ctx* me,
-                            const struct q_useful_buf_c    message,
+                            QCBORDecodeContext            *cbor_decoder,
                             const struct q_useful_buf_c    ext_sup_data,
                             const struct q_useful_buf_c    detached_ciphertext,
                             struct q_useful_buf            plaintext_buffer,
                             struct q_useful_buf_c         *plaintext,
-                            struct t_cose_parameter      **returned_parameters)
+                            struct t_cose_parameter      **returned_parameters,
+                            uint64_t                       tag_numbers[T_COSE_MAX_TAGS_TO_RETURN])
 {
     enum t_cose_err_t              return_value;
-    QCBORDecodeContext             cbor_decoder;
     QCBORItem                      array_item;
     QCBORError                     cbor_error;
     uint64_t                       message_type;
@@ -160,26 +161,35 @@ t_cose_encrypt_dec_detached(struct t_cose_encrypt_dec_ctx* me,
     enum t_cose_err_t              previous_return_value;
 
 
-    /* --- Get started decoding array of 4 and tags --- */
-    QCBORDecode_Init(&cbor_decoder, message, QCBOR_DECODE_MODE_NORMAL);
+    /* --- Tag number processing, COSE_Sign or COSE_Sign1? --- */
+    message_type = me->option_flags & T_COSE_OPT_MESSAGE_TYPE_MASK;
 
-    QCBORDecode_EnterArray(&cbor_decoder, &array_item);
-    cbor_error = QCBORDecode_GetError(&cbor_decoder);
+#if QCBOR_VERSION_MAJOR >= 2
+    if(message_type == T_COSE_OPT_MESSAGE_TYPE_UNSPECIFIED) {
+        /* Caller didn't tell us what it is, get a tag number */
+        QCBORDecode_VGetNextTagNumber(cbor_decoder, &message_type);
+    }
+#endif /* QCBOR_VERSION_MAJOR >= 2 */
+
+
+    /* --- Get started decoding array of 4 and tags --- */
+    QCBORDecode_EnterArray(cbor_decoder, &array_item);
+    cbor_error = QCBORDecode_GetError(cbor_decoder);
     if(cbor_error != QCBOR_SUCCESS) {
         goto Done;
     }
 
-    const uint64_t signing_tag_nums[] = {CBOR_TAG_COSE_ENCRYPT,
-                                         CBOR_TAG_COSE_ENCRYPT0,
-                                         CBOR_TAG_INVALID64};
-    return_value = t_cose_tags_and_type(signing_tag_nums,
-                                        me->option_flags,
-                                        &array_item,
-                                        &cbor_decoder,
-                                        me->unprocessed_tag_nums,
-                                       &message_type);
+#if QCBOR_VERSION_MAJOR == 1
+    return_value = t_cose_process_tag_numbers_qcbor1(cbor_decoder, &array_item, &message_type, tag_numbers);
     if(return_value != T_COSE_SUCCESS) {
-        goto Done;
+        return return_value;
+    }
+#endif /* QCBOR_VERSION_MAJOR == 1 */
+
+    /* --- Finish tag number & type processing, COSE_Encrypt or COSE_Encrypt0? --- */
+    if(message_type != CBOR_TAG_COSE_ENCRYPT &&
+       message_type != CBOR_TAG_COSE_ENCRYPT0) {
+        return T_COSE_ERR_CANT_DETERMINE_MESSAGE_TYPE;
     }
 
 
@@ -192,7 +202,7 @@ t_cose_encrypt_dec_detached(struct t_cose_encrypt_dec_ctx* me,
 
     return_value =
         t_cose_headers_decode(
-           &cbor_decoder,     /* in: cbor decoder context */
+            cbor_decoder,     /* in: cbor decoder context */
             header_location,  /* in: location of headers in message */
             NULL,             /* TODO: in: header decode callback function */
             NULL,             /* TODO: in: header decode callback context */
@@ -234,10 +244,10 @@ t_cose_encrypt_dec_detached(struct t_cose_encrypt_dec_ctx* me,
 
     /* --- The Ciphertext --- */
     if(!q_useful_buf_c_is_null(detached_ciphertext)) {
-        QCBORDecode_GetNull(&cbor_decoder);
+        QCBORDecode_GetNull(cbor_decoder);
         cipher_text = detached_ciphertext;
     } else {
-        QCBORDecode_GetByteString(&cbor_decoder, &cipher_text);
+        QCBORDecode_GetByteString(cbor_decoder, &cipher_text);
     }
 
     /* --- COSE_Recipients (if there are any) --- */
@@ -257,8 +267,8 @@ t_cose_encrypt_dec_detached(struct t_cose_encrypt_dec_ctx* me,
         header_location.index   = 0;
 
         /* --- Enter array of recipients --- */
-        QCBORDecode_EnterArray(&cbor_decoder, NULL);
-        cbor_error = QCBORDecode_GetError(&cbor_decoder);
+        QCBORDecode_EnterArray(cbor_decoder, NULL);
+        cbor_error = QCBORDecode_GetError(cbor_decoder);
         if(cbor_error != QCBOR_SUCCESS) {
             goto Done;
         }
@@ -270,7 +280,7 @@ t_cose_encrypt_dec_detached(struct t_cose_encrypt_dec_ctx* me,
             return_value = decrypt_one_recipient(me,
                                                  header_location,
                                                  ce_alg,
-                                                 &cbor_decoder,
+                                                 cbor_decoder,
                                                  cek_buf,
                                                 &rcpnt_params_list,
                                                  &cek);
@@ -316,7 +326,7 @@ t_cose_encrypt_dec_detached(struct t_cose_encrypt_dec_ctx* me,
         }
 
         /* Successfully decoded one recipient */
-        QCBORDecode_ExitArray(&cbor_decoder);
+        QCBORDecode_ExitArray(cbor_decoder);
 
 
         t_cose_params_append(&all_params_list, rcpnt_params_list);
@@ -339,8 +349,8 @@ t_cose_encrypt_dec_detached(struct t_cose_encrypt_dec_ctx* me,
     /* --- Close of CBOR decode of the array of 4 --- */
     /* This tolerates extra items. Someday we'll have a better ExitArray()
      * and efficiently catch this (mostly harmless) error. */
-    QCBORDecode_ExitArray(&cbor_decoder);
-    cbor_error = QCBORDecode_Finish(&cbor_decoder);
+    QCBORDecode_ExitArray(cbor_decoder);
+    cbor_error = QCBORDecode_Finish(cbor_decoder);
     if(cbor_error != QCBOR_SUCCESS) {
         goto Done;
     }
@@ -419,4 +429,103 @@ Done:
          return_value = qcbor_decode_error_to_t_cose_error(cbor_error, T_COSE_ERR_ENCRYPT_FORMAT);
      }
     return return_value;
+}
+
+
+
+
+/* TODO: get rid of this
+You tell t_cose you don't know what the type is by not specifying a type
+
+ If there is no tag, the error is clearly 'can't determine message type'
+
+ If there is a tag that doesn't indicate what the type is,
+  - could be unprocessed tag
+  - could also be can't determine message type -- this seems better 
+
+ You tell t_cose the message type
+  - There is a tag number that not for the message type -- unprocessed tag number
+  - There is a tag number that is for the message type -- unprocessed tag number, but redundant tag number is better
+
+
+ */
+
+/*
+ * Public Function. See t_cose_encrypt_dec.h
+ */
+enum t_cose_err_t
+t_cose_encrypt_dec_msg(struct t_cose_encrypt_dec_ctx  *me,
+                       const struct q_useful_buf_c    cose_message,
+                       const struct q_useful_buf_c    ext_sup_data,
+                       struct q_useful_buf            plaintext_buffer,
+                       struct q_useful_buf_c         *plaintext,
+                       struct t_cose_parameter      **returned_parameters,
+                       uint64_t                       returned_tag_numbers[T_COSE_MAX_TAGS_TO_RETURN])
+{
+    QCBORDecodeContext cbor_decoder;
+    enum t_cose_err_t  error;
+    uint32_t           save_option_flags;
+
+    QCBORDecode_Init(&cbor_decoder, cose_message, QCBOR_DECODE_MODE_NORMAL);
+
+    save_option_flags = me->option_flags;
+#if QCBOR_VERSION_MAJOR >= 2
+
+    error = process_msg_tag_numbers(&cbor_decoder, &me->option_flags, returned_tag_numbers);
+    if(error) {
+        return error;
+    }
+#endif
+
+    error = t_cose_encrypt_dec(me,
+                              &cbor_decoder,
+                               ext_sup_data,
+                               plaintext_buffer,
+                               plaintext,
+                               returned_parameters);
+
+     me->option_flags = save_option_flags;
+
+    return error;
+}
+
+
+enum t_cose_err_t
+t_cose_encrypt_dec_detached_msg(struct t_cose_encrypt_dec_ctx *me,
+                                struct q_useful_buf_c          cose_message,
+                                struct q_useful_buf_c          ext_sup_data,
+                                struct q_useful_buf_c          detached_ciphertext,
+                                struct q_useful_buf            plaintext_buffer,
+                                struct q_useful_buf_c         *plaintext,
+                                struct t_cose_parameter      **returned_parameters,
+                                uint64_t                       returned_tag_numbers[T_COSE_MAX_TAGS_TO_RETURN])
+{
+    QCBORDecodeContext cbor_decoder;
+    enum t_cose_err_t  error;
+    uint32_t           saved_option_flags;
+
+    QCBORDecode_Init(&cbor_decoder, cose_message, QCBOR_DECODE_MODE_NORMAL);
+
+    saved_option_flags = me->option_flags;
+
+#if QCBOR_VERSION_MAJOR >= 2
+
+    error = process_msg_tag_numbers(&cbor_decoder, &me->option_flags, returned_tag_numbers);
+    if(error != T_COSE_SUCCESS) {
+        return error;
+    }
+#endif
+
+    error = t_cose_encrypt_dec_detached(me,
+                                       &cbor_decoder,
+                                        ext_sup_data,
+                                        detached_ciphertext,
+                                        plaintext_buffer,
+                                        plaintext,
+                                        returned_parameters,
+                                        returned_tag_numbers);
+
+    me->option_flags = saved_option_flags;
+
+    return error;
 }

--- a/src/t_cose_encrypt_dec.c
+++ b/src/t_cose_encrypt_dec.c
@@ -457,7 +457,10 @@ t_cose_encrypt_dec_msg(struct t_cose_encrypt_dec_ctx *me,
     save_option_flags = me->option_flags;
 
 #if QCBOR_VERSION_MAJOR >= 2
-    error = t_cose_private_process_msg_tag_nums(&cbor_decoder, &me->option_flags, returned_tag_numbers);
+    error = t_cose_private_process_msg_tag_nums(&cbor_decoder,
+                                                T_COSE_ERR_ENCRYPT_FORMAT,
+                                                &me->option_flags,
+                                                returned_tag_numbers);
     if(error) {
         return error;
     }
@@ -502,7 +505,10 @@ t_cose_encrypt_dec_detached_msg(struct t_cose_encrypt_dec_ctx *me,
     saved_option_flags = me->option_flags;
 
 #if QCBOR_VERSION_MAJOR >= 2
-    error = t_cose_private_process_msg_tag_nums(&cbor_decoder, &me->option_flags, returned_tag_numbers);
+    error = t_cose_private_process_msg_tag_nums(&cbor_decoder,
+                                                T_COSE_ERR_ENCRYPT_FORMAT,
+                                                &me->option_flags,
+                                                returned_tag_numbers);
     if(error != T_COSE_SUCCESS) {
         return error;
     }

--- a/src/t_cose_encrypt_dec.c
+++ b/src/t_cose_encrypt_dec.c
@@ -180,7 +180,12 @@ t_cose_encrypt_dec_detached(struct t_cose_encrypt_dec_ctx* me,
     }
 
 #if QCBOR_VERSION_MAJOR == 1
-    return_value = t_cose_process_tag_numbers_qcbor1(cbor_decoder, &array_item, &message_type, tag_numbers);
+    return_value = t_cose_process_tag_numbers_qcbor1(0,
+                                                     false, /* Always t_cose v2 semantics, there was no decrypt in t_cose v1 */
+                                                     cbor_decoder,
+                                                     &array_item,
+                                                     &message_type,
+                                                     tag_numbers);
     if(return_value != T_COSE_SUCCESS) {
         return return_value;
     }
@@ -343,7 +348,7 @@ t_cose_encrypt_dec_detached(struct t_cose_encrypt_dec_ctx* me,
         }
 
     } else {
-       /* This never happens because of checks in t_cose_tags_and_type() */
+       /* This never happens because of type determination above */
     }
 
     /* --- Close of CBOR decode of the array of 4 --- */
@@ -475,7 +480,7 @@ t_cose_encrypt_dec_msg(struct t_cose_encrypt_dec_ctx  *me,
     if(error) {
         return error;
     }
-#endif
+#endif /* QCBOR_VERSION_MAJOR >= 2 */
 
     error = t_cose_encrypt_dec(me,
                               &cbor_decoder,

--- a/src/t_cose_encrypt_enc.c
+++ b/src/t_cose_encrypt_enc.c
@@ -2,7 +2,7 @@
  * t_cose_encrypt_enc.c
  *
  * Copyright (c) 2022, Arm Limited. All rights reserved.
- * Copyright (c) 2023, Laurence Lundblade. All rights reserved.
+ * Copyright (c) 2025, Laurence Lundblade. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *
@@ -22,7 +22,7 @@
 
 
 /*
- * Pubilc Function. See t_cose_sign_sign.h
+ * Public Function. See t_cose_encrypt_enc.h
  */
 enum t_cose_err_t
 t_cose_encrypt_enc_detached(struct t_cose_encrypt_enc *me,

--- a/src/t_cose_mac_validate.c
+++ b/src/t_cose_mac_validate.c
@@ -23,7 +23,7 @@
 
 
 /**
- * \brief Semi-private function to validate a COSE_Mac0 message.
+ * \brief Semi-private main function to validate a COSE_Mac0 message.
  *
  * \param[in] context   The context of COSE_Mac0 validation.
  * \param[in] cbor_decoder    Source of the input COSE message to validate.
@@ -53,7 +53,7 @@ t_cose_mac_validate_private(struct t_cose_mac_validate_ctx *me,
                             bool                            payload_is_detached,
                             struct q_useful_buf_c          *payload,
                             struct t_cose_parameter       **return_params,
-                            uint64_t                        returned_tag_numbers[T_COSE_MAX_TAGS_TO_RETURN])
+                            uint64_t                        tag_numbers[T_COSE_MAX_TAGS_TO_RETURN])
 {
     struct q_useful_buf_c         protected_parameters;
     QCBORError                    qcbor_error;
@@ -93,7 +93,7 @@ t_cose_mac_validate_private(struct t_cose_mac_validate_ctx *me,
                                                      cbor_decoder,
                                                      &array_item,
                                                      &message_type_tag_number,
-                                                     returned_tag_numbers);
+                                                     tag_numbers);
     if(return_value != T_COSE_SUCCESS) {
         goto Done;
     }
@@ -198,15 +198,7 @@ Done:
 }
 
 
-/*
- * TODO: finish this documentation
- * \param[out] returned_tag_numbers   Place to return tag numbers or NULL.
- *                                    The order is outer-most first, the order
- *                                    from the encoded input.
- *
- * If returned_tag_numbers is NULL and tag numbers are present,
- * an error occurs.
- */
+/* See t_cose_mac_validate_msg() and t_cose_mac_validate_detached_msg() */
 enum t_cose_err_t
 t_cose_mac_validate_msg_private(struct t_cose_mac_validate_ctx *me,
                                 struct q_useful_buf_c           cose_mac,

--- a/src/t_cose_mac_validate.c
+++ b/src/t_cose_mac_validate.c
@@ -225,7 +225,10 @@ t_cose_mac_validate_msg_private(struct t_cose_mac_validate_ctx *me,
     saved_option_flags = me->option_flags;
     
 #if QCBOR_VERSION_MAJOR >= 2
-    error = t_cose_private_process_msg_tag_nums(&cbor_decoder, &me->option_flags, returned_tag_numbers);
+    error = t_cose_private_process_msg_tag_nums(&cbor_decoder,
+                                                T_COSE_ERR_MAC0_FORMAT,
+                                                &me->option_flags,
+                                                returned_tag_numbers);
     if(error != T_COSE_SUCCESS) {
         return error;
     }

--- a/src/t_cose_mac_validate.c
+++ b/src/t_cose_mac_validate.c
@@ -22,18 +22,11 @@
  */
 
 
-
-/**
- * @param[out] returned_tag_numbers  Place to return tag numbers or NULL. Encoded order, outer most first.
-
- */
-
 /**
  * \brief Semi-private function to validate a COSE_Mac0 message.
  *
  * \param[in] context   The context of COSE_Mac0 validation.
- * \param[in] cose_mac  Pointer and length of CBOR encoded \c COSE_Mac0
- *                      that is to be validated.
+ * \param[in] cbor_decoder    Source of the input COSE message to validate.
  * \param[in] ext_sup_data       The Additional Authenticated Data or
  *                      \c NULL_Q_USEFUL_BUF_C.
  * \param[in] payload_is_detached  If \c true, indicates the \c payload
@@ -42,7 +35,7 @@
  *                                 encoded payload.
  * \param[out] return_params       Place to return decoded parameters.
  *                                 May be \c NULL.
- * @param[out] returned_tag_numbers  Place to return tag numbers or NULL. Always the order from the input encoded CBOR, outer most first.
+ * \param[out] returned_tag_numbers  Place to return tag numbers or NULL. Always the order from the input encoded CBOR, outer most first.
  *
  * \return This returns one of the error codes defined by \ref t_cose_err_t.
  *
@@ -84,7 +77,6 @@ t_cose_mac_validate_private(struct t_cose_mac_validate_ctx *me,
         QCBORDecode_VGetNextTagNumber(cbor_decoder, &message_type_tag_number);
     }
 #endif /* QCBOR_VERSION_MAJOR >= 2 */
-
 
     /* --- The array of 4, type determination and tags --- */
     QCBORDecode_EnterArray(cbor_decoder, &array_item);
@@ -207,8 +199,11 @@ Done:
 
 
 /*
- * @param[out] returned_tag_numbers   Place to return tag numbers or NULL. Tag number order is outer-most first, the order from the encoded input.
-
+ * TODO: finish this documentation
+ * \param[out] returned_tag_numbers   Place to return tag numbers or NULL.
+ *                                    The order is outer-most first, the order
+ *                                    from the encoded input.
+ *
  * If returned_tag_numbers is NULL and tag numbers are present,
  * an error occurs.
  */
@@ -230,12 +225,12 @@ t_cose_mac_validate_msg_private(struct t_cose_mac_validate_ctx *me,
     saved_option_flags = me->option_flags;
     
 #if QCBOR_VERSION_MAJOR >= 2
-    error = process_msg_tag_numbers(&cbor_decoder, &me->option_flags, returned_tag_numbers);
+    error = t_cose_private_process_msg_tag_nums(&cbor_decoder, &me->option_flags, returned_tag_numbers);
     if(error != T_COSE_SUCCESS) {
         return error;
     }
 #else
-    /* Tag number processing with QCBORv1 is called inside t_cose_mac_validate_private() */
+    /* QCBORv1 tag number processing is in t_cose_mac_validate_private() */
 #endif /* QCBOR_VERSION_MAJOR >= 2 */
 
     error = t_cose_mac_validate_private(me,

--- a/src/t_cose_qcbor_gap.c
+++ b/src/t_cose_qcbor_gap.c
@@ -1,7 +1,7 @@
 /*
  * t_cose_qcbor_gap.c
  *
- * Copyright (c) 2023, Laurence Lundblade. All rights reserved.
+ * Copyright (c) 2025, Laurence Lundblade. All rights reserved.
  * Created by Laurence Lundblade on 5/29/23.
  *
  * SPDX-License-Identifier: BSD-3-Clause
@@ -11,7 +11,7 @@
 #include "t_cose_qcbor_gap.h"
 
 
-#if !defined(QCBOR_MAJOR_VERSION) || QCBOR_MAJOR_VERSION < 2
+#if QCBOR_MAJOR_VERSION < 2
 
 #include "qcbor/qcbor_decode.h"
 
@@ -39,4 +39,4 @@ void QCBORDecode_RestoreCursor(QCBORDecodeContext *pMe,
     pMe->uLastError = cursor->last_error;
 }
 
-#endif
+#endif /* QCBOR_MAJOR_VERSION < 2 */

--- a/src/t_cose_qcbor_gap.h
+++ b/src/t_cose_qcbor_gap.h
@@ -15,8 +15,9 @@
 
 #include "qcbor/qcbor_decode.h"
 
-#if !defined(QCBOR_MAJOR_VERSION) || QCBOR_MAJOR_VERSION < 2
 
+
+#if QCBOR_MAJOR_VERSION < 2
 
 
 /* These two functions are planned for QCBOR 2, but we want t_cose
@@ -49,6 +50,6 @@ void QCBORDecode_SaveCursor(QCBORDecodeContext *pCtx, QCBORSaveDecodeCursor *cur
 
 void QCBORDecode_RestoreCursor(QCBORDecodeContext *pCtx, const QCBORSaveDecodeCursor *cursor);
 
-#endif /* QCBOR_MAJOR_VERSION >= 2 */
+#endif /* QCBOR_MAJOR_VERSION < 2 */
 
 #endif /* t_cose_qcbor_gap_h */

--- a/src/t_cose_sign1_verify.c
+++ b/src/t_cose_sign1_verify.c
@@ -86,7 +86,7 @@ t_cose_sign1_private_verify_main(struct t_cose_sign1_verify_ctx *me,
     /* This implements t_cose v1 tag semantics with QCBOR v2 */
 
     /* Get all the tag numbers that preceed the COSE_Sign1 */
-    cbor_error = t_cose_consume_tags(&cbor_decoder, tag_numbers, &tag_num_index);
+    cbor_error = t_cose_private_consume_tag_nums(&cbor_decoder, tag_numbers, &tag_num_index);
     if(cbor_error != QCBOR_SUCCESS) {
         return qcbor_decode_error_to_t_cose_error(cbor_error, T_COSE_ERR_SIGN1_FORMAT);
     }
@@ -155,4 +155,3 @@ t_cose_sign1_private_verify_main(struct t_cose_sign1_verify_ctx *me,
 Done:
     return return_value;
 }
-

--- a/src/t_cose_sign1_verify.c
+++ b/src/t_cose_sign1_verify.c
@@ -1,7 +1,7 @@
 /*
  * t_cose_sign1_verify.c
  *
- * Copyright 2019-2023, Laurence Lundblade
+ * Copyright 2019-2025, Laurence Lundblade
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *
@@ -13,6 +13,9 @@
 #include "t_cose/t_cose_parameters.h"
 #include "t_cose/t_cose_sign_verify.h"
 #include "t_cose/t_cose_standard_constants.h"
+
+#include "t_cose_util.h"
+
 
 /**
  * \file t_cose_sign1_verify.c
@@ -59,30 +62,96 @@ t_cose_sign1_set_verification_key(struct t_cose_sign1_verify_ctx *me,
 }
 
 
-
 enum t_cose_err_t
-t_cose_sign1_verify(struct t_cose_sign1_verify_ctx *me,
-                    struct q_useful_buf_c           cose_sign1,
-                    struct q_useful_buf_c          *payload,
-                    struct t_cose_parameters       *parameters)
+t_cose_sign1_private_verify_main(struct t_cose_sign1_verify_ctx *me,
+                                 struct q_useful_buf_c           cose_message,
+                                 struct q_useful_buf_c           ext_sup_data,
+                                 const bool                      payload_is_detached,
+                                 struct q_useful_buf_c          *payload,
+                                 struct t_cose_parameters       *parameters)
 {
     enum t_cose_err_t        return_value;
     struct t_cose_parameter *decoded_params;
+    QCBORDecodeContext       cbor_decoder;
+    uint64_t                 tag_numbers[T_COSE_MAX_TAGS_TO_RETURN];
 
-    return_value = t_cose_sign_verify(&(me->me2),
-                                      cose_sign1,
-                                      NULL_Q_USEFUL_BUF_C,
-                                      payload,
-                                      &decoded_params);
+
+    struct t_cose_sign_verify_ctx *me2 = &(me->me2);
+
+// TODO: fix this up for QCBOR v1... could be messy...
+
+    QCBORDecode_Init(&cbor_decoder, cose_message, QCBOR_DECODE_MODE_NORMAL);
+
+#if QCBOR_VERSION_MAJOR >= 2
+    QCBORError               cbor_error;
+    int                      tag_num_index;
+
+    /* This needs to process the tags the way t_cose v1 does
+     * using either the QCBOR v1 or v2 libraries. */
+
+    /* Get all the tag numbers that preceed the COSE_Sign1 */
+    cbor_error = t_cose_consume_tags(&cbor_decoder, me->tag_numbers, &tag_num_index);
+    if(cbor_error != QCBOR_SUCCESS) {
+        return qcbor_decode_error_to_t_cose_error(cbor_error, T_COSE_ERR_SIGN1_FORMAT);
+    }
+
+    /* See if it is tagged as a COSE_Sign1 */
+    bool is_tagged_cose_sign1 = false;
+    if(me->tag_numbers[tag_num_index] == CBOR_TAG_COSE_SIGN1) {
+        me->tag_numbers[tag_num_index] = CBOR_TAG_INVALID64;
+        is_tagged_cose_sign1 = true;
+    }
+
+    /* What flags matter? T_COSE_OPT_TAG_REQUIRED, T_COSE_OPT_TAG_PROHIBITED, */
+    if(me->option_flags & T_COSE_OPT_TAG_REQUIRED) {
+        if(!is_tagged_cose_sign1) {
+            /* Caller doesn't know if this is a COSESign1 or not. They
+             * are relying on that, so if not tagged, it is an error. */
+            return T_COSE_ERR_INCORRECTLY_TAGGED;
+        }
+    }
+
+    if(me->option_flags & T_COSE_OPT_TAG_PROHIBITED) {
+        if(is_tagged_cose_sign1) {
+            /* Caller knows this is a COSE_Sign1 for sure and there should
+             * be no tag indicating so. */
+            return T_COSE_ERR_INCORRECTLY_TAGGED;
+        }
+    }
+#endif
+    /* Possible tag error conditions processed and all OK. It's a COSE_Sign1 */
+    me2->option_flags |= CBOR_TAG_COSE_SIGN1;
+
+    return_value = t_cose_sign_verify_private(me2,
+                                             &cbor_decoder,
+                                              ext_sup_data,
+                                              payload_is_detached,
+                                              payload,
+                                             &decoded_params,
+                                              tag_numbers);
+
     if(return_value != T_COSE_SUCCESS) {
         goto Done;
     }
 
     if(parameters != NULL) {
-        return_value = t_cose_params_common(decoded_params,
-                                            parameters);
+        return_value = t_cose_params_common(decoded_params, parameters);
     }
 
 Done:
     return return_value;
+}
+
+enum t_cose_err_t
+t_cose_sign1_verify(struct t_cose_sign1_verify_ctx *me,
+                    struct q_useful_buf_c           cose_message,
+                    struct q_useful_buf_c          *payload,
+                    struct t_cose_parameters       *parameters)
+{
+    return t_cose_sign1_private_verify_main(me,
+                                            cose_message,
+                                            NULLUsefulBufC,
+                                            false,
+                                            payload,
+                                            parameters);
 }

--- a/src/t_cose_sign1_verify.c
+++ b/src/t_cose_sign1_verify.c
@@ -126,10 +126,11 @@ t_cose_sign1_private_verify_main(struct t_cose_sign1_verify_ctx *me,
         }
     }
 
+    me2->option_flags |= CBOR_TAG_COSE_SIGN1;
+
 #endif /* QCBOR_VERSION_MAJOR >= 2 */
     
     /* Possible tag error conditions processed and all OK. It's a COSE_Sign1 */
-    me2->option_flags |= CBOR_TAG_COSE_SIGN1;
     me2->v1_compatible = true;
 
     return_value = t_cose_sign_verify_private(me2,

--- a/src/t_cose_sign_verify.c
+++ b/src/t_cose_sign_verify.c
@@ -505,12 +505,14 @@ t_cose_sign_verify_private(struct t_cose_sign_verify_ctx  *me,
     return_value = t_cose_process_tag_numbers_qcbor1(me->option_flags,
                                                      me->v1_compatible,
                                                      cbor_decoder,
-                                                     &array_item,
-                                                     &message_type_tag_number,
+                                                    &array_item,
+                                                    &message_type_tag_number,
                                                      tag_numbers);
     if(return_value != T_COSE_SUCCESS) {
         goto Done;
     }
+#else
+    (void)tag_numbers;
 #endif /* QCBOR_VERSION_MAJOR == 1 */
 
 
@@ -643,6 +645,7 @@ t_cose_sign_verify_msg_private(struct t_cose_sign_verify_ctx  *me,
         return error;
     }
 #else
+    (void)returned_tag_numbers;
     /* QCBORv1 tag number processing is in t_cose_sign_verify_private() */
 #endif /* QCBOR_VERSION_MAJOR >= 2 */
 

--- a/src/t_cose_sign_verify.c
+++ b/src/t_cose_sign_verify.c
@@ -1,7 +1,7 @@
 /*
  * t_cose_sign_verify.c
  *
- * Copyright 2019-2023, Laurence Lundblade
+ * Copyright 2019-2025, Laurence Lundblade
  * Copyright (c) 2023, Arm Limited. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
@@ -449,18 +449,19 @@ call_sign1_verifiers(struct t_cose_sign_verify_ctx   *me,
 }
 
 
+
 /*
  * A semi-private function. See t_cose_sign_verify.h
  */
 enum t_cose_err_t
 t_cose_sign_verify_private(struct t_cose_sign_verify_ctx  *me,
-                           const struct q_useful_buf_c     message,
+                           QCBORDecodeContext             *cbor_decoder,
                            const struct q_useful_buf_c     ext_sup_data,
                            const bool                      is_detached,
                            struct q_useful_buf_c          *payload,
-                           struct t_cose_parameter       **returned_params)
+                           struct t_cose_parameter       **returned_params,
+                           uint64_t                        tag_numbers[T_COSE_MAX_TAGS_TO_RETURN])
 {
-    QCBORDecodeContext              cbor_decoder;
     struct q_useful_buf_c           protected_params;
     enum t_cose_err_t               return_value;
     struct q_useful_buf_c           signature;
@@ -471,16 +472,42 @@ t_cose_sign_verify_private(struct t_cose_sign_verify_ctx  *me,
     QCBORItem                       array_item;
     uint64_t                        message_type_tag_number;
 
+    /* --- Tag number processing, COSE_Sign or COSE_Sign1? --- */
+    message_type_tag_number = me->option_flags & T_COSE_OPT_MESSAGE_TYPE_MASK;
+
+#if QCBOR_VERSION_MAJOR >= 2
+    if(message_type_tag_number == T_COSE_OPT_MESSAGE_TYPE_UNSPECIFIED) {
+        /* Caller didn't tell us what it is, get a tag number */
+        QCBORDecode_VGetNextTagNumber(cbor_decoder, &message_type_tag_number);
+    }
+#endif /* QCBOR_VERSION_MAJOR >= 2 */
+
     /* --- Get started with the array of four --- */
-    QCBORDecode_Init(&cbor_decoder, message, QCBOR_DECODE_MODE_NORMAL);
-    QCBORDecode_EnterArray(&cbor_decoder, &array_item);
+    QCBORDecode_EnterArray(cbor_decoder, &array_item);
     /* t_cose_headers_decode processes errors from this to save object code */
+
+#if QCBOR_VERSION_MAJOR == 1
+    return_value = t_cose_process_tag_numbers_qcbor1(cbor_decoder,
+                                                     &array_item,
+                                                     &message_type_tag_number,
+                                                     tag_numbers);
+    if(return_value != T_COSE_SUCCESS) {
+        goto Done;
+    }
+#endif /* QCBOR_VERSION_MAJOR == 1 */
+
+
+    /* --- Finish tag number & type processing, COSE_Sign or COSE_Sign1? --- */
+    if(message_type_tag_number != T_COSE_OPT_MESSAGE_TYPE_SIGN1 &&
+       message_type_tag_number != T_COSE_OPT_MESSAGE_TYPE_SIGN) {
+        return T_COSE_ERR_CANT_DETERMINE_MESSAGE_TYPE;
+    }
 
     /* --- The main body header parameters --- */
     header_location.nesting = 0; /* Location of body header */
     header_location.index   = 0; /* params is 0, 0          */
     decoded_params          = NULL;
-    return_value = t_cose_headers_decode(&cbor_decoder,
+    return_value = t_cose_headers_decode(cbor_decoder,
                                           header_location,
                                           me->special_param_decode_cb,
                                           me->special_param_decode_ctx,
@@ -491,28 +518,14 @@ t_cose_sign_verify_private(struct t_cose_sign_verify_ctx  *me,
         goto Done;
     }
 
-    /* --- The tags and message type --- */
-    const uint64_t signing_tag_nums[] = {T_COSE_OPT_MESSAGE_TYPE_SIGN1,
-                                         T_COSE_OPT_MESSAGE_TYPE_SIGN,
-                                         CBOR_TAG_INVALID64};
-    return_value = t_cose_tags_and_type(signing_tag_nums,
-                                        me->option_flags,
-                                       &array_item,
-                                       &cbor_decoder,
-                                        me->unprocessed_tag_nums,
-                                       &message_type_tag_number);
-    if(return_value != T_COSE_SUCCESS) {
-        goto Done;
-    }
-
     /* --- The payload --- */
     if(is_detached) {
-        QCBORDecode_GetNull(&cbor_decoder);
+        QCBORDecode_GetNull(cbor_decoder);
         /* In detached content mode, the payload should be set by
          * function caller, so there is no need to set the payload.
          */
     } else {
-        QCBORDecode_GetByteString(&cbor_decoder, payload);
+        QCBORDecode_GetByteString(cbor_decoder, payload);
     }
 
 
@@ -523,8 +536,8 @@ t_cose_sign_verify_private(struct t_cose_sign_verify_ctx  *me,
     sign_inputs.payload        = *payload;
     if(message_type_tag_number == T_COSE_OPT_MESSAGE_TYPE_SIGN1) {
         /* --- The signature bytes for a COSE_Sign1, not COSE_Signatures */
-        QCBORDecode_GetByteString(&cbor_decoder, &signature);
-        if(QCBORDecode_GetError(&cbor_decoder)) {
+        QCBORDecode_GetByteString(cbor_decoder, &signature);
+        if(QCBORDecode_GetError(cbor_decoder)) {
             /* Must have successfully decoded sig before verifying */
             /* Done2 re-uses CBOR->COSE error mapping code. */
             goto Done2;
@@ -539,21 +552,21 @@ t_cose_sign_verify_private(struct t_cose_sign_verify_ctx  *me,
 
 #ifndef T_COSE_DISABLE_COSE_SIGN
         /* --- The array of COSE_Signatures --- */
-        QCBORDecode_EnterArray(&cbor_decoder, NULL);
+        QCBORDecode_EnterArray(cbor_decoder, NULL);
 
         return_value = process_cose_signatures(me,
-                                               &cbor_decoder,
+                                               cbor_decoder,
                                                &sign_inputs,
                                                &decoded_params);
 
-        QCBORDecode_ExitArray(&cbor_decoder);
+        QCBORDecode_ExitArray(cbor_decoder);
 #else
         return_value = T_COSE_ERR_UNSUPPORTED;
-#endif /* !T_COSE_DISABLE_COSE_SIGN */
+#endif /* ! T_COSE_DISABLE_COSE_SIGN */
     }
 
     /* --- Finish up the CBOR decode --- */
-    QCBORDecode_ExitArray(&cbor_decoder);
+    QCBORDecode_ExitArray(cbor_decoder);
 
     if(returned_params != NULL) {
         *returned_params = decoded_params;
@@ -564,7 +577,7 @@ t_cose_sign_verify_private(struct t_cose_sign_verify_ctx  *me,
      * items. It works for definite and indefinte length arrays. Also
      * makes sure there were no extra bytes. Also maps the error code
      * for other decode errors detected above. */
-    cbor_error = QCBORDecode_Finish(&cbor_decoder);
+    cbor_error = QCBORDecode_Finish(cbor_decoder);
     if(cbor_error != QCBOR_SUCCESS) {
         /* A decode error overrides the other errors detected above. */
         return_value = qcbor_decode_error_to_t_cose_error(cbor_error,
@@ -584,4 +597,49 @@ t_cose_sign_verify_private(struct t_cose_sign_verify_ctx  *me,
 
   Done:
     return return_value;
+}
+
+
+
+/*
+ * A semi-private function. See t_cose_sign_verify.h
+ */
+enum t_cose_err_t
+t_cose_sign_verify_msg_private(struct t_cose_sign_verify_ctx  *me,
+                               const struct q_useful_buf_c     cose_message,
+                               const struct q_useful_buf_c     ext_sup_data,
+                               const bool                      is_detached,
+                               struct q_useful_buf_c          *payload,
+                               struct t_cose_parameter       **returned_params,
+                               uint64_t                        returned_tag_numbers[T_COSE_MAX_TAGS_TO_RETURN])
+{
+    QCBORDecodeContext  cbor_decoder;
+    enum t_cose_err_t   error;
+    uint32_t            save_option_flags;
+    uint64_t            tag_numbers[T_COSE_MAX_TAGS_TO_RETURN];
+
+    QCBORDecode_Init(&cbor_decoder, cose_message, QCBOR_DECODE_MODE_NORMAL);
+
+    save_option_flags = me->option_flags;
+
+#if QCBOR_VERSION_MAJOR >= 2
+    error = process_msg_tag_numbers(&cbor_decoder, &me->option_flags, returned_tag_numbers);
+    if(error != T_COSE_SUCCESS) {
+        return error;
+    }
+#endif
+
+    error =  t_cose_sign_verify_private(me,
+                                       &cbor_decoder,
+                                        ext_sup_data,
+                                        is_detached,
+                                        payload,
+                                        returned_params,
+                                        tag_numbers);
+
+    // TODO: fix this up for QCBOR v1
+
+    me->option_flags = save_option_flags;
+
+    return error;
 }

--- a/src/t_cose_sign_verify.c
+++ b/src/t_cose_sign_verify.c
@@ -640,7 +640,10 @@ t_cose_sign_verify_msg_private(struct t_cose_sign_verify_ctx  *me,
     save_option_flags = me->option_flags;
 
 #if QCBOR_VERSION_MAJOR >= 2
-    error = t_cose_private_process_msg_tag_nums(&cbor_decoder, &me->option_flags, returned_tag_numbers);
+    error = t_cose_private_process_msg_tag_nums(&cbor_decoder,
+                                                T_COSE_ERR_SIGN1_FORMAT,
+                                                &me->option_flags,
+                                                returned_tag_numbers);
     if(error != T_COSE_SUCCESS) {
         return error;
     }

--- a/src/t_cose_util.c
+++ b/src/t_cose_util.c
@@ -190,7 +190,12 @@ t_cose_private_process_msg_tag_nums(QCBORDecodeContext  *cbor_decoder,
 
 #if QCBOR_VERSION_MAJOR == 1
 
-/* t_cose v1 style tag number handling when linked with QCBOR v1
+/* 
+ * This is hard-coded to only works for COSE_Sign1. It is the only
+ * format supported by t_cose v1 and hard coding simplies the calling stack.
+ *
+ *
+ * t_cose v1 style tag number handling when linked with QCBOR v1
  * This code is cloned from t_cose v1
  * Order of return_tag_numbers is inner-most first as in t_cose v1.
  */
@@ -213,8 +218,9 @@ t_cose_process_tag_numbers_qcbor1_t_cose1(uint32_t             option_flags,
     /* The 0th tag is the only one that might identify the type of the
      * CBOR we are trying to decode so it is handled special.
      */
-    uTag = QCBORDecode_GetNthTagOfLast(cbor_decoder, item_tag_index);
+    uTag = QCBORDecode_GetNthTag(cbor_decoder, item, item_tag_index);
     item_tag_index++;
+    // TODO: use message_type
     if(option_flags & T_COSE_OPT_TAG_REQUIRED) {
         /* The protocol that is using COSE says the input CBOR must
          * be a COSE tag.
@@ -234,6 +240,7 @@ t_cose_process_tag_numbers_qcbor1_t_cose1(uint32_t             option_flags,
     /* If the protocol using COSE doesn't say one way or another about the
      * tag, then either is OK.
      */
+    *message_type = CBOR_TAG_COSE_SIGN1;
 
 
     /* Initialize auTags, the returned tags, to CBOR_TAG_INVALID64 */

--- a/src/t_cose_util.c
+++ b/src/t_cose_util.c
@@ -147,6 +147,7 @@ t_cose_private_consume_tag_nums(QCBORDecodeContext *cbor_decoder,
 /* See interface documentation in t_cose_util.h */
 enum t_cose_err_t
 t_cose_private_process_msg_tag_nums(QCBORDecodeContext  *cbor_decoder,
+                                    enum t_cose_err_t    error_format,
                                     uint32_t            *option_flags,
                                     uint64_t             returned_tag_numbers[T_COSE_MAX_TAGS_TO_RETURN])
 {
@@ -156,8 +157,7 @@ t_cose_private_process_msg_tag_nums(QCBORDecodeContext  *cbor_decoder,
 
     cbor_error = t_cose_private_consume_tag_nums(cbor_decoder, unprocessed_tag_nums, &tag_num_index);
     if(cbor_error != QCBOR_SUCCESS) {
-        // TODO: make T_COSE_ERR_MAC_FORMAT a parameter
-        return qcbor_decode_error_to_t_cose_error(cbor_error, T_COSE_ERR_MESSAGE_FORMAT);
+        return qcbor_decode_error_to_t_cose_error(cbor_error, error_format);
     }
 
     if((*option_flags & T_COSE_OPT_MESSAGE_TYPE_MASK) == T_COSE_OPT_MESSAGE_TYPE_UNSPECIFIED) {
@@ -219,7 +219,6 @@ t_cose_process_tag_numbers_qcbor1_t_cose1(uint32_t             option_flags,
      */
     uTag = QCBORDecode_GetNthTag(cbor_decoder, item, item_tag_index);
     item_tag_index++;
-    // TODO: use message_type
     if(option_flags & T_COSE_OPT_TAG_REQUIRED) {
         /* The protocol that is using COSE says the input CBOR must
          * be a COSE tag.

--- a/src/t_cose_util.c
+++ b/src/t_cose_util.c
@@ -113,7 +113,6 @@ hash_alg_id_from_sig_alg_id(int32_t cose_algorithm_id)
 
 
 
-#include <limits.h>
 
 #if QCBOR_VERSION_MAJOR >= 2
 

--- a/src/t_cose_util.c
+++ b/src/t_cose_util.c
@@ -117,17 +117,11 @@ hash_alg_id_from_sig_alg_id(int32_t cose_algorithm_id)
 
 #if QCBOR_VERSION_MAJOR >= 2
 
-/*
- * Public function. See t_cose_util.h
- */
-// last_tag always points to a tag_number in tag_numbers.
-// If the value of tag_numbers[*last_tag_index] != INVALID, then
-// there is a last tag number; that is tag_numbers isn't empty
-/* This is used only when linked with QCBOR v2 */
+/* See interface documentation in t_cose_util.h */
 QCBORError
-t_cose_consume_tags(QCBORDecodeContext *cbor_decoder,
-                    uint64_t            tag_numbers[QCBOR_MAX_TAGS_PER_ITEM],
-                    int                *last_tag_index)
+t_cose_private_consume_tag_nums(QCBORDecodeContext *cbor_decoder,
+                                uint64_t            tag_numbers[QCBOR_MAX_TAGS_PER_ITEM],
+                                int                *last_tag_index)
 {
     QCBORError  cbor_error;
     uint64_t    message_type_tag_number;
@@ -150,16 +144,18 @@ t_cose_consume_tags(QCBORDecodeContext *cbor_decoder,
     return cbor_error;
 }
 
+
+/* See interface documentation in t_cose_util.h */
 enum t_cose_err_t
-process_msg_tag_numbers(QCBORDecodeContext  *cbor_decoder,
-                        uint32_t            *option_flags,
-                        uint64_t             returned_tag_numbers[T_COSE_MAX_TAGS_TO_RETURN])
+t_cose_private_process_msg_tag_nums(QCBORDecodeContext  *cbor_decoder,
+                                    uint32_t            *option_flags,
+                                    uint64_t             returned_tag_numbers[T_COSE_MAX_TAGS_TO_RETURN])
 {
     QCBORError  cbor_error;
     uint64_t    unprocessed_tag_nums[T_COSE_MAX_TAGS_TO_RETURN];
     int         tag_num_index;
 
-    cbor_error = t_cose_consume_tags(cbor_decoder, unprocessed_tag_nums, &tag_num_index);
+    cbor_error = t_cose_private_consume_tag_nums(cbor_decoder, unprocessed_tag_nums, &tag_num_index);
     if(cbor_error != QCBOR_SUCCESS) {
         // TODO: make T_COSE_ERR_MAC_FORMAT a parameter
         return qcbor_decode_error_to_t_cose_error(cbor_error, T_COSE_ERR_MESSAGE_FORMAT);
@@ -196,6 +192,7 @@ process_msg_tag_numbers(QCBORDecodeContext  *cbor_decoder,
 
 /* t_cose v1 style tag number handling when linked with QCBOR v1
  * This code is cloned from t_cose v1
+ * Order of return_tag_numbers is inner-most first as in t_cose v1.
  */
 static enum t_cose_err_t
 t_cose_process_tag_numbers_qcbor1_t_cose1(uint32_t             option_flags,
@@ -327,7 +324,8 @@ t_cose_process_tag_numbers_qcbor1_t_cose2(QCBORDecodeContext  *cbor_decoder,
  *
  * @param[in] v1_semantics  If true, tag processing is per t_cose v1, if false it is per t_cose v2.
  *
- * @param[out] return_tag_numbers  Place to return tag numbers or NULL. Order is as encoded, outermost first.  Or does it depend on v1_semantics?
+ * @param[out] return_tag_numbers  Place to return tag numbers or NULL. The order depends on
+ * v1_semantics. If v1 is true, then it is inner-most first. Otherwise it is outer-most first.
  */
 enum t_cose_err_t
 t_cose_process_tag_numbers_qcbor1(uint32_t             option_flags,

--- a/src/t_cose_util.h
+++ b/src/t_cose_util.h
@@ -1,7 +1,7 @@
 /*
  *  t_cose_util.h
  *
- * Copyright 2019-2023, Laurence Lundblade
+ * Copyright 2019-2025, Laurence Lundblade
  * Copyright (c) 2020-2023, Arm Limited. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
@@ -36,45 +36,6 @@ extern "C" {
 
 
 
-/*
- * \brief Process CBOR tag numbers and figure out message type.
- *
- * \param[in] relevant_cose_tag_nums  List of tag numbers relevant for
- *                                    message type being processed, ending
- *                                    with \ref CBOR_TAG_INVALID64
- * \param[in] option_flags            Flags passed to xxxx_init() that
- *                                    say how to process tag nums, plus
- *                                    optional default message type.
- * \param[in] item                    The QCBORItem of the array that
- *                                    opens the message so the tag
- *                                    numbers on it can be processed.
- * \param[in] cbor_decoder            Needed to process the tag numbers
- *                                    on item.
- * \param[out] unprocessed_tag_nums   Any additional tag numbers that were
- *                                    not used to determine the message
- *                                    type.
- * \param[out] cost_tag_num           The end result message type.
- *
- * Either this will error out or \c cose_tag_num will identify the
- * message type and be one of those listed in \c relevant_cose_tag_nums.
- * This also puts any additional tag numbers that are not the
- * one returned in \c cose_tag_num in \c unprocessed_tag_nums. This
- * genric processor can be used for all the CBOR message types with
- * tag numbers (e.g., COSE_Sign1, COSE_Encrypt,...)
- *
- * \c option_flags are a critical input. It may contain the
- * tag number of the expected type and option flags that say
- * how the tag numbers are to be interpreted and error conditions.
- */
-enum t_cose_err_t
-t_cose_tags_and_type(const uint64_t     *relevant_cose_tag_nums,
-                     uint32_t            option_flags,
-                     const QCBORItem    *item,
-                     QCBORDecodeContext *cbor_decoder,
-                     uint64_t            unprocessed_tag_nums[T_COSE_MAX_TAGS_TO_RETURN],
-                     uint64_t           *cose_tag_num);
-
-
 #if QCBOR_VERSION_MAJOR >= 2
 
 // TODO: document this
@@ -96,7 +57,9 @@ process_msg_tag_numbers(QCBORDecodeContext  *cbor_decoder,
 
 /* Do v2 style tag processing with QCBOR v1 */
 enum t_cose_err_t
-t_cose_process_tag_numbers_qcbor1(QCBORDecodeContext  *cbor_decoder,
+t_cose_process_tag_numbers_qcbor1(uint32_t             option_flags,
+                                  bool                 v1_semantics,
+                                  QCBORDecodeContext  *cbor_decoder,
                                   const QCBORItem     *item,
                                   uint64_t            *message_type,
                                   uint64_t             tag_numbers[T_COSE_MAX_TAGS_TO_RETURN]);

--- a/src/t_cose_util.h
+++ b/src/t_cose_util.h
@@ -74,6 +74,7 @@ t_cose_private_consume_tag_nums(QCBORDecodeContext *cbor_decoder,
  */
 enum t_cose_err_t
 t_cose_private_process_msg_tag_nums(QCBORDecodeContext  *cbor_decoder,
+                                    enum t_cose_err_t    error_format,
                                     uint32_t            *option_flags,
                                     uint64_t             returned_tag_numbers[T_COSE_MAX_TAGS_TO_RETURN]);
 

--- a/src/t_cose_util.h
+++ b/src/t_cose_util.h
@@ -75,6 +75,32 @@ t_cose_tags_and_type(const uint64_t     *relevant_cose_tag_nums,
                      uint64_t           *cose_tag_num);
 
 
+#if QCBOR_VERSION_MAJOR >= 2
+
+// TODO: document this
+QCBORError
+t_cose_consume_tags(QCBORDecodeContext *cbor_decoder,
+                    uint64_t            tag_numbers[QCBOR_MAX_TAGS_PER_ITEM],
+                    int                *last_tag_index);
+
+
+enum t_cose_err_t
+process_msg_tag_numbers(QCBORDecodeContext  *cbor_decoder,
+                        uint32_t            *option_flags,
+                        uint64_t             returned_tag_numbers[T_COSE_MAX_TAGS_TO_RETURN]);
+
+#endif /* QCBOR_VERSION_MAJOR >= 2 */
+
+
+#if QCBOR_VERSION_MAJOR == 1
+
+/* Do v2 style tag processing with QCBOR v1 */
+enum t_cose_err_t
+t_cose_process_tag_numbers_qcbor1(QCBORDecodeContext  *cbor_decoder,
+                                  const QCBORItem     *item,
+                                  uint64_t            *message_type,
+                                  uint64_t             tag_numbers[T_COSE_MAX_TAGS_TO_RETURN]);
+#endif /* QCBOR_VERSION_MAJOR == 1 */
 
 /**
  * This value represents an invalid or in-error algorithm ID.  The

--- a/src/t_cose_util.h
+++ b/src/t_cose_util.h
@@ -38,17 +38,44 @@ extern "C" {
 
 #if QCBOR_VERSION_MAJOR >= 2
 
-// TODO: document this
+/**
+ * @brief Consume all the tag numbers preceding and item.
+ *
+ * @param[in] cbor_decoder  Decoder to read the tag numbers from.
+ * @param[out] tag_numbers  The tag numbers consumed. Order is outer-most first.
+ * @param[out] last_tag_index   Index of the inner-most tag number.
+ *
+ * Used with QCBOR v2 where tag numbers are to be consumed.
+ *
+ * If the value of tag_numbers[*last_tag_index] != INVALID, then
+ * there is a last tag number; that is tag_numbers isn't empty.
+ */
 QCBORError
-t_cose_consume_tags(QCBORDecodeContext *cbor_decoder,
-                    uint64_t            tag_numbers[QCBOR_MAX_TAGS_PER_ITEM],
-                    int                *last_tag_index);
+t_cose_private_consume_tag_nums(QCBORDecodeContext *cbor_decoder,
+                                uint64_t            tag_numbers[QCBOR_MAX_TAGS_PER_ITEM],
+                                int                *last_tag_index);
 
 
+/**
+ * @brief A common processor for tag numbers for the _msg methods
+ *
+ * @param[in] cbor_decoder Decoder to read the tag numbers from.
+ * @param[in,out] option_flags
+ * @param[out] returned_tag_numbers   The tag numbers decoded. May be NULL.
+ *
+ * Used by the methods that consume and return all the tag numbers.
+ *
+ * This consumes all the tag numbers before the first item in the COSE message.
+ * The option_flags are examined to know if there should be a tag number
+ * to indicate the message type. If so it is put into the option_flags.
+ * Any remaining tag_numbers are returned. If there are any and
+ * returned_tag_numbers is NULL, it is an error.
+ *
+ */
 enum t_cose_err_t
-process_msg_tag_numbers(QCBORDecodeContext  *cbor_decoder,
-                        uint32_t            *option_flags,
-                        uint64_t             returned_tag_numbers[T_COSE_MAX_TAGS_TO_RETURN]);
+t_cose_private_process_msg_tag_nums(QCBORDecodeContext  *cbor_decoder,
+                                    uint32_t            *option_flags,
+                                    uint64_t             returned_tag_numbers[T_COSE_MAX_TAGS_TO_RETURN]);
 
 #endif /* QCBOR_VERSION_MAJOR >= 2 */
 

--- a/src/t_cose_util.h
+++ b/src/t_cose_util.h
@@ -39,11 +39,11 @@ extern "C" {
 #if QCBOR_VERSION_MAJOR >= 2
 
 /**
- * @brief Consume all the tag numbers preceding and item.
+ * \brief Consume all the tag numbers preceding an item.
  *
- * @param[in] cbor_decoder  Decoder to read the tag numbers from.
- * @param[out] tag_numbers  The tag numbers consumed. Order is outer-most first.
- * @param[out] last_tag_index   Index of the inner-most tag number.
+ * \param[in] cbor_decoder  Decoder to read the tag numbers from.
+ * \param[out] tag_numbers  The tag numbers consumed. Order is outer-most first.
+ * \param[out] last_tag_index   Index of the inner-most tag number.
  *
  * Used with QCBOR v2 where tag numbers are to be consumed.
  *
@@ -57,11 +57,11 @@ t_cose_private_consume_tag_nums(QCBORDecodeContext *cbor_decoder,
 
 
 /**
- * @brief A common processor for tag numbers for the _msg methods
+ * \brief A common processor for tag numbers for the _msg methods
  *
- * @param[in] cbor_decoder Decoder to read the tag numbers from.
- * @param[in,out] option_flags
- * @param[out] returned_tag_numbers   The tag numbers decoded. May be NULL.
+ * \param[in] cbor_decoder Decoder to read the tag numbers from.
+ * \param[in,out] option_flags
+ * \param[out] returned_tag_numbers   The tag numbers decoded. May be NULL.
  *
  * Used by the methods that consume and return all the tag numbers.
  *
@@ -82,7 +82,25 @@ t_cose_private_process_msg_tag_nums(QCBORDecodeContext  *cbor_decoder,
 
 #if QCBOR_VERSION_MAJOR == 1
 
-/* Do v2 style tag processing with QCBOR v1 */
+/**
+ * \brief Process tag numbers when linked against QCBOR v1.
+ *
+ * \param[in] option_flags   Option flags from initialization of context
+ * \param[in] v1_semantics   If true t_cose v1, if false t_cose v2 semantics
+ * \param[in] cbor_decoder   Decoder instance needed to unmap tag numbers in QCBOR v1
+ * \param[in] item           Decoded first item that has tag numbers associated
+ * \param[out] message_type  The type of COSE message
+ * \param[out] tag_numbers   The returned tag numbers.
+ *
+ * This determines the message type from option_flags and the
+ * encoded tag numbers. This returns the tag numbers not consumed
+ * in determining the message type.
+ *
+ * This is only for use when linked against QCBOR v1. This mainly provides
+ * t_cose v2 tag semantics when linked against QCBOR v1, but also provides
+ * t_cose v1 tag semantics to for the backwards compatibility for  t_cose_sign1
+ * which is supported in t_cose v2.
+ */
 enum t_cose_err_t
 t_cose_process_tag_numbers_qcbor1(uint32_t             option_flags,
                                   bool                 v1_semantics,
@@ -90,7 +108,11 @@ t_cose_process_tag_numbers_qcbor1(uint32_t             option_flags,
                                   const QCBORItem     *item,
                                   uint64_t            *message_type,
                                   uint64_t             tag_numbers[T_COSE_MAX_TAGS_TO_RETURN]);
+
 #endif /* QCBOR_VERSION_MAJOR == 1 */
+
+
+
 
 /**
  * This value represents an invalid or in-error algorithm ID.  The

--- a/t_cose.xcodeproj/project.pbxproj
+++ b/t_cose.xcodeproj/project.pbxproj
@@ -43,6 +43,11 @@
 		E730E61823612DAB00175CE0 /* main.c in Sources */ = {isa = PBXBuildFile; fileRef = E7E36E7B226CB8400040613B /* main.c */; };
 		E730E61923612DAB00175CE0 /* t_cose_sign1_sign.c in Sources */ = {isa = PBXBuildFile; fileRef = E7E36E8E226CB9460040613B /* t_cose_sign1_sign.c */; };
 		E730E62123612E3900175CE0 /* t_cose_test_crypto.c in Sources */ = {isa = PBXBuildFile; fileRef = E7E36EA4226CBB570040613B /* t_cose_test_crypto.c */; };
+		E73559BE2D30BEFC0023A20A /* libqcbor.a in Frameworks */ = {isa = PBXBuildFile; fileRef = E73559BD2D30BECD0023A20A /* libqcbor.a */; };
+		E73559BF2D30BEFD0023A20A /* libqcbor.a in Frameworks */ = {isa = PBXBuildFile; fileRef = E73559BD2D30BECD0023A20A /* libqcbor.a */; };
+		E73559C02D30BEFE0023A20A /* libqcbor.a in Frameworks */ = {isa = PBXBuildFile; fileRef = E73559BD2D30BECD0023A20A /* libqcbor.a */; };
+		E73559C12D30BEFE0023A20A /* libqcbor.a in Frameworks */ = {isa = PBXBuildFile; fileRef = E73559BD2D30BECD0023A20A /* libqcbor.a */; };
+		E73559C22D30BEFF0023A20A /* libqcbor.a in Frameworks */ = {isa = PBXBuildFile; fileRef = E73559BD2D30BECD0023A20A /* libqcbor.a */; };
 		E73BF6D723AFFB4100DF5C36 /* t_cose_sign1_verify.c in Sources */ = {isa = PBXBuildFile; fileRef = E7E36E8A226CB9460040613B /* t_cose_sign1_verify.c */; };
 		E73BF6DB23AFFB4100DF5C36 /* t_cose_psa_crypto.c in Sources */ = {isa = PBXBuildFile; fileRef = E73CDAD223AD4E6D00D262E0 /* t_cose_psa_crypto.c */; };
 		E73BF6DC23AFFB4100DF5C36 /* t_cose_util.c in Sources */ = {isa = PBXBuildFile; fileRef = E7E36E89226CB9460040613B /* t_cose_util.c */; };
@@ -120,11 +125,6 @@
 		E7AF703728DADFCF00F07637 /* t_cose_param_test.c in Sources */ = {isa = PBXBuildFile; fileRef = E7AF703528DADF5E00F07637 /* t_cose_param_test.c */; };
 		E7AF703828DADFD000F07637 /* t_cose_param_test.c in Sources */ = {isa = PBXBuildFile; fileRef = E7AF703528DADF5E00F07637 /* t_cose_param_test.c */; };
 		E7B72D792AE23AF400A0CD06 /* t_cose_signature_sign_restart.c in Sources */ = {isa = PBXBuildFile; fileRef = E7088A0E2A50B78100F1B2DE /* t_cose_signature_sign_restart.c */; };
-		E7B72D7C2AE23DE900A0CD06 /* libqcbor.a in Frameworks */ = {isa = PBXBuildFile; fileRef = E7B72D7A2AE23DE400A0CD06 /* libqcbor.a */; };
-		E7B72D7D2AE23DE900A0CD06 /* libqcbor.a in Frameworks */ = {isa = PBXBuildFile; fileRef = E7B72D7A2AE23DE400A0CD06 /* libqcbor.a */; };
-		E7B72D7E2AE23DEA00A0CD06 /* libqcbor.a in Frameworks */ = {isa = PBXBuildFile; fileRef = E7B72D7A2AE23DE400A0CD06 /* libqcbor.a */; };
-		E7B72D7F2AE23DEA00A0CD06 /* libqcbor.a in Frameworks */ = {isa = PBXBuildFile; fileRef = E7B72D7A2AE23DE400A0CD06 /* libqcbor.a */; };
-		E7B72D802AE23E7500A0CD06 /* libqcbor.a in Frameworks */ = {isa = PBXBuildFile; fileRef = E7B72D7A2AE23DE400A0CD06 /* libqcbor.a */; };
 		E7C960B527FC97A800FB537C /* libmbedcrypto.a in Frameworks */ = {isa = PBXBuildFile; fileRef = E751F9F027E1F90F00EBA5FA /* libmbedcrypto.a */; };
 		E7E36E7C226CB8400040613B /* main.c in Sources */ = {isa = PBXBuildFile; fileRef = E7E36E7B226CB8400040613B /* main.c */; };
 		E7E36E90226CB9460040613B /* t_cose_util.c in Sources */ = {isa = PBXBuildFile; fileRef = E7E36E89226CB9460040613B /* t_cose_util.c */; };
@@ -243,6 +243,7 @@
 		E730E60623612D2B00175CE0 /* sha256.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = sha256.h; path = b_con_hash/sha256.h; sourceTree = "<group>"; };
 		E730E60723612D2B00175CE0 /* sha256.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = sha256.c; path = b_con_hash/sha256.c; sourceTree = "<group>"; };
 		E730E62023612DAB00175CE0 /* t_cose_test */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = t_cose_test; sourceTree = BUILT_PRODUCTS_DIR; };
+		E73559BD2D30BECD0023A20A /* libqcbor.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libqcbor.a; path = ../../../../../usr/local/lib/libqcbor.a; sourceTree = "<group>"; };
 		E73BF6EE23AFFB4100DF5C36 /* PSA examples */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = "PSA examples"; sourceTree = BUILT_PRODUCTS_DIR; };
 		E73BF71C23B07ACF00DF5C36 /* Ossl examples */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = "Ossl examples"; sourceTree = BUILT_PRODUCTS_DIR; };
 		E73CDAC623A7316700D262E0 /* t_cose_psa */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = t_cose_psa; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -427,7 +428,6 @@
 		E7AE88FF29D54C000093B326 /* x509.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = x509.h; path = "../../mbedtls-2.28.0/include/mbedtls/x509.h"; sourceTree = "<group>"; };
 		E7AF703428DADF5E00F07637 /* t_cose_param_test.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = t_cose_param_test.h; sourceTree = "<group>"; };
 		E7AF703528DADF5E00F07637 /* t_cose_param_test.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = t_cose_param_test.c; sourceTree = "<group>"; };
-		E7B72D7A2AE23DE400A0CD06 /* libqcbor.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libqcbor.a; path = ../../../../../usr/local/lib/libqcbor.a; sourceTree = "<group>"; };
 		E7E36E78226CB8400040613B /* t_cose_openssl */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = t_cose_openssl; sourceTree = BUILT_PRODUCTS_DIR; };
 		E7E36E7B226CB8400040613B /* main.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = main.c; sourceTree = "<group>"; };
 		E7E36E89226CB9460040613B /* t_cose_util.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = t_cose_util.c; sourceTree = "<group>"; };
@@ -455,7 +455,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				E7B72D802AE23E7500A0CD06 /* libqcbor.a in Frameworks */,
+				E73559BE2D30BEFC0023A20A /* libqcbor.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -464,7 +464,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				E7FECC5328877DFE00420F6F /* libmbedcrypto.a in Frameworks */,
-				E7B72D7E2AE23DEA00A0CD06 /* libqcbor.a in Frameworks */,
+				E73559C12D30BEFE0023A20A /* libqcbor.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -473,7 +473,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				E7F17339293ED70E00E5ADF3 /* libcrypto.a in Frameworks */,
-				E7B72D7F2AE23DEA00A0CD06 /* libqcbor.a in Frameworks */,
+				E73559C22D30BEFF0023A20A /* libqcbor.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -482,7 +482,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				E7C960B527FC97A800FB537C /* libmbedcrypto.a in Frameworks */,
-				E7B72D7D2AE23DE900A0CD06 /* libqcbor.a in Frameworks */,
+				E73559C02D30BEFE0023A20A /* libqcbor.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -491,7 +491,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				E74FFBBA263BAB38003B66FF /* libcrypto.a in Frameworks */,
-				E7B72D7C2AE23DE900A0CD06 /* libqcbor.a in Frameworks */,
+				E73559BF2D30BEFD0023A20A /* libqcbor.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -899,7 +899,7 @@
 		E7F70AB22270D989007CE07F /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				E7B72D7A2AE23DE400A0CD06 /* libqcbor.a */,
+				E73559BD2D30BECD0023A20A /* libqcbor.a */,
 				E751F9F027E1F90F00EBA5FA /* libmbedcrypto.a */,
 				E74FFBB8263BAB0D003B66FF /* libcrypto.a */,
 			);
@@ -1364,7 +1364,7 @@
 				CLANG_WARN_CONSTANT_CONVERSION = YES;
 				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
-				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = NO;
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
 				CLANG_WARN_IMPLICIT_SIGN_CONVERSION = YES;
@@ -1430,7 +1430,7 @@
 				CLANG_WARN_CONSTANT_CONVERSION = YES;
 				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
-				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = NO;
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
 				CLANG_WARN_IMPLICIT_SIGN_CONVERSION = YES;

--- a/test/run_tests.c
+++ b/test/run_tests.c
@@ -85,7 +85,6 @@ static test_entry s_tests[] = {
 
 #ifndef T_COSE_DISABLE_COSE_SIGN
     TEST_ENTRY(verify_multi_test),
-    TEST_ENTRY(verify_multi_test),
     TEST_ENTRY(decode_only_multi_test),
     TEST_ENTRY(restart_test_2_step),
 #endif /* T_COSE_DISABLE_SIGN1 */

--- a/test/t_cose_compute_validate_mac_test.c
+++ b/test/t_cose_compute_validate_mac_test.c
@@ -1,7 +1,7 @@
 /*
  *  t_cose_compute_validate_mac_test.c
  *
- * Copyright 2019-2023, Laurence Lundblade
+ * Copyright 2019-2025, Laurence Lundblade
  * Copyright (c) 2022-2023, Arm Limited. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
@@ -15,6 +15,7 @@
 #include "t_cose/q_useful_buf.h"
 #include "t_cose_compute_validate_mac_test.h"
 #include "data/test_messages.h"
+#include "qcbor/qcbor_decode.h"
 
 
 #define KEY_hmac256 \
@@ -109,11 +110,12 @@ static int32_t compute_validate_basic_test_alg_mac(int32_t cose_alg)
 
     t_cose_mac_set_validate_key(&validate_ctx, key);
 
-    cose_res = t_cose_mac_validate(&validate_ctx,
+    cose_res = t_cose_mac_validate_msg(&validate_ctx,
                                     maced_cose,  /* COSE to validate */
                                     in_exp_sup_data,
                                    &out_payload, /* Payload from maced_cose */
-                                    NULL);
+                                    NULL,
+                                           NULL);
     if(cose_res != T_COSE_SUCCESS) {
         return_value = 5000 + (int32_t)cose_res;
         goto Done;
@@ -240,11 +242,11 @@ int32_t compute_validate_mac_fail_test(void)
 
     t_cose_mac_set_validate_key(&validate_ctx, key);
 
-    result = t_cose_mac_validate(&validate_ctx,
+    result = t_cose_mac_validate_msg(&validate_ctx,
                                   maced_cose, /* COSE to validate */
                                   NULL_Q_USEFUL_BUF_C,
                                  &payload,    /* Payload from maced_cose */
-                                  NULL);
+                                  NULL, NULL);
 
     if(result != T_COSE_ERR_HMAC_VERIFY) {
         return_value = 5000 + (int32_t)result;
@@ -500,11 +502,11 @@ int32_t compute_validate_known_good_test(void)
     /* Verify the COSE_Mac0 structure */
     t_cose_mac_validate_init(&validate_ctx, 0);
     t_cose_mac_set_validate_key(&validate_ctx, key);
-    cose_res = t_cose_mac_validate(&validate_ctx,
+    cose_res = t_cose_mac_validate_msg(&validate_ctx,
                                     maced_cose,  /* COSE to validate */
                                     NULL_Q_USEFUL_BUF_C,
                                    &payload_out, /* Payload from maced_cose */
-                                    NULL);
+                                    NULL, NULL);
     if (cose_res != T_COSE_SUCCESS) {
         return_value = 3000 + (int32_t)cose_res;
         goto Done;
@@ -527,11 +529,11 @@ int32_t compute_validate_known_good_test(void)
     T_COSE_PARAM_STORAGE_INIT(extra_params, _params);
     t_cose_mac_add_param_storage(&validate_ctx, &extra_params);
 
-    cose_res = t_cose_mac_validate(&validate_ctx,
+    cose_res = t_cose_mac_validate_msg(&validate_ctx,
                                     Q_USEFUL_BUF_FROM_BYTE_ARRAY_LITERAL(hmac_big_head),
                                     NULL_Q_USEFUL_BUF_C,
                                    &payload_out, /* Payload from maced_cose */
-                                   &returns_params);
+                                   &returns_params, NULL);
     if (cose_res != T_COSE_SUCCESS) {
         return_value = 3000 + (int32_t)cose_res;
         goto Done;
@@ -549,11 +551,11 @@ int32_t compute_validate_known_good_test(void)
     t_cose_mac_set_validate_key(&validate_ctx, key);
     t_cose_mac_add_param_storage(&validate_ctx, &extra_params);
 
-    cose_res = t_cose_mac_validate(&validate_ctx,
+    cose_res = t_cose_mac_validate_msg(&validate_ctx,
                                     Q_USEFUL_BUF_FROM_BYTE_ARRAY_LITERAL(hmac_error_header),
                                     NULL_Q_USEFUL_BUF_C,
                                    &payload_out, /* Payload from maced_cose */
-                                   &returns_params);
+                                   &returns_params, NULL);
     if (cose_res != T_COSE_ERR_CBOR_DECODE) {
         return_value = 5000 + (int32_t)cose_res;
         goto Done;
@@ -576,6 +578,7 @@ int32_t compute_validate_detached_content_mac_fail_test(void)
     struct t_cose_mac_calculate_ctx   mac_ctx;
     struct t_cose_mac_validate_ctx    validate_ctx;
     QCBOREncodeContext           cbor_encode;
+    QCBORDecodeContext           cbor_decode;
     int32_t                      return_value;
     enum t_cose_err_t            result;
     Q_USEFUL_BUF_MAKE_STACK_UB(  maced_cose_buffer, 300);
@@ -631,8 +634,10 @@ int32_t compute_validate_detached_content_mac_fail_test(void)
 
     t_cose_mac_set_validate_key(&validate_ctx, key);
 
+    QCBORDecode_Init(&cbor_decode, maced_cose, 0);
+
     result = t_cose_mac_validate_detached(&validate_ctx, /* in: me*/
-                                           maced_cose, /* in: COSE message to validate */
+                                          &cbor_decode, /* in: COSE message to validate */
                                            NULL_Q_USEFUL_BUF_C, /* in: AAD */
                                            Q_USEFUL_BUF_FROM_SZ_LITERAL("hayload"), /* in: detached payload */
                                           NULL); /* out: decoded parameters */

--- a/test/t_cose_compute_validate_mac_test.c
+++ b/test/t_cose_compute_validate_mac_test.c
@@ -15,7 +15,6 @@
 #include "t_cose/q_useful_buf.h"
 #include "t_cose_compute_validate_mac_test.h"
 #include "data/test_messages.h"
-#include "qcbor/qcbor_decode.h"
 
 
 #define KEY_hmac256 \
@@ -503,10 +502,11 @@ int32_t compute_validate_known_good_test(void)
     t_cose_mac_validate_init(&validate_ctx, 0);
     t_cose_mac_set_validate_key(&validate_ctx, key);
     cose_res = t_cose_mac_validate_msg(&validate_ctx,
-                                    maced_cose,  /* COSE to validate */
-                                    NULL_Q_USEFUL_BUF_C,
-                                   &payload_out, /* Payload from maced_cose */
-                                    NULL, NULL);
+                                        maced_cose,  /* COSE to validate */
+                                        NULL_Q_USEFUL_BUF_C,
+                                       &payload_out, /* Payload from maced_cose */
+                                        NULL,
+                                        NULL);
     if (cose_res != T_COSE_SUCCESS) {
         return_value = 3000 + (int32_t)cose_res;
         goto Done;
@@ -530,10 +530,10 @@ int32_t compute_validate_known_good_test(void)
     t_cose_mac_add_param_storage(&validate_ctx, &extra_params);
 
     cose_res = t_cose_mac_validate_msg(&validate_ctx,
-                                    Q_USEFUL_BUF_FROM_BYTE_ARRAY_LITERAL(hmac_big_head),
-                                    NULL_Q_USEFUL_BUF_C,
-                                   &payload_out, /* Payload from maced_cose */
-                                   &returns_params, NULL);
+                                        Q_USEFUL_BUF_FROM_BYTE_ARRAY_LITERAL(hmac_big_head),
+                                        NULL_Q_USEFUL_BUF_C,
+                                       &payload_out, /* Payload from maced_cose */
+                                       &returns_params, NULL);
     if (cose_res != T_COSE_SUCCESS) {
         return_value = 3000 + (int32_t)cose_res;
         goto Done;
@@ -552,10 +552,10 @@ int32_t compute_validate_known_good_test(void)
     t_cose_mac_add_param_storage(&validate_ctx, &extra_params);
 
     cose_res = t_cose_mac_validate_msg(&validate_ctx,
-                                    Q_USEFUL_BUF_FROM_BYTE_ARRAY_LITERAL(hmac_error_header),
-                                    NULL_Q_USEFUL_BUF_C,
-                                   &payload_out, /* Payload from maced_cose */
-                                   &returns_params, NULL);
+                                        Q_USEFUL_BUF_FROM_BYTE_ARRAY_LITERAL(hmac_error_header),
+                                        NULL_Q_USEFUL_BUF_C,
+                                       &payload_out, /* Payload from maced_cose */
+                                       &returns_params, NULL);
     if (cose_res != T_COSE_ERR_CBOR_DECODE) {
         return_value = 5000 + (int32_t)cose_res;
         goto Done;

--- a/test/t_cose_encrypt_decrypt_test.c
+++ b/test/t_cose_encrypt_decrypt_test.c
@@ -231,12 +231,12 @@ int32_t encrypt0_enc_dec(int32_t cose_algorithm_id)
     // TODO: header callbacks
 
     t_cose_err = t_cose_encrypt_dec_msg(&dec_ctx,
-                                     encrypted_cose_message,
-                                     ext_sup_data,
-                                     decrypted_payload_buf,
-                                    &decrypted_payload,
-                                    &decoded_parameters,
-                                        NULL);
+                                         encrypted_cose_message,
+                                         ext_sup_data,
+                                         decrypted_payload_buf,
+                                        &decrypted_payload,
+                                        &decoded_parameters,
+                                         NULL);
     if(t_cose_err) {
         return_value = 3000 + (int32_t)t_cose_err;
         goto Done;

--- a/test/t_cose_encrypt_decrypt_test.c
+++ b/test/t_cose_encrypt_decrypt_test.c
@@ -857,7 +857,7 @@ int32_t decrypt_known_bad(void)
 
     for(i = 0; test_list[i].sz_description != NULL; i++) {
         const struct decrypt_test *t = &test_list[i];
-        const char *test_to_break_on = "wrong tag n";
+        const char *test_to_break_on = "wrong tag";
         if(!strncmp(t->sz_description, test_to_break_on, strlen(test_to_break_on))){
             /* For setting break point for a particular test */
             result = 99;

--- a/test/t_cose_encrypt_decrypt_test.c
+++ b/test/t_cose_encrypt_decrypt_test.c
@@ -270,7 +270,6 @@ int32_t encrypt0_enc_dec(int32_t cose_algorithm_id)
         goto Done;
     }
 
-    // TODO: fix this
     t_cose_encrypt_dec_init(&dec_ctx, T_COSE_OPT_MESSAGE_TYPE_UNSPECIFIED);
     t_cose_encrypt_dec_set_cek(&dec_ctx, cek);
     t_cose_err = t_cose_encrypt_dec_detached_msg(&dec_ctx,

--- a/test/t_cose_encrypt_decrypt_test.c
+++ b/test/t_cose_encrypt_decrypt_test.c
@@ -212,7 +212,7 @@ int32_t encrypt0_enc_dec(int32_t cose_algorithm_id)
     }
 
 
-    t_cose_encrypt_dec_init(&dec_ctx, T_COSE_OPT_MESSAGE_TYPE_ENCRYPT0);
+    t_cose_encrypt_dec_init(&dec_ctx, T_COSE_OPT_MESSAGE_TYPE_UNSPECIFIED);
 
     t_cose_encrypt_dec_set_cek(&dec_ctx, cek);
 
@@ -230,12 +230,13 @@ int32_t encrypt0_enc_dec(int32_t cose_algorithm_id)
 
     // TODO: header callbacks
 
-    t_cose_err = t_cose_encrypt_dec(&dec_ctx,
+    t_cose_err = t_cose_encrypt_dec_msg(&dec_ctx,
                                      encrypted_cose_message,
                                      ext_sup_data,
                                      decrypted_payload_buf,
                                     &decrypted_payload,
-                                    &decoded_parameters);
+                                    &decoded_parameters,
+                                        NULL);
     if(t_cose_err) {
         return_value = 3000 + (int32_t)t_cose_err;
         goto Done;
@@ -269,6 +270,8 @@ int32_t encrypt0_enc_dec(int32_t cose_algorithm_id)
         goto Done;
     }
 
+#if 0
+    // TODO: fix this
     t_cose_encrypt_dec_init(&dec_ctx, T_COSE_OPT_MESSAGE_TYPE_ENCRYPT0);
     t_cose_encrypt_dec_set_cek(&dec_ctx, cek);
     t_cose_err = t_cose_encrypt_dec_detached(&dec_ctx,
@@ -286,6 +289,7 @@ int32_t encrypt0_enc_dec(int32_t cose_algorithm_id)
         return_value = -8;
         goto Done;
     }
+#endif
 
 
 Done:
@@ -374,17 +378,18 @@ int32_t decrypt_key_wrap(struct q_useful_buf_c cose_encrypt_buffer)
         goto Done2;
     }
 
-    t_cose_encrypt_dec_init(&decrypt_context, T_COSE_OPT_MESSAGE_TYPE_ENCRYPT);
+    t_cose_encrypt_dec_init(&decrypt_context, T_COSE_OPT_MESSAGE_TYPE_UNSPECIFIED);
     t_cose_recipient_dec_keywrap_init(&kw_unwrap_recipient);
     t_cose_recipient_dec_keywrap_set_kek(&kw_unwrap_recipient, kek, NULL_Q_USEFUL_BUF_C);
     t_cose_encrypt_dec_add_recipient(&decrypt_context, (struct t_cose_recipient_dec *)&kw_unwrap_recipient);
 
-    result = t_cose_encrypt_dec(&decrypt_context,
-                                cose_encrypt_buffer,
-                                NULL_Q_USEFUL_BUF_C,
-                                decrypted_buffer,
-                                &decrypted_payload,
-                                &params);
+    result = t_cose_encrypt_dec_msg(&decrypt_context,
+                                     cose_encrypt_buffer,
+                                     NULL_Q_USEFUL_BUF_C,
+                                     decrypted_buffer,
+                                    &decrypted_payload,
+                                    &params,
+                                     NULL);
 
     if(result != T_COSE_SUCCESS) {
         return_value = 2000 + (int32_t)result;
@@ -516,12 +521,13 @@ esdh_enc_dec(int32_t curve, int32_t payload_cose_algorithm_id)
     t_cose_encrypt_dec_add_recipient(&dec_ctx,
                                      (struct t_cose_recipient_dec *)&dec_recipient);
 
-    result = t_cose_encrypt_dec(&dec_ctx,
-                                 cose_encrypted_message,
-                                 NULL_Q_USEFUL_BUF_C, /* in/unused: AAD */
-                                 decrypted_buffer,
-                                &decrypted_payload,
-                                &params);
+    result = t_cose_encrypt_dec_msg(&dec_ctx,
+                                     cose_encrypted_message,
+                                     NULL_Q_USEFUL_BUF_C, /* in/unused: AAD */
+                                     decrypted_buffer,
+                                    &decrypted_payload,
+                                    &params,
+                                     NULL);
     if(result != T_COSE_SUCCESS) {
         goto Done;
     }
@@ -609,12 +615,13 @@ int32_t decrypt_known_good(void)
     t_cose_encrypt_dec_add_recipient(&dec_ctx,
                                      (struct t_cose_recipient_dec *)&dec_recipient);
 
-    result = t_cose_encrypt_dec(&dec_ctx,
-                                UsefulBuf_FROM_BYTE_ARRAY_LITERAL(cose_encrypt_p256_wrap_128), /* in: message to decrypt */
-                                NULL_Q_USEFUL_BUF_C, /* in/unused: AAD */
-                                decrypted_buffer,
-                                &decrypted_payload,
-                                &params);
+    result = t_cose_encrypt_dec_msg(&dec_ctx,
+                                     UsefulBuf_FROM_BYTE_ARRAY_LITERAL(cose_encrypt_p256_wrap_128), /* in: message to decrypt */
+                                     NULL_Q_USEFUL_BUF_C, /* in/unused: AAD */
+                                     decrypted_buffer,
+                                    &decrypted_payload,
+                                    &params,
+                                     NULL);
 
     if(result != T_COSE_SUCCESS) {
         return (int32_t)result + 2000;
@@ -674,12 +681,13 @@ int32_t run_decrypt_test(const struct decrypt_test *test)
     t_cose_encrypt_dec_add_recipient(&dec_ctx,
                                      (struct t_cose_recipient_dec *)&dec_recipient);
 
-    result = t_cose_encrypt_dec(&dec_ctx,
-                                test->message, /* in: message to decrypt */
-                                NULL_Q_USEFUL_BUF_C, /* in/unused: AAD */
-                                decrypted_buffer,
-                                &decrypted_payload,
-                                &params);
+    result = t_cose_encrypt_dec_msg(&dec_ctx,
+                                     test->message, /* in: message to decrypt */
+                                     NULL_Q_USEFUL_BUF_C, /* in/unused: AAD */
+                                     decrypted_buffer,
+                                    &decrypted_payload,
+                                    &params,
+                                     NULL);
 
     free_fixed_test_ec_encryption_key(pubkey);
     free_fixed_test_ec_encryption_key(privatekey);
@@ -849,7 +857,7 @@ int32_t decrypt_known_bad(void)
 
     for(i = 0; test_list[i].sz_description != NULL; i++) {
         const struct decrypt_test *t = &test_list[i];
-        const char *test_to_break_on = "one recipient array is a map";
+        const char *test_to_break_on = "wrong tag n";
         if(!strncmp(t->sz_description, test_to_break_on, strlen(test_to_break_on))){
             /* For setting break point for a particular test */
             result = 99;
@@ -973,12 +981,13 @@ kdf_instance_test(int32_t                             ecdh_alg,
     kdf_ctx_buf.len = enc_items->kdf_context_size;
     t_cose_recipient_dec_esdh_kdf_buf(&dec_recipient, kdf_ctx_buf);
 
-    result = t_cose_encrypt_dec(&dec_ctx,
-                                cose_encrypted_message,
-                                NULL_Q_USEFUL_BUF_C, /* in/unused: AAD */
-                                decrypted_buffer,
-                                &decrypted_payload,
-                                &params);
+    result = t_cose_encrypt_dec_msg(&dec_ctx,
+                                     cose_encrypted_message,
+                                     NULL_Q_USEFUL_BUF_C, /* in/unused: AAD */
+                                     decrypted_buffer,
+                                    &decrypted_payload,
+                                    &params,
+                                     NULL);
 Done:
     free_fixed_test_ec_encryption_key(publickey);
     free_fixed_test_ec_encryption_key(privatekey);

--- a/test/t_cose_encrypt_decrypt_test.c
+++ b/test/t_cose_encrypt_decrypt_test.c
@@ -270,17 +270,17 @@ int32_t encrypt0_enc_dec(int32_t cose_algorithm_id)
         goto Done;
     }
 
-#if 0
     // TODO: fix this
-    t_cose_encrypt_dec_init(&dec_ctx, T_COSE_OPT_MESSAGE_TYPE_ENCRYPT0);
+    t_cose_encrypt_dec_init(&dec_ctx, T_COSE_OPT_MESSAGE_TYPE_UNSPECIFIED);
     t_cose_encrypt_dec_set_cek(&dec_ctx, cek);
-    t_cose_err = t_cose_encrypt_dec_detached(&dec_ctx,
-                                              encrypted_cose_message,
-                                              NULL_Q_USEFUL_BUF_C,
-                                              encrypted_detached,
-                                              decrypted_payload_buf,
-                                             &decrypted_payload,
-                                             NULL);
+    t_cose_err = t_cose_encrypt_dec_detached_msg(&dec_ctx,
+                                                  encrypted_cose_message,
+                                                  NULL_Q_USEFUL_BUF_C,
+                                                  encrypted_detached,
+                                                  decrypted_payload_buf,
+                                                 &decrypted_payload,
+                                                  NULL,
+                                                  NULL);
     if(t_cose_err) {
         return_value = 7000 + (int32_t)t_cose_err;
         goto Done;
@@ -289,7 +289,6 @@ int32_t encrypt0_enc_dec(int32_t cose_algorithm_id)
         return_value = -8;
         goto Done;
     }
-#endif
 
 
 Done:

--- a/test/t_cose_sign_verify_test.c
+++ b/test/t_cose_sign_verify_test.c
@@ -1306,11 +1306,11 @@ int32_t verify_multi_test(void)
     t_cose_sign_add_verifier(&verify_ctx, (struct t_cose_signature_verify *)&verify_rsa);
 
     err = t_cose_sign_verify_msg(&verify_ctx,
-                              cose_sign,
-                              Q_USEFUL_BUF_FROM_SZ_LITERAL("SAMPLE AAD"),
-                             &payload,
-                              NULL,
-                                 NULL);
+                                  cose_sign,
+                                  Q_USEFUL_BUF_FROM_SZ_LITERAL("SAMPLE AAD"),
+                                 &payload,
+                                  NULL,
+                                  NULL);
 
     if(err) {
         return 3;
@@ -1380,11 +1380,11 @@ int32_t decode_only_multi_test(void)
     t_cose_sign_add_param_storage(&verify_ctx, &st);
 
     err = t_cose_sign_verify_msg(&verify_ctx,
-                              cose_sign,
-                              Q_USEFUL_BUF_FROM_SZ_LITERAL("SAMPLE AAD"),
-                             &payload,
-                             &decoded_params,
-                                 NULL);
+                                  cose_sign,
+                                  Q_USEFUL_BUF_FROM_SZ_LITERAL("SAMPLE AAD"),
+                                 &payload,
+                                 &decoded_params,
+                                  NULL);
 
     if(err) {
         return 2000 + (int32_t)err;
@@ -1432,11 +1432,11 @@ int32_t decode_only_multi_test(void)
      t_cose_sign_add_verifier(&verify_ctx, (struct t_cose_signature_verify *)&verify_eddsa);
 
      err = t_cose_sign_verify_msg(&verify_ctx,
-                               cose_sign,
-                               Q_USEFUL_BUF_FROM_SZ_LITERAL("SAMPLE AAD"),
-                              &payload,
-                              &decoded_params,
-                                  NULL);
+                                   cose_sign,
+                                   Q_USEFUL_BUF_FROM_SZ_LITERAL("SAMPLE AAD"),
+                                  &payload,
+                                  &decoded_params,
+                                   NULL);
 
      if(err) {
          return 4000 + (int32_t)err;
@@ -1458,11 +1458,11 @@ int32_t decode_only_multi_test(void)
      t_cose_sign_add_verifier(&verify_ctx, (struct t_cose_signature_verify *)&verify_eddsa);
 
      err = t_cose_sign_verify_msg(&verify_ctx,
-                               cose_sign,
-                               Q_USEFUL_BUF_FROM_SZ_LITERAL("SAMPLE AAD"),
-                              &payload,
-                              &decoded_params,
-                                  NULL);
+                                   cose_sign,
+                                   Q_USEFUL_BUF_FROM_SZ_LITERAL("SAMPLE AAD"),
+                                  &payload,
+                                  &decoded_params,
+                                   NULL);
 
      if(err) {
          return 5000 + (int32_t)err;

--- a/test/t_cose_sign_verify_test.c
+++ b/test/t_cose_sign_verify_test.c
@@ -1150,11 +1150,11 @@ int32_t sign_verify_multi(void)
     t_cose_sign_add_verifier(&verify_ctx, (struct t_cose_signature_verify *)&verify2);
 
     result = t_cose_sign_verify_msg(&verify_ctx,
-                                 signed_cose,
-                                 NULL_Q_USEFUL_BUF_C,
-                                &verified_payload,
-                                 NULL,
-                                    NULL);
+                                     signed_cose,
+                                     NULL_Q_USEFUL_BUF_C,
+                                    &verified_payload,
+                                     NULL,
+                                     NULL);
 
     if(result) {
         return 3;
@@ -1406,11 +1406,11 @@ int32_t decode_only_multi_test(void)
     t_cose_sign_add_verifier(&verify_ctx, (struct t_cose_signature_verify *)&verify_rsa);
 
     err = t_cose_sign_verify_msg(&verify_ctx,
-                              cose_sign,
-                              Q_USEFUL_BUF_FROM_SZ_LITERAL("SAMPLE AAD"),
-                             &payload,
-                             &decoded_params,
-                                 NULL);
+                                  cose_sign,
+                                  Q_USEFUL_BUF_FROM_SZ_LITERAL("SAMPLE AAD"),
+                                 &payload,
+                                 &decoded_params,
+                                  NULL);
 
     if(err) {
         return 3000 + (int32_t)err;

--- a/test/t_cose_sign_verify_test.c
+++ b/test/t_cose_sign_verify_test.c
@@ -1149,11 +1149,12 @@ int32_t sign_verify_multi(void)
     t_cose_signature_verify_main_set_key(&verify2, key_pair2, Q_USEFUL_BUF_FROM_SZ_LITERAL("kid2"));
     t_cose_sign_add_verifier(&verify_ctx, (struct t_cose_signature_verify *)&verify2);
 
-    result = t_cose_sign_verify(&verify_ctx,
+    result = t_cose_sign_verify_msg(&verify_ctx,
                                  signed_cose,
                                  NULL_Q_USEFUL_BUF_C,
                                 &verified_payload,
-                                 NULL);
+                                 NULL,
+                                    NULL);
 
     if(result) {
         return 3;
@@ -1254,7 +1255,7 @@ int32_t verify_multi_test(void)
     struct t_cose_sign_verify_ctx  verify_ctx;
     struct q_useful_buf_c payload;
 
-    t_cose_sign_verify_init(&verify_ctx, T_COSE_OPT_MESSAGE_TYPE_SIGN | T_COSE_OPT_VERIFY_ALL_SIGNATURES);
+    t_cose_sign_verify_init(&verify_ctx,  T_COSE_OPT_VERIFY_ALL_SIGNATURES);
 
     struct t_cose_parameter_storage st;
     T_COSE_PARAM_STORAGE_INIT(st, param_pool);
@@ -1270,11 +1271,12 @@ int32_t verify_multi_test(void)
                                           Q_USEFUL_BUF_FROM_SZ_LITERAL("ecsda_kid"));
     t_cose_sign_add_verifier(&verify_ctx, (struct t_cose_signature_verify *)&verify_ecdsa);
 
-    err = t_cose_sign_verify(&verify_ctx,
-                              cose_sign,
-                              Q_USEFUL_BUF_FROM_SZ_LITERAL("SAMPLE AAD"),
-                             &payload,
-                              NULL);
+    err = t_cose_sign_verify_msg(&verify_ctx,
+                                  cose_sign,
+                                  Q_USEFUL_BUF_FROM_SZ_LITERAL("SAMPLE AAD"),
+                                 &payload,
+                                  NULL,
+                                  NULL);
 
     /* Not all verifier were configured, but verify all was requested so
      * decline is expected */
@@ -1303,11 +1305,12 @@ int32_t verify_multi_test(void)
                                           Q_USEFUL_BUF_FROM_SZ_LITERAL("rsa_kid"));
     t_cose_sign_add_verifier(&verify_ctx, (struct t_cose_signature_verify *)&verify_rsa);
 
-    err = t_cose_sign_verify(&verify_ctx,
+    err = t_cose_sign_verify_msg(&verify_ctx,
                               cose_sign,
                               Q_USEFUL_BUF_FROM_SZ_LITERAL("SAMPLE AAD"),
                              &payload,
-                              NULL);
+                              NULL,
+                                 NULL);
 
     if(err) {
         return 3;
@@ -1372,15 +1375,16 @@ int32_t decode_only_multi_test(void)
     }
 
     /* --- First run with no verifiers ---- */
-    t_cose_sign_verify_init(&verify_ctx, T_COSE_OPT_MESSAGE_TYPE_SIGN | T_COSE_OPT_DECODE_ONLY);
+    t_cose_sign_verify_init(&verify_ctx, T_COSE_OPT_DECODE_ONLY);
     T_COSE_PARAM_STORAGE_INIT(st, param_pool);
     t_cose_sign_add_param_storage(&verify_ctx, &st);
 
-    err = t_cose_sign_verify(&verify_ctx,
+    err = t_cose_sign_verify_msg(&verify_ctx,
                               cose_sign,
                               Q_USEFUL_BUF_FROM_SZ_LITERAL("SAMPLE AAD"),
                              &payload,
-                             &decoded_params);
+                             &decoded_params,
+                                 NULL);
 
     if(err) {
         return 2000 + (int32_t)err;
@@ -1401,11 +1405,12 @@ int32_t decode_only_multi_test(void)
     t_cose_signature_verify_main_init(&verify_rsa);
     t_cose_sign_add_verifier(&verify_ctx, (struct t_cose_signature_verify *)&verify_rsa);
 
-    err = t_cose_sign_verify(&verify_ctx,
+    err = t_cose_sign_verify_msg(&verify_ctx,
                               cose_sign,
                               Q_USEFUL_BUF_FROM_SZ_LITERAL("SAMPLE AAD"),
                              &payload,
-                             &decoded_params);
+                             &decoded_params,
+                                 NULL);
 
     if(err) {
         return 3000 + (int32_t)err;
@@ -1426,11 +1431,12 @@ int32_t decode_only_multi_test(void)
      t_cose_signature_verify_eddsa_init(&verify_eddsa, 0);
      t_cose_sign_add_verifier(&verify_ctx, (struct t_cose_signature_verify *)&verify_eddsa);
 
-     err = t_cose_sign_verify(&verify_ctx,
+     err = t_cose_sign_verify_msg(&verify_ctx,
                                cose_sign,
                                Q_USEFUL_BUF_FROM_SZ_LITERAL("SAMPLE AAD"),
                               &payload,
-                              &decoded_params);
+                              &decoded_params,
+                                  NULL);
 
      if(err) {
          return 4000 + (int32_t)err;
@@ -1451,11 +1457,12 @@ int32_t decode_only_multi_test(void)
      t_cose_signature_verify_eddsa_init(&verify_eddsa, 0);
      t_cose_sign_add_verifier(&verify_ctx, (struct t_cose_signature_verify *)&verify_eddsa);
 
-     err = t_cose_sign_verify(&verify_ctx,
+     err = t_cose_sign_verify_msg(&verify_ctx,
                                cose_sign,
                                Q_USEFUL_BUF_FROM_SZ_LITERAL("SAMPLE AAD"),
                               &payload,
-                              &decoded_params);
+                              &decoded_params,
+                                  NULL);
 
      if(err) {
          return 5000 + (int32_t)err;

--- a/test/t_cose_test.c
+++ b/test/t_cose_test.c
@@ -2225,7 +2225,7 @@ int32_t crypto_context_test(void)
     t_cose_signature_verify_main_set_key(&verifier, key_pair, NULL_Q_USEFUL_BUF_C);
     t_cose_signature_verify_main_set_crypto_context(&verifier, &crypto_context);
     crypto_context.test_error = T_COSE_SUCCESS;
-    t_cose_sign_verify_init(&verify_ctx, T_COSE_OPT_MESSAGE_TYPE_SIGN1);
+    t_cose_sign_verify_init(&verify_ctx, 0);
     t_cose_sign_add_verifier(&verify_ctx,
                              t_cose_signature_verify_from_main(&verifier));
     result = t_cose_sign_verify_msg(&verify_ctx,

--- a/test/t_cose_test.c
+++ b/test/t_cose_test.c
@@ -1537,10 +1537,10 @@ int32_t sign1_structure_decode_test(void)
 
 
         result = t_cose_sign_verify_msg(&verify_ctx,
-                                     cose_sign,
-                                     Q_USEFUL_BUF_FROM_SZ_LITERAL("AAD"),
-                                    &payload,
-                                    &decoded_params,
+                                        cose_sign,
+                                        Q_USEFUL_BUF_FROM_SZ_LITERAL("AAD"),
+                                       &payload,
+                                       &decoded_params,
                                         NULL);
         if(result != T_COSE_SUCCESS) {
             return -99;
@@ -2229,14 +2229,11 @@ int32_t crypto_context_test(void)
     t_cose_sign_add_verifier(&verify_ctx,
                              t_cose_signature_verify_from_main(&verifier));
     result = t_cose_sign_verify_msg(&verify_ctx,
-                                /* COSE to verify */
-                                good_signed_cose,
-                                NULL_Q_USEFUL_BUF_C,
-                                /* The returned payload */
-                                &payload,
-                                /* Don't return parameters */
-                                NULL,
-                                    NULL);
+                                     good_signed_cose, /* COSE to verify */
+                                     NULL_Q_USEFUL_BUF_C, /* No ext sup  data*/
+                                    &payload, /* The returned payload */
+                                     NULL, /* Don't return parameters */
+                                     NULL/* Don't care about tag numbers */);
     if(result) {
         return 2000 + (int32_t)result;
     }
@@ -2251,14 +2248,11 @@ int32_t crypto_context_test(void)
     crypto_context.test_error = 18; /* 18 just picked to make test work */
     /* Run the signature verification */
     result = t_cose_sign_verify_msg(&verify_ctx,
-                                /* COSE to verify */
-                                good_signed_cose,
-                                NULL_Q_USEFUL_BUF_C,
-                                /* The returned payload */
-                                &payload,
-                                /* Don't return parameters */
-                                NULL,
-                                    NULL);
+                                     good_signed_cose, /* COSE to verify */
+                                     NULL_Q_USEFUL_BUF_C, /* No ext sup  data*/
+                                    &payload, /* The returned payload */
+                                     NULL, /* Don't return parameters */
+                                     NULL/* Don't care about tag numbers */);
     if(result != 18) {
         return 2000 + (int32_t)result;
     }

--- a/test/t_cose_test.c
+++ b/test/t_cose_test.c
@@ -813,12 +813,11 @@ int32_t all_header_parameters_test(void)
                                  key_pair,
                                  Q_USEFUL_BUF_FROM_SZ_LITERAL("11"));
 
-    result =
-        t_cose_test_message_sign1_sign(&sign_ctx,
-                                       T_COSE_TEST_ALL_PARAMETERS,
-                                       s_input_payload,
-                                       signed_cose_buffer,
-                                      &output);
+    result = t_cose_test_message_sign1_sign(&sign_ctx,
+                                             T_COSE_TEST_ALL_PARAMETERS,
+                                             s_input_payload,
+                                             signed_cose_buffer,
+                                            &output);
     if(result) {
         return 1;
     }
@@ -828,12 +827,10 @@ int32_t all_header_parameters_test(void)
 
 
     result = t_cose_sign1_verify(&verify_ctx,
-                                       /* COSE to verify */
-                                       output,
-                                       /* The returned payload */
-                                       &payload,
-                                       /* Get parameters for checking */
-                                       &parameters);
+                                  output, /* COSE message to verify */
+                                 &payload, /* The returned payload */
+                                 &parameters/* Get parameters for checking */
+                                 );
     if(result) {
         return -2;
     }
@@ -920,6 +917,9 @@ int32_t bad_parameters_test(void)
         test = &bad_parameters_tests_table[n];
         if(!test->test_option) {
             break;
+        }
+        if(n == 0) {
+            err = 11; // To set a break point
         }
         err = run_test_sign_and_verify(test->test_option, test->verify_option);
         if(err != test->result) {
@@ -1536,11 +1536,12 @@ int32_t sign1_structure_decode_test(void)
         t_cose_sign_add_param_storage(&verify_ctx, &extra_params);
 
 
-        result = t_cose_sign_verify(&verify_ctx,
+        result = t_cose_sign_verify_msg(&verify_ctx,
                                      cose_sign,
                                      Q_USEFUL_BUF_FROM_SZ_LITERAL("AAD"),
                                     &payload,
-                                    &decoded_params);
+                                    &decoded_params,
+                                        NULL);
         if(result != T_COSE_SUCCESS) {
             return -99;
         }
@@ -1554,7 +1555,7 @@ int32_t sign1_structure_decode_test(void)
 
 
     for(int i = 0; !q_useful_buf_c_is_null(sign1_sample_inputs[i].CBOR); i++) {
-        if(i == 7) {
+        if(i == 9) {
             result = 9;
         }
 
@@ -2227,14 +2228,15 @@ int32_t crypto_context_test(void)
     t_cose_sign_verify_init(&verify_ctx, T_COSE_OPT_MESSAGE_TYPE_SIGN1);
     t_cose_sign_add_verifier(&verify_ctx,
                              t_cose_signature_verify_from_main(&verifier));
-    result = t_cose_sign_verify(&verify_ctx,
+    result = t_cose_sign_verify_msg(&verify_ctx,
                                 /* COSE to verify */
                                 good_signed_cose,
                                 NULL_Q_USEFUL_BUF_C,
                                 /* The returned payload */
                                 &payload,
                                 /* Don't return parameters */
-                                NULL);
+                                NULL,
+                                    NULL);
     if(result) {
         return 2000 + (int32_t)result;
     }
@@ -2248,14 +2250,15 @@ int32_t crypto_context_test(void)
     /* __4__ See failure when crypto context is set for failure  */
     crypto_context.test_error = 18; /* 18 just picked to make test work */
     /* Run the signature verification */
-    result = t_cose_sign_verify(&verify_ctx,
+    result = t_cose_sign_verify_msg(&verify_ctx,
                                 /* COSE to verify */
                                 good_signed_cose,
                                 NULL_Q_USEFUL_BUF_C,
                                 /* The returned payload */
                                 &payload,
                                 /* Don't return parameters */
-                                NULL);
+                                NULL,
+                                    NULL);
     if(result != 18) {
         return 2000 + (int32_t)result;
     }


### PR DESCRIPTION
This is a breaking change in the t_cose v2 API, but it is not difficult to adapt to it. To adapt, switch from t_cose_sign_verify() to t_cose_sign_verify_msg() with an additional parameter if tag numbers are expected or NULL if not. 

The main entry points for verify/validate/decrypt are changed to take a QCBORDecodeContext from which to read the message to decode. This makes them simpler inside and more flexible for the caller.

A new additional entry point for verify/validate/decrypt is added with the name ending in _msg that takes the 
pointer and length like the old main entry points. This also returns all the tag numbers. t_cose_mac_validate_nth_tag()
is removed and the size of the verify/validate/decrypt context is reduced.

This commit make t_cose compatible with QCBOR v2, which does tag number decoding in a different way than
QCBOR v1. This commit also continues to work with QCBOR v1 and the sign1 APIs are still compatible with t_cose v1.

