### PR TITLE
Add some missing OpenSSL includes

### DIFF
--- a/crypto_adapters/t_cose_openssl_crypto.c
+++ b/crypto_adapters/t_cose_openssl_crypto.c
@@ -13,6 +13,8 @@
 
 #include "t_cose_crypto.h" /* The interface this code implements */
 
+#include <openssl/bn.h>
+#include <openssl/crypto.h>
 #include <openssl/ecdsa.h> /* Needed for signature format conversion */
 #include <openssl/rsa.h>
 #include <openssl/evp.h>


### PR DESCRIPTION
The `BN_*` functions live in `<openssl/bn.h>`. `OPENSSL_free` lives in `<openssl/crypto.h>`. This was previously depending on some transitive includes.