### PR TITLE
More CI fixes, mostly for windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -252,7 +252,8 @@ jobs:
         ref: ${{ matrix.qcbor-version }}
         path: QCBOR
 
-    - name: Configure QCBOR
+    - name: Configure Q        qcbor-version: [master, dev]
+CBOR
       shell: bash
       run: |
         cd QCBOR
@@ -305,6 +306,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        qcbor-version: [master, dev]
+
         # TODO: add OPenSSL back in when we figure out why it is broken
         crypto: [ Test, MbedTLS ]
     
@@ -350,7 +353,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: laurencelundblade/QCBOR
-          ref: master
+          ref: ${{ matrix.qcbor-version }}
           path: QCBOR
 
       - name: Configure QCBOR Win

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,7 @@ jobs:
 
         config:
           - os-image: ubuntu-latest
-            container: ubuntu:22.04
+          # Intentionally not using a container to have less problems with libc and python versions
 
     name: ${{ matrix.crypto.interface}} • ${{ matrix.crypto.provider }} • ${{matrix.crypto.version}} • ${{ matrix.c-compiler }} • ${{ matrix.qcbor-version }} • ${{ matrix.ifdef }}
 
@@ -223,7 +223,7 @@ jobs:
 
         config:
           - os-image: ubuntu-latest
-            container: ubuntu:22.04
+          # Intentionally not using a container to have less problems with libc and python versions
 
     name: ${{ matrix.crypto.interface}} • ${{ matrix.crypto.provider }} • ${{matrix.crypto.version}} • ${{ matrix.c-compiler }} • ${{ matrix.qcbor-version }} • ${{ matrix.ifdef }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -320,10 +320,10 @@ jobs:
             cmake: -DCMAKE_TOOLCHAIN_FILE=build/conan_toolchain.cmake
 
 #TODO: switch to later version of OpenSSL
-#          - interface: OpenSSL
-#            provider: OpenSSL
-#            version: 1.1.1v
-#            cmake: -DCMAKE_TOOLCHAIN_FILE=build/conan_toolchain.cmake
+          - interface: OpenSSL
+            provider: OpenSSL
+            version: 1.1.1v
+            cmake: -DCMAKE_TOOLCHAIN_FILE=build/conan_toolchain.cmake
     
     name: ${{ matrix.crypto.interface}} • ${{ matrix.crypto.provider }} • ${{matrix.crypto.version}} • MSVC • ${{ matrix.qcbor-version }} 
 
@@ -350,6 +350,17 @@ jobs:
 
       - name: Detect Conan profile
         run: conan profile detect --force
+
+      - name: Install OpenSSL
+        if: matrix.crypto.provider == 'OpenSSL'
+        run: |
+          conan install \
+            --requires=openssl/${{ matrix.crypto.version }} \
+            --output-folder=build \
+            --build=missing \
+            -g CMakeDeps \
+            -g CMakeToolchain \
+            -s build_type=Debug
 
       - name: Install mbedTLS with Conan (inline)
         shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,10 @@ jobs:
     name: ${{ matrix.crypto.interface}} • ${{ matrix.crypto.provider }} • ${{matrix.crypto.version}} • ${{ matrix.c-compiler }} • ${{ matrix.qcbor-version }} • ${{ matrix.ifdef }}
 
     runs-on: ${{ matrix.config.os-image }}
- #   container: ${{ matrix.config.container }}
+    container: ${{ matrix.config.container }}
+
+    env:
+      CC: ${{ matrix.c-compiler }}
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,20 +1,40 @@
+# ci.yml -- Configuration QCBOR continuous integration for github workflow
+#
+# Copyright (c) 2024-2026, Laurence Lundblade. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+# See BSD-3-Clause license in README.md
+#
 
-# 15 ifdefs
-# 3 qcbor versions
-# 3 compilers
-# 3 containers
-# 6 crypto libraries
-# 2 debug/release 
+# The fan out strategy is two parts:
+#
+# 1) Fan out all ifdefs and all crypto libraries against each other.
+#
+# 2) Fan out QCBOR versions, compilers and minimal crypto libraries.
+#
+# If everything fans out against everything it ends up with
+# over 1,000. This two-part strategy keeps it under 200.
+#
+# The ifdefs relate to crypto algorithms and features hence testing
+# them against crypto libraries.
+#
+# The QCBOR version and compiler doesn't relate much to the
+# ifdefs and the crypto library.
+#
+# Case 2) is handled by the "main" and "msvc" jobs. MSVC has to
+# be separate because it is just different.
 
-# ifdefs X crypto 15 * 6 = 90 
-
-# qcbor X compilers X min crypto  = 3 * 2 * 3 = 18
 
 name: CI
 
 on: [push, pull_request]
 
 jobs:
+  # =========================================================================
+  #  Fan out compiler vs qcbor vs minimal crypto on Linux
+  # =========================================================================
+
   main:
     strategy:
       fail-fast: false
@@ -52,100 +72,104 @@ jobs:
  #   container: ${{ matrix.config.container }}
 
     steps:
-    - uses: actions/checkout@v3
+      - uses: actions/checkout@v3
+  
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
 
-    - name: Set up Python
-      uses: actions/setup-python@v5
-      with:
-        python-version: "3.11"
-
-    - name: Install Python dependencies
-      run: |
-        python -m pip install --upgrade pip
-
-    - name: Install Conan
-      run: pip install --upgrade conan
-
-    - name: Detect Conan profile
-      run: conan profile detect --force
-
-    - name: Install OpenSSL
-      if: matrix.crypto.provider == 'OpenSSL'
-      run: |
-        conan install \
-          --requires=openssl/${{ matrix.crypto.version }} \
-          --output-folder=build \
-          --build=missing \
-          -g CMakeDeps \
-          -g CMakeToolchain \
-          -s build_type=Debug
-
-    - name: Install mbedTLS with Conan (inline)
-      if: matrix.crypto.provider == 'MbedTLS'
-      shell: bash
-      run: |
-        conan install \
-          --requires=mbedtls/${{ matrix.crypto.version }} \
-          --output-folder=build \
-          --build=missing \
-          -g CMakeDeps \
-          -g CMakeToolchain \
-          -o mbedtls/*:enable_psa=True \
-          -s build_type=Debug
-
-    - name: Fetch QCBOR
-      uses: actions/checkout@v3
-      with:
-        repository: laurencelundblade/QCBOR
-        ref: ${{ matrix.qcbor-version }}
-        path: QCBOR
-
-    - name: Configure QCBOR
-      shell: bash
-      run: |
-        cd QCBOR
-        cmake -S . -B qcbor-build 
-
-    - name: build QCBOR
-      shell: bash
-      run: |
-        cd QCBOR
-        cmake --build qcbor-build
-
-    - name: Install QCBOR
-      shell: bash
-      run: |
-        cd QCBOR
-        cmake --install qcbor-build --prefix "$GITHUB_WORKSPACE/install" 
-
-    - name: Configure t_cose
-      shell: bash
-      run: |
-        IFD="${{ matrix.ifdef }}"
-        if [ -z "$IFD" ]; then
-          CONDITIONAL=""
-        else
-          CONDITIONAL="-D${IFD}=ON"
-        fi
-        cmake -S . -B build \
-          -DBUILD_TESTS=ON -DBUILD_EXAMPLES=ON \
-          ${{ matrix.crypto.cmake }} \
-          -DCRYPTO_PROVIDER=${{ matrix.crypto.provider }} \
-          -DCMAKE_PREFIX_PATH=$GITHUB_WORKSPACE/install \
-          -DCMAKE_BUILD_TYPE=Debug \
-          "$CONDITIONAL"
-
-    - name: Build t_cose
-      run: |
-        set -ex
-        cmake --build build --verbose
-
-    - name: Run examples
-      run: build/t_cose_examples
-
-    - name: Run tests
-      run: build/t_cose_test
-
+      - name: Install Python dependencies
+        run: |
+          python -m pip install --upgrade pip
+  
+      - name: Install Conan
+        run: pip install --upgrade conan
+  
+      - name: Detect Conan profile
+        run: conan profile detect --force
+  
+      - name: Install OpenSSL
+        if: matrix.crypto.provider == 'OpenSSL'
+        run: |
+          conan install \
+            --requires=openssl/${{ matrix.crypto.version }} \
+            --output-folder=build \
+            --build=missing \
+            -g CMakeDeps \
+            -g CMakeToolchain \
+            -s build_type=Debug
+  
+      - name: Install mbedTLS with Conan (inline)
+        if: matrix.crypto.provider == 'MbedTLS'
+        shell: bash
+        run: |
+          conan install \
+            --requires=mbedtls/${{ matrix.crypto.version }} \
+            --output-folder=build \
+            --build=missing \
+            -g CMakeDeps \
+            -g CMakeToolchain \
+            -o mbedtls/*:enable_psa=True \
+            -s build_type=Debug
+  
+      - name: Fetch QCBOR
+        uses: actions/checkout@v3
+        with:
+          repository: laurencelundblade/QCBOR
+          ref: ${{ matrix.qcbor-version }}
+          path: QCBOR
+  
+      - name: Configure QCBOR
+        shell: bash
+        run: |
+          cd QCBOR
+          cmake -S . -B qcbor-build 
+  
+      - name: build QCBOR
+        shell: bash
+        run: |
+          cd QCBOR
+          cmake --build qcbor-build
+  
+      - name: Install QCBOR
+        shell: bash
+        run: |
+          cd QCBOR
+          cmake --install qcbor-build --prefix "$GITHUB_WORKSPACE/install" 
+  
+      - name: Configure t_cose
+        shell: bash
+        run: |
+          IFD="${{ matrix.ifdef }}"
+          if [ -z "$IFD" ]; then
+            CONDITIONAL=""
+          else
+            CONDITIONAL="-D${IFD}=ON"
+          fi
+          cmake -S . -B build \
+            -DBUILD_TESTS=ON -DBUILD_EXAMPLES=ON \
+            ${{ matrix.crypto.cmake }} \
+            -DCRYPTO_PROVIDER=${{ matrix.crypto.provider }} \
+            -DCMAKE_PREFIX_PATH=$GITHUB_WORKSPACE/install \
+            -DCMAKE_BUILD_TYPE=Debug \
+            "$CONDITIONAL"
+  
+      - name: Build t_cose
+        run: |
+          set -ex
+          cmake --build build --verbose
+  
+      - name: Run examples
+        run: build/t_cose_examples
+  
+      - name: Run tests
+        run: build/t_cose_test
+  
+  # =========================================================================
+  #  Fan out ifdefs against crypto libraries and versions
+  #  Hold compiler constant (clang), and QCBOR constant (dev branch) 
+  # =========================================================================
   ifdef-fan-out:
     strategy:
       fail-fast: false
@@ -204,100 +228,105 @@ jobs:
  #   container: ${{ matrix.config.container }}
 
     steps:
-    - uses: actions/checkout@v3
+      - uses: actions/checkout@v3
+  
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+  
+      - name: Install Python dependencies
+        run: |
+          python -m pip install --upgrade pip
+  
+      - name: Install Conan
+        run: pip install --upgrade conan
+  
+      - name: Detect Conan profile
+        run: conan profile detect --force
+  
+      - name: Install OpenSSL
+        if: matrix.crypto.provider == 'OpenSSL'
+        run: |
+          conan install \
+            --requires=openssl/${{ matrix.crypto.version }} \
+            --output-folder=build \
+            --build=missing \
+            -g CMakeDeps \
+            -g CMakeToolchain \
+            -s build_type=Debug
+  
+      - name: Install mbedTLS with Conan (inline)
+        if: matrix.crypto.provider == 'MbedTLS'
+        shell: bash
+        run: |
+          conan install \
+            --requires=mbedtls/${{ matrix.crypto.version }} \
+            --output-folder=build \
+            --build=missing \
+            -g CMakeDeps \
+            -g CMakeToolchain \
+            -o mbedtls/*:enable_psa=True \
+            -s build_type=Debug
+  
+      - name: Fetch QCBOR
+        uses: actions/checkout@v3
+        with:
+          repository: laurencelundblade/QCBOR
+          ref: ${{ matrix.qcbor-version }}
+          path: QCBOR
+  
+      - name: Configure QCBOR
+        shell: bash
+        run: |
+          cd QCBOR
+          cmake -S . -B qcbor-build 
+  
+      - name: build QCBOR
+        shell: bash
+        run: |
+          cd QCBOR
+          cmake --build qcbor-build
+  
+      - name: Install QCBOR
+        shell: bash
+        run: |
+          cd QCBOR
+          cmake --install qcbor-build --prefix "$GITHUB_WORKSPACE/install" 
+  
+      - name: Configure t_cose
+        shell: bash
+        run: |
+          IFD="${{ matrix.ifdef }}"
+          if [ -z "$IFD" ]; then
+            CONDITIONAL=""
+          else
+            CONDITIONAL="-D${IFD}=ON"
+          fi
+          cmake -S . -B build \
+            -DBUILD_TESTS=ON -DBUILD_EXAMPLES=ON \
+            ${{ matrix.crypto.cmake }} \
+            -DCRYPTO_PROVIDER=${{ matrix.crypto.provider }} \
+            -DCMAKE_PREFIX_PATH=$GITHUB_WORKSPACE/install \
+            -DCMAKE_BUILD_TYPE=Debug \
+            "$CONDITIONAL"
+  
+      - name: Build t_cose
+        run: |
+          set -ex
+          cmake --build build --verbose
+  
+      - name: Run examples
+        run: build/t_cose_examples
+  
+      - name: Run tests
+        run: build/t_cose_test
 
-    - name: Set up Python
-      uses: actions/setup-python@v5
-      with:
-        python-version: "3.11"
 
-    - name: Install Python dependencies
-      run: |
-        python -m pip install --upgrade pip
-
-    - name: Install Conan
-      run: pip install --upgrade conan
-
-    - name: Detect Conan profile
-      run: conan profile detect --force
-
-    - name: Install OpenSSL
-      if: matrix.crypto.provider == 'OpenSSL'
-      run: |
-        conan install \
-          --requires=openssl/${{ matrix.crypto.version }} \
-          --output-folder=build \
-          --build=missing \
-          -g CMakeDeps \
-          -g CMakeToolchain \
-          -s build_type=Debug
-
-    - name: Install mbedTLS with Conan (inline)
-      if: matrix.crypto.provider == 'MbedTLS'
-      shell: bash
-      run: |
-        conan install \
-          --requires=mbedtls/${{ matrix.crypto.version }} \
-          --output-folder=build \
-          --build=missing \
-          -g CMakeDeps \
-          -g CMakeToolchain \
-          -o mbedtls/*:enable_psa=True \
-          -s build_type=Debug
-
-    - name: Fetch QCBOR
-      uses: actions/checkout@v3
-      with:
-        repository: laurencelundblade/QCBOR
-        ref: ${{ matrix.qcbor-version }}
-        path: QCBOR
-
-    - name: Configure QCBOR
-      shell: bash
-      run: |
-        cd QCBOR
-        cmake -S . -B qcbor-build 
-
-    - name: build QCBOR
-      shell: bash
-      run: |
-        cd QCBOR
-        cmake --build qcbor-build
-
-    - name: Install QCBOR
-      shell: bash
-      run: |
-        cd QCBOR
-        cmake --install qcbor-build --prefix "$GITHUB_WORKSPACE/install" 
-
-    - name: Configure t_cose
-      shell: bash
-      run: |
-        IFD="${{ matrix.ifdef }}"
-        if [ -z "$IFD" ]; then
-          CONDITIONAL=""
-        else
-          CONDITIONAL="-D${IFD}=ON"
-        fi
-        cmake -S . -B build \
-          -DBUILD_TESTS=ON -DBUILD_EXAMPLES=ON \
-          ${{ matrix.crypto.cmake }} \
-          -DCRYPTO_PROVIDER=${{ matrix.crypto.provider }} \
-          -DCMAKE_PREFIX_PATH=$GITHUB_WORKSPACE/install \
-          -DCMAKE_BUILD_TYPE=Debug \
-          "$CONDITIONAL"
-
-    - name: Build t_cose
-      run: |
-        set -ex
-        cmake --build build --verbose
-
-    - name: Run examples
-      run: build/t_cose_examples
-
-    - name: Run tests
-      run: build/t_cose_test
-
+  # =========================================================================
+  #  Fan out CBOR versions and minimal crypto for MSVC compiler
+  #  No ifdefs are ever set 
+  # =========================================================================
   msvc:
     runs-on: windows-latest
 
@@ -306,8 +335,6 @@ jobs:
       matrix:
 
         qcbor-version: [master, dev]
-
-        # TODO: add OPenSSL back in when we figure out why it is broken
 
         crypto:
           - interface: Test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -360,6 +360,8 @@ jobs:
             --build=missing \
             -g CMakeDeps \
             -g CMakeToolchain \
+            -s compiler=msvc \
+            -s compiler.runtime=dynamic \
             -s build_type=Debug
 
       - name: Install mbedTLS with Conan (inline)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -353,9 +353,10 @@ jobs:
 
       - name: Install OpenSSL
         if: matrix.crypto.provider == 'OpenSSL'
+        shell: bash
         run: |
           conan install \
-            --requires=openssl/${{ matrix.crypto.version }} \
+            --requires=mbedtls/${{ matrix.crypto.version }} \
             --output-folder=build \
             --build=missing \
             -g CMakeDeps \
@@ -365,8 +366,8 @@ jobs:
             -s build_type=Debug
 
       - name: Install mbedTLS with Conan (inline)
-        shell: bash
         if: matrix.crypto.provider == 'MbedTLS'
+        shell: bash
         run: |
           conan install \
             --requires=mbedtls/${{ matrix.crypto.version }} \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -357,7 +357,6 @@ jobs:
         run: |
           conan install \
             --requires=mbedtls/${{ matrix.crypto.version }} \
-            --requires=mbedtls/3.5.2 \
             --output-folder=build \
             --build=missing \
             -g CMakeDeps \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -319,11 +319,11 @@ jobs:
             version: 3.5.2
             cmake: -DCMAKE_TOOLCHAIN_FILE=build/conan_toolchain.cmake
 
-#TODO: switch to later version of OpenSSL
-          - interface: OpenSSL
-            provider: OpenSSL
-            version: 1.1.1v
-            cmake: -DCMAKE_TOOLCHAIN_FILE=build/conan_toolchain.cmake
+#TODO: figure out why OpenSSL is broken on Windows; also switch to later version of OpenSSL
+#          - interface: OpenSSL
+#            provider: OpenSSL
+#            version: 1.1.1v
+#            cmake: -DCMAKE_TOOLCHAIN_FILE=build/conan_toolchain.cmake
     
     name: ${{ matrix.crypto.interface}} • ${{ matrix.crypto.provider }} • ${{matrix.crypto.version}} • MSVC • ${{ matrix.qcbor-version }} 
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -308,10 +308,24 @@ jobs:
         qcbor-version: [master, dev]
 
         # TODO: add OPenSSL back in when we figure out why it is broken
-        crypto: [ Test, MbedTLS ]
+
+        crypto:
+          - interface: Test
+            provider: Test
+            cmake: ""
+
+          - interface: psa
+            provider: MbedTLS
+            version: 3.5.2
+            cmake: -DCMAKE_TOOLCHAIN_FILE=build/conan_toolchain.cmake
+
+#TODO: switch to later version of OpenSSL
+#          - interface: OpenSSL
+#            provider: OpenSSL
+#            version: 1.1.1v
+#            cmake: -DCMAKE_TOOLCHAIN_FILE=build/conan_toolchain.cmake
     
-    #name: ${{ matrix.crypto.interface}} • ${{ matrix.crypto.provider }} • ${{matrix.crypto.version}} • MSVC • ${{ matrix.qcbor-version }} 
-    name: MSVC • ${{ matrix.qcbor-version }} 
+    name: ${{ matrix.crypto.interface}} • ${{ matrix.crypto.provider }} • ${{matrix.crypto.version}} • MSVC • ${{ matrix.qcbor-version }} 
 
     env:
       ARCH: x64
@@ -339,8 +353,10 @@ jobs:
 
       - name: Install mbedTLS with Conan (inline)
         shell: bash
+        if: matrix.crypto.provider == 'MbedTLS'
         run: |
           conan install \
+            --requires=mbedtls/${{ matrix.crypto.version }} \
             --requires=mbedtls/3.5.2 \
             --output-folder=build \
             --build=missing \
@@ -377,19 +393,14 @@ jobs:
           cd QCBOR
           cmake --install qcbor-build --prefix "$GITHUB_WORKSPACE/install" --config Debug
 
-      - name: Install OpenSSL with vcpkg
-        uses: lukka/run-vcpkg@v11
-        with:
-          vcpkgJsonGlob: '**/vcpkg.json'
-
       - name: Config t_cose
         shell: bash
         run: |
           cmake -S . -B build \
           -DCMAKE_PREFIX_PATH="$GITHUB_WORKSPACE/install" \
           -DBUILD_TESTS=ON  -DBUILD_EXAMPLES=ON \
-          -DCMAKE_TOOLCHAIN_FILE=build/conan_toolchain.cmake \
-          -DCRYPTO_PROVIDER=${{ matrix.crypto }} 
+          ${{ matrix.crypto.cmake }} \
+          -DCRYPTO_PROVIDER=${{ matrix.crypto.provider }} 
 
       - name: Build t_cose
         run: cmake --build build --config Debug

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,6 +153,7 @@ jobs:
           cmake -S . -B build \
             -DBUILD_TESTS=ON -DBUILD_EXAMPLES=ON \
             ${{ matrix.crypto.cmake }} \
+            -DBUILD_T_COSE_WARN=ON \
             -DCRYPTO_PROVIDER=${{ matrix.crypto.provider }} \
             -DCMAKE_PREFIX_PATH=$GITHUB_WORKSPACE/install \
             -DCMAKE_BUILD_TYPE=Debug \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -252,8 +252,7 @@ jobs:
         ref: ${{ matrix.qcbor-version }}
         path: QCBOR
 
-    - name: Configure Q        qcbor-version: [master, dev]
-CBOR
+    - name: Configure QCBOR
       shell: bash
       run: |
         cd QCBOR
@@ -306,6 +305,7 @@ CBOR
     strategy:
       fail-fast: false
       matrix:
+
         qcbor-version: [master, dev]
 
         # TODO: add OPenSSL back in when we figure out why it is broken

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -299,7 +299,6 @@ jobs:
       run: build/t_cose_test
 
   msvc:
-    name: msvc • windows-latest
     runs-on: windows-latest
 
     strategy:
@@ -311,6 +310,9 @@ jobs:
         # TODO: add OPenSSL back in when we figure out why it is broken
         crypto: [ Test, MbedTLS ]
     
+    #name: ${{ matrix.crypto.interface}} • ${{ matrix.crypto.provider }} • ${{matrix.crypto.version}} • MSVC • ${{ matrix.qcbor-version }} 
+    name: MSVC • ${{ matrix.qcbor-version }} 
+
     env:
       ARCH: x64
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -356,7 +356,7 @@ jobs:
         shell: bash
         run: |
           conan install \
-            --requires=mbedtls/${{ matrix.crypto.version }} \
+            --requires=openssl/${{ matrix.crypto.version }} \
             --output-folder=build \
             --build=missing \
             -g CMakeDeps \

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,7 @@ project(t_cose
 #    General Configuration
 # =========================================================================
 
-option(BUILD_QCBOR_WARN  "Compile with the warning flags used in the QCBOR release process" OFF)
+option(BUILD_T_COSE_WARN  "Compile with the warning flags used in the t_cose release process" OFF)
 option(BUILD_TESTS "Build tests" OFF)
 option(BUILD_EXAMPLES "Build examples" OFF)
 option(BUILD_SHARED_LIBS  "Build shared libraries instead of static ones" OFF)
@@ -134,7 +134,7 @@ target_link_libraries(t_cose PUBLIC qcbor::qcbor)
 target_link_libraries(t_cose PUBLIC ${CRYPTO_LIBRARY})
 
 # Global compile options applying to all targets
-if (BUILD_QCBOR_WARN)
+if (BUILD_T_COSE_WARN)
     target_compile_options(t_cose PRIVATE -Wall -Wextra -Wpedantic -Wshadow -Wconversion -Wcast-qual)
     
     # Tell MSVC not to warn about padded structures

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,8 +1,0 @@
-{
-  "name": "my-project",
-  "version": "1.0.0",
-  "builtin-baseline": "37dcabc43809a960f41758e00e615cc6e26e8bbf",
-  "dependencies": [
-    "openssl"
-  ]
-}

--- a/vcpkg_psa.json
+++ b/vcpkg_psa.json
@@ -1,8 +1,0 @@
-{
-  "name": "my-project",
-  "version": "1.0.0",
-  "builtin-baseline": "37dcabc43809a960f41758e00e615cc6e26e8bbf",
-  "dependencies": [
-    "mbedtls"
-  ]
-}


### PR DESCRIPTION
More CI fixes, mostly for windows

- Fan out QCBOR versions for windows
- Windows uses Conan to fetch all crypto libs; same as linux; no more vcpkg
- Turn on warning flags for the compiler
- Add comments and improve formatting
- Fix Linux compiler fan out