### PR TITLE
Add content type validation as specified in RFC 9052

### DIFF
--- a/src/t_cose_sign1_sign.c
+++ b/src/t_cose_sign1_sign.c
@@ -153,6 +153,12 @@ add_unprotected_parameters(const struct t_cose_sign1_sign_ctx *me,
     }
 
     if(me->content_type_tstr != NULL) {
+        /* If the content type is a string, it must be a valid content type string. */
+        enum t_cose_err_t return_value = vaildate_content_type(me->content_type_tstr);
+        if(return_value != T_COSE_SUCCESS) {
+            return return_value;
+        }
+        /* Add the content type string */
         QCBOREncode_AddSZStringToMapN(cbor_encode_ctx,
                                       COSE_HEADER_PARAM_CONTENT_TYPE,
                                       me->content_type_tstr);

--- a/src/t_cose_util.c
+++ b/src/t_cose_util.c
@@ -284,5 +284,49 @@ struct q_useful_buf_c get_short_circuit_kid(void)
 
     return short_circuit_kid;
 }
+#endif
 
+#ifndef T_COSE_DISABLE_CONTENT_TYPE
+
+/**
+ * Public function. See t_cose_util.h
+ */
+enum t_cose_err_t vaildate_content_type(const char *str)
+{
+    enum t_cose_err_t           return_value;
+    int i = 0;
+    int slash_index = -1;
+
+    if (is_space(str[0])) {
+        return T_COSE_ERR_BAD_CONTENT_TYPE;
+    }
+
+    while (str[i] != '\0') {
+        if (str[i] == '/') {
+            if (slash_index != -1) { // More than one slash?
+                return T_COSE_ERR_BAD_CONTENT_TYPE;
+            }
+            slash_index = i;
+        }
+        i++;
+    }
+
+    if (slash_index == -1) { // No slash?
+        return T_COSE_ERR_BAD_CONTENT_TYPE;
+    }else if (slash_index == 0 || str[slash_index + 1] == '\0') {
+        // Slash at the start or end?
+        return T_COSE_ERR_BAD_CONTENT_TYPE;
+    } else if (is_space(str[slash_index - 1]) || is_space(str[slash_index + 1])) {
+        // Check for spaces before and after the slash
+        return T_COSE_ERR_BAD_CONTENT_TYPE;
+    }
+
+    int last = i - 1;
+    if (is_space(str[last])){
+        // Space at the end
+        return T_COSE_ERR_BAD_CONTENT_TYPE;
+    }
+
+    return T_COSE_SUCCESS;
+}
 #endif

--- a/src/t_cose_util.h
+++ b/src/t_cose_util.h
@@ -193,6 +193,32 @@ enum t_cose_err_t create_tbs(struct q_useful_buf_c  protected_parameters,
 struct q_useful_buf_c get_short_circuit_kid(void);
 #endif
 
+#ifndef T_COSE_DISABLE_CONTENT_TYPE
+
+/**
+ * \brief validate and normalize a content type string
+ *
+ * Ensures the input is non-empty, has exactly one '/', and no leading,
+ * trailing, or surrounding whitespace. Both <type> and <subtype> must be
+ * present. Follows the syntax rules from RFC 6838 and CoAP Content-Formats.
+ */
+enum t_cose_err_t vaildate_content_type(const char *str);
+
+/**
+ * \brief Check if a character is a space.
+ *
+ * This function is used as a helper for \ref vaildate_content_type.
+ *
+ * \param c Character to check
+ * \return Non-zero if the character is a space.
+ */
+inline int is_space(char c)
+{
+    return c == ' ' || c == '\t' || c == '\n' || c == '\r';
+}
+
+#endif /* T_COSE_DISABLE_CONTENT_TYPE */
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
Implemented validation for textual content type values to ensure they follow the `<type-name>/<subtype-name>` format as required by RFC 9052, Section 3.2.

Currently, setting a content type is allowed when signing a message. When encryption and the other functionalities are implemented/merged, setting a content type must be moved somewhere else, right?

I've put the validation in `util` just so that it can be used in the future when content type can be used across the library.
